### PR TITLE
Implement Image upload

### DIFF
--- a/tmbr/Sources/App/Modules/Gallery/Gallery.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Gallery.swift
@@ -1,0 +1,32 @@
+import Vapor
+import Fluent
+import Core
+
+struct Gallery: Module {
+    fileprivate struct ServiceKey: StorageKey {
+        typealias Value = ImageService
+    }
+
+    func configure(_ app: Vapor.Application) async throws {
+        app.databases.middleware.use(
+            ImageCleanupMiddleware(publicDirectory: app.directory.publicDirectory),
+            on: .psql
+        )
+        app.storage[ServiceKey.self] = ImageService(publicDirectory: app.directory.publicDirectory)
+        app.migrations.add(CreateImage())
+    }
+    
+    func boot(_ app: Vapor.Application) async throws {
+        try app.register(collection: GalleryAPIController())
+    }
+}
+
+extension Module where Self == Gallery {
+    static var gallery: Self { Gallery() }
+}
+
+extension Application {
+    var imageService: ImageService? {
+        storage[Gallery.ServiceKey.self]
+    }
+}

--- a/tmbr/Sources/App/Modules/Gallery/Middlewares/ImageCleanupMiddleware.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Middlewares/ImageCleanupMiddleware.swift
@@ -1,0 +1,39 @@
+import Fluent
+import Vapor
+
+/// Middleware that deletes image files from disk after the DB row was deleted.
+struct ImageCleanupMiddleware: AsyncModelMiddleware {
+    typealias Model = Image
+
+    private let publicDirectory: String
+    
+    init(publicDirectory: String) {
+        self.publicDirectory = publicDirectory
+    }
+
+    func delete(model: Image, on db: Database, next: AnyAsyncModelResponder) async throws {
+        // Perform the delete in DB first
+        try await next.delete(model, force: true, on: db)
+
+        let fm = FileManager.default
+        let originalPath = fsPath(for: model.path)
+        let thumbnailPath = fsPath(for: model.thumbnailPath)
+
+        if fm.fileExists(atPath: originalPath) {
+            try? fm.removeItem(atPath: originalPath)
+        }
+        if thumbnailPath != originalPath, fm.fileExists(atPath: thumbnailPath) {
+            try? fm.removeItem(atPath: thumbnailPath)
+        }
+    }
+    
+    private func fsPath(for publicPath: String) -> String {
+        // If already absolute under Public/, return as-is
+        guard !publicPath.hasPrefix(publicDirectory) else {
+            return publicPath
+        }
+        // Otherwise treat it as a public URL path and prefix with Public/
+        let trimmed = publicPath.hasPrefix("/") ? String(publicPath.dropFirst()) : publicPath
+        return publicDirectory + trimmed
+    }
+}

--- a/tmbr/Sources/App/Modules/Gallery/Models/CreateImage.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Models/CreateImage.swift
@@ -1,0 +1,19 @@
+import Fluent
+
+struct CreateImage: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Image.schema)
+            .field("id", .int, .identifier(auto: true))
+            .field("alt", .string)
+            .field("path", .string, .required)
+            .field("thumbnail_path", .string, .required)
+            .field("size_width", .int, .required)
+            .field("size_height", .int, .required)
+            .field("uploaded_at", .datetime)
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Image.schema).delete()
+    }
+}

--- a/tmbr/Sources/App/Modules/Gallery/Models/Image.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Models/Image.swift
@@ -1,0 +1,83 @@
+import Fluent
+import Vapor
+import Foundation
+
+final class Size: Fields, @unchecked Sendable, Codable {
+
+    @Field(key: "width")
+    private(set) var width: Int
+    
+    @Field(key: "height")
+    private(set) var height: Int
+    
+    init() {
+        self.width = 0
+        self.height = 0
+    }
+
+    init(
+        width: Int,
+        height: Int
+    ) {
+        self.width = width
+        self.height = height
+    }
+}
+
+final class Image: Model, Content, @unchecked Sendable {
+    static let schema = "images"
+    
+    @ID(custom: "id", generatedBy: .database)
+    var id: Int?
+    
+    @OptionalField(key: "alt")
+    var alt: String?
+    
+    @Field(key: "path")
+    private(set) var path: String
+    
+    @Field(key: "thumbnail_path")
+    private(set) var thumbnailPath: String
+    
+    @Group(key: "size")
+    private(set) var size: Size
+    
+    @Timestamp(key: "uploaded_at", on: .create)
+    private(set) var uploadedAt: Date?
+    
+    init() {}
+
+    convenience init(
+        id: Int? = nil,
+        alt: String?,
+        path: String,
+        thumbnailPath: String,
+        width: Int,
+        height: Int,
+        uploadedAt: Date? = nil
+    ) {
+        self.init(
+            id: id,
+            alt: alt,
+            path: path,
+            thumbnailPath: thumbnailPath,
+            size: CGSize(width: width, height: height)
+        )
+    }
+    
+    init(
+        id: Int? = nil,
+        alt: String?,
+        path: String,
+        thumbnailPath: String,
+        size: CGSize,
+        uploadedAt: Date? = nil
+    ) {
+        self.id = id
+        self.alt = alt
+        self.path = path
+        self.thumbnailPath = thumbnailPath
+        self.size = Size(width: Int(size.width), height: Int(size.height))
+        self.uploadedAt = uploadedAt
+    }
+}

--- a/tmbr/Sources/App/Modules/Gallery/Routes/API/GalleryAPIController.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Routes/API/GalleryAPIController.swift
@@ -1,0 +1,85 @@
+import Vapor
+import Fluent
+import Foundation
+
+struct GalleryAPIController: RouteCollection {
+    
+    func boot(routes: RoutesBuilder) throws {
+        // Group all API routes under /api/gallery
+        let galleryRoute = routes.grouped("api", "gallery")
+        let protectedRoutes = galleryRoute.grouped(AppleSignInAuthenticator())
+        
+        protectedRoutes.get("images") { req async throws -> [ImageResponse] in
+            let images = try await Image.query(on: req.db)
+                .sort(\.$uploadedAt, .descending)
+                .all()
+            return images.map { makeResponse(from: $0, req: req) }
+        }
+        
+        protectedRoutes.get("images", ":id") { req async throws -> ImageResponse in
+            guard let id = req.parameters.get("id", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid image id")
+            }
+            guard let image = try await Image.find(id, on: req.db) else {
+                throw Abort(.notFound)
+            }
+            return makeResponse(from: image, req: req)
+        }
+
+        protectedRoutes.on(.POST, "images", body: .collect(maxSize: "10mb")) { req async throws -> ImageResponse in
+            guard let user = req.auth.get(User.self), user.role == .admin else {
+                throw Abort(.unauthorized)
+            }
+            guard let service = req.application.imageService else {
+                throw Abort(.internalServerError, reason: "Image service not configured")
+            }
+
+            let payload = try req.content.decode(ImageUploadPayload.self)
+            let meta = try await service.storeImage(file: payload.image)
+            let image = Image(
+                alt: payload.alt,
+                path: meta.path,
+                thumbnailPath: meta.thumbnailPath,
+                size: meta.size
+            )
+            try await image.save(on: req.db)
+            return makeResponse(from: image, req: req)
+        }
+        
+        protectedRoutes.delete("images", ":id") { req async throws -> HTTPStatus in
+            guard let user = req.auth.get(User.self), user.role == .admin else {
+                throw Abort(.unauthorized)
+            }
+            guard let id = req.parameters.get("id", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid image id")
+            }
+            guard let image = try await Image.find(id, on: req.db) else {
+                throw Abort(.notFound)
+            }
+            try await image.delete(on: req.db)
+            return .noContent
+        }
+    }
+    
+    private func absoluteURL(for path: String, on request: Request) -> String {
+        let scheme = request.headers.first(name: .xForwardedProto)
+            ?? request.url.scheme
+            ?? (request.application.http.server.configuration.tlsConfiguration != nil ? "https" : "http")
+        let host = request.headers.first(name: .xForwardedHost) 
+            ?? request.headers.first(name: .host)
+            ?? "localhost"
+        return "\(scheme)://\(host)\(path)"
+    }
+    
+    @Sendable
+    private func makeResponse(from image: Image, req: Request) -> ImageResponse {
+        return ImageResponse(
+            id: image.id,
+            alt: image.alt,
+            url: absoluteURL(for: image.path, on: req),
+            thumbnailUrl: absoluteURL(for: image.thumbnailPath, on: req),
+            size: CGSize(width: image.size.width, height: image.size.height),
+            uploadedAt: image.uploadedAt ?? .now
+        )
+    }
+}

--- a/tmbr/Sources/App/Modules/Gallery/Routes/API/Payloads/ImageResponse.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Routes/API/Payloads/ImageResponse.swift
@@ -1,0 +1,32 @@
+import Vapor
+
+struct ImageResponse: Content {
+    
+    private let id: Int?
+    
+    private let alt: String?
+    
+    private let url: String
+    
+    private let thumbnailUrl: String
+    
+    private let size: CGSize
+    
+    private let uploadedAt: Date
+    
+    init(
+        id: Int?,
+        alt: String?,
+        url: String,
+        thumbnailUrl: String,
+        size: CGSize,
+        uploadedAt: Date
+    ) {
+        self.id = id
+        self.alt = alt
+        self.url = url
+        self.thumbnailUrl = thumbnailUrl
+        self.size = size
+        self.uploadedAt = uploadedAt
+    }
+}

--- a/tmbr/Sources/App/Modules/Gallery/Routes/API/Payloads/ImageUploadPayload.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Routes/API/Payloads/ImageUploadPayload.swift
@@ -1,0 +1,8 @@
+import Vapor
+
+struct ImageUploadPayload: Content {
+    
+    let image: File
+    
+    let alt: String?
+}

--- a/tmbr/Sources/App/Modules/Gallery/Services/ImageService.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Services/ImageService.swift
@@ -1,0 +1,138 @@
+import Vapor
+import Foundation
+import CoreGraphics
+import ImageIO
+import NIOFoundationCompat
+#if canImport(UniformTypeIdentifiers)
+import UniformTypeIdentifiers
+#endif
+
+struct ImageMetadata: Sendable {
+    let path: String
+    let thumbnailPath: String
+    let size: CGSize
+}
+
+actor ImageService {
+    
+    struct MediaType: Equatable {
+        let httpType: HTTPMediaType
+        
+        let fileExtension: String
+        
+        static let png = MediaType(httpType: .png, fileExtension: "png")
+        
+        static let jpeg = MediaType(httpType: .jpeg, fileExtension: "jpg")
+        
+        static let webp = MediaType(
+            httpType: HTTPMediaType(type: "image", subType: "webp"),
+            fileExtension: "webp"
+        )
+        
+        static let gif = MediaType(httpType: .gif, fileExtension: "gif")
+        
+        static let svg = MediaType(
+            httpType: HTTPMediaType(type: "image", subType: "svg+xml"),
+            fileExtension: "svg"
+        )
+    }
+    
+    private let allowedMediaTypes: [MediaType]
+    
+    private let absoluteFolderPath: String
+    
+    private let relativeFolderPath: String
+
+    init(
+        allowedMediaTypes: [MediaType] = [.png, .jpeg, .webp, .gif, .svg],
+        relativeFolderPath: String = "uploads/images",
+        publicDirectory: String
+    ) {
+        self.allowedMediaTypes = allowedMediaTypes
+        self.absoluteFolderPath = publicDirectory.appending(relativeFolderPath)
+        self.relativeFolderPath = relativeFolderPath
+    }
+
+    func storeImage(file: File) async throws -> ImageMetadata {
+        let mediaType = try validateAndResolveMediaType(for: file)
+        let uuid = UUID().uuidString
+        let filename = "\(uuid).\(mediaType.fileExtension)"
+        let relativePath = "/\(relativeFolderPath)/\(filename)"
+        let absolutePath = "\(absoluteFolderPath)/\(filename)"
+
+        try FileManager.default.createDirectory(
+            atPath: absoluteFolderPath,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        let imageData = Data(buffer: file.data)
+        try write(data: imageData, to: absolutePath)
+
+        let thumbnailRelativePath: String
+        if mediaType != .svg, let thumbnailData = makeThumbnail(from: imageData) {
+            let thumbnailFilename = "\(uuid)-thumbnail.\(mediaType.fileExtension)"
+            let thumbnailAbsolutePath = "\(absoluteFolderPath)/\(thumbnailFilename)"
+            
+            try write(data: thumbnailData, to: thumbnailAbsolutePath)
+            thumbnailRelativePath = "/\(relativeFolderPath)/\(thumbnailFilename)"
+        } else {
+            thumbnailRelativePath = relativePath
+        }
+
+        return ImageMetadata(
+            path: relativePath,
+            thumbnailPath: thumbnailRelativePath,
+            size: dimensions(of: imageData)
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func validateAndResolveMediaType(for file: File) throws -> MediaType {
+        guard let contentType = file.contentType else {
+            throw Abort(.unsupportedMediaType, reason: "Missing content type")
+        }
+        guard let mediaType = allowedMediaTypes.first(where: { $0.httpType == contentType }) else {
+            throw Abort(.unsupportedMediaType, reason: "Unsupported image content type")
+        }
+        return mediaType
+    }
+
+    private func write(data: Data, to absolutePath: String) throws {
+        let url = URL(fileURLWithPath: absolutePath)
+        try data.write(to: url, options: .atomic)
+    }
+
+    private func dimensions(of data: Data) -> CGSize {
+        var size: CGSize = .zero
+        if let src = CGImageSourceCreateWithData(data as CFData, nil),
+           let props = CGImageSourceCopyPropertiesAtIndex(src, 0, nil) as? [CFString: Any] {
+            if let w = props[kCGImagePropertyPixelWidth] as? NSNumber { size.width = w.doubleValue }
+            if let h = props[kCGImagePropertyPixelHeight] as? NSNumber { size.height = h.doubleValue }
+        }
+        return size
+    }
+
+    private func makeThumbnail(from data: Data, maxPixel: Int = 200) -> Data? {
+        guard let src = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixel,
+            kCGImageSourceCreateThumbnailWithTransform: true
+        ]
+        guard let thumb = CGImageSourceCreateThumbnailAtIndex(src, 0, options as CFDictionary) else { return nil }
+        let mutableData = CFDataCreateMutable(nil, 0)!
+        let type: CFString
+        #if canImport(UniformTypeIdentifiers)
+        type = UTType.jpeg.identifier as CFString
+        #else
+        type = "public.jpeg" as CFString
+        #endif
+        guard let dest = CGImageDestinationCreateWithData(mutableData, type, 1, nil) else { return nil }
+        let destOptions: [CFString: Any] = [kCGImageDestinationLossyCompressionQuality: 0.85]
+        CGImageDestinationAddImage(dest, thumb, destOptions as CFDictionary)
+        guard CGImageDestinationFinalize(dest) else { return nil }
+        return mutableData as Data
+    }
+}

--- a/tmbr/Sources/App/entrypoint.swift
+++ b/tmbr/Sources/App/entrypoint.swift
@@ -23,6 +23,7 @@ enum Entrypoint {
                 .authentication,
                 .notifications,
                 .posts,
+                .gallery,
             ]
         )
         


### PR DESCRIPTION
This PR adds a gallery module with API endpoints to upload, list and remove images.
Some metadata is also saved to the db of the images as well as thumbnail is generated from them.