### PR TITLE
Replace CryptoKit with swift-crypto

### DIFF
--- a/tmbr/Package.swift
+++ b/tmbr/Package.swift
@@ -27,12 +27,14 @@ let package = Package(
         // 🔔 Push notifications
         .package(url: "https://github.com/mochidev/swift-webpush.git", from: "0.4.1"),
         // 🖼️ File storage for gallery
-        .package(url: "https://github.com/soto-project/soto.git", from: "7.9.0")
+        .package(url: "https://github.com/soto-project/soto.git", from: "7.9.0"),
+        // 🔏 CryptoKit substitution for Linux
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.7.0"),
     ],
     targets: [
         .target(name: "Core", dependencies: [
             .product(name: "Vapor", package: "vapor"),
-            .product(name: "Markdown", package: "swift-markdown")
+            .product(name: "Markdown", package: "swift-markdown"),
         ]),
         .executableTarget(
             name: "App",
@@ -47,6 +49,7 @@ let package = Package(
                 .product(name: "Markdown", package: "swift-markdown"),
                 .product(name: "WebPush", package: "swift-webpush"),
                 .product(name: "SotoS3", package: "soto"),
+                .product(name: "Crypto", package: "swift-crypto"),
                 "Core",
             ],
             swiftSettings: swiftSettings
@@ -68,3 +71,4 @@ var swiftSettings: [SwiftSetting] { [
     .enableExperimentalFeature("StrictConcurrency"),
     .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
 ] }
+

--- a/tmbr/Sources/App/Modules/Authentication/Authentication.swift
+++ b/tmbr/Sources/App/Modules/Authentication/Authentication.swift
@@ -2,7 +2,7 @@ import Vapor
 import Leaf
 import Fluent
 import JWT
-import CryptoKit
+import Crypto
 import Core
 
 struct Authentication: Module {
@@ -47,3 +47,4 @@ extension Module where Self == Authentication {
         Authentication()
     }
 }
+

--- a/tmbr/Sources/App/Modules/Authentication/Routes/API/AuthenticationAPIController.swift
+++ b/tmbr/Sources/App/Modules/Authentication/Routes/API/AuthenticationAPIController.swift
@@ -1,5 +1,5 @@
 import Vapor
-import CryptoKit
+import Crypto
 import JWT
 import Foundation
 


### PR DESCRIPTION
The site is hosted on Heroku that runs Linux. CryptoKit is apparently not available on Linux hence I needed to replace with a cross platform implementation. Luckily swift-crypto mirrors the API of CryptoKit so it seems like I only needed to add the package and update the imports.