### PR TITLE
Fix Permissions and Error template

### DIFF
--- a/tmbr/Public/Styles/main.css
+++ b/tmbr/Public/Styles/main.css
@@ -147,6 +147,11 @@ main > section > article > a {
     color: inherit;
 }
 
+main > a,
+main > a > svg {
+    color: inherit;
+}
+
 main > section > article > a > svg.signature {
     transform: translateX(-16px);
 }

--- a/tmbr/Resources/Views/Error/error.leaf
+++ b/tmbr/Resources/Views/Error/error.leaf
@@ -1,16 +1,18 @@
 #extend("Shared/page"):
     #export("main"):
-        #extend("Shared/signature")
+        <a href="/">#extend("Shared/signature")</a>
         <section alt="Error">
-            <h1>#(error.title)</h1>
-            #unsafeHTML(error.message)
-            #if(error.suggestedFixes):
-                <ul class="suggested-fix">
-                #for(fix in error.suggestedFixes):
-                    <li>#unsafeHTML(fix)</li>
-                #endfor
-                </ul>
-            #endif
+            <article>
+                <h1>#(title)</h1>
+                #unsafeHTML(message)
+                #if(suggestedFixes):
+                    <ul class="suggested-fix">
+                    #for(fix in suggestedFixes):
+                        <li>#unsafeHTML(fix)</li>
+                    #endfor
+                    </ul>
+                #endif
+            </article>
         </section>
     #endexport
 #endextend

--- a/tmbr/Sources/App/Modules/Posts/Permissions/Permission+Posts.swift
+++ b/tmbr/Sources/App/Modules/Posts/Permissions/Permission+Posts.swift
@@ -1,38 +1,43 @@
 import Foundation
 import Core
 import AuthKit
+import Vapor
 
 extension Permission<Post> {
-    
     static var accessPost: Permission<Post> {
         Permission<Post>(
             "This post is not published yet. Only its author can see a draft post."
         ) { user, post in
-            post.state == .published || post.author.id == user.userID || user.role == .admin
-        }
-    }
-    
-    static var deletePost: Self {
-        Permission<Post>(
-            "Only its author can delete a post."
-        ) { user, post in
-            post.author.id == user.userID || user.role == .admin
-        }
-    }
-    
-    static var editPost: Self {
-        Permission<Post>(
-            "Only its author can edit a post."
-        ) { user, post in
-            post.author.id == user.userID || user.role == .admin
+            if post.state == .published { return true }
+            guard let user else { throw Abort(.unauthorized) }
+            return post.$author.id == user.userID || user.role == .admin
         }
     }
 }
 
-extension Permission<Void> {
+extension AuthenticatingPermission<Post> {
+    
+    static var deletePost: Self {
+        AuthenticatingPermission<Post>(
+            "Only its author can delete a post."
+        ) { user, post in
+            post.$author.id == user.userID || user.role == .admin
+        }
+    }
+    
+    static var editPost: Self {
+        AuthenticatingPermission<Post>(
+            "Only its author can edit a post."
+        ) { user, post in
+            post.$author.id == user.userID || user.role == .admin
+        }
+    }
+}
+
+extension AuthenticatingPermission<Void> {
     
     static var createPost: Self {
-        Permission<Void>(
+        AuthenticatingPermission<Void>(
             "Only authors can create posts."
         ) { user, _ in
             user.role == .author || user.role == .admin
@@ -40,6 +45,6 @@ extension Permission<Void> {
     }
     
     static var listDrafts: Self {
-        Permission<Void>()
+        AuthenticatingPermission<Void>()
     }
 }

--- a/tmbr/Sources/App/Modules/Posts/Permissions/PermissionScopes+Posts.swift
+++ b/tmbr/Sources/App/Modules/Posts/Permissions/PermissionScopes+Posts.swift
@@ -9,20 +9,20 @@ extension PermissionScopes {
         
         let access: Permission<Post>
         
-        let create: Permission<Void>
+        let create: AuthenticatingPermission<Void>
         
-        let delete: Permission<Post>
+        let delete: AuthenticatingPermission<Post>
         
-        let drafts: Permission<Void>
+        let drafts: AuthenticatingPermission<Void>
         
-        let edit: Permission<Post>
+        let edit: AuthenticatingPermission<Post>
         
         init(
             access: Permission<Post> = .accessPost,
-            create: Permission<Void> = .createPost,
-            delete: Permission<Post> = .deletePost,
-            drafts: Permission<Void> = .listDrafts,
-            edit: Permission<Post> = .editPost
+            create: AuthenticatingPermission<Void> = .createPost,
+            delete: AuthenticatingPermission<Post> = .deletePost,
+            drafts: AuthenticatingPermission<Void> = .listDrafts,
+            edit: AuthenticatingPermission<Post> = .editPost
         ) {
             self.access = access
             self.create = create

--- a/tmbr/Sources/AuthKit/Permissions/AuthenticatingPermission.swift
+++ b/tmbr/Sources/AuthKit/Permissions/AuthenticatingPermission.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Vapor
+
+public struct AuthenticatingPermission<Input>: Sendable {
+    
+    public typealias AuthenticatedUser = Permission<Input>.AuthenticatedUser
+    
+    public typealias Grant = @Sendable (Request, Input) throws -> AuthenticatedUser
+    
+    private let grant: Grant
+    
+    public init(grant: @escaping Grant) {
+        self.grant = grant
+    }
+    
+    public init(
+        grant: @Sendable @escaping (AuthenticatedUser, Input) throws -> Void
+    ) {
+        self.init { (request, input) in
+            guard let user = request.auth.get(User.self),
+                  let userID = user.id else {
+                throw Abort(.unauthorized)
+            }
+            let authenticatedUser = AuthenticatedUser(user: user, userID: userID)
+            try grant(authenticatedUser, input)
+            return authenticatedUser
+        }
+    }
+    
+    /// Can be used for permission check where the
+    /// only requirement is to have an authenticated user.
+    ///
+    public init() where Input == Void {
+        self.init { _, _ in }
+    }
+    
+    public init(
+        _ deniedReason: String,
+        granted: @Sendable @escaping (AuthenticatedUser, Input) -> Bool
+    ) {
+        self.init { (user, input) in
+            if !granted(user, input) {
+                throw Abort(.forbidden, reason: deniedReason)
+            }
+        }
+    }
+    
+    @discardableResult
+    public func grant(_ input: Input, on request: Request) throws -> AuthenticatedUser {
+        try self.grant(request, input)
+    }
+    
+    @discardableResult
+    public func grant(on request: Request) throws -> AuthenticatedUser
+    where Input == Void {
+        try self.grant((), on: request)
+    }
+}

--- a/tmbr/Sources/AuthKit/Permissions/PermissionResolver.swift
+++ b/tmbr/Sources/AuthKit/Permissions/PermissionResolver.swift
@@ -1,24 +1,60 @@
 import Vapor
 
-public struct PermissionResolver<Input> {
+public struct PermissionResolver<Input, Output>: Sendable {
     
-    private let permission: Permission<Input>
+    public typealias Resolve = @Sendable (Input) async throws -> Output
     
-    private let request: Request
+    private let resolve: Resolve
     
-    init(request: Request, permission: Permission<Input>) {
-        self.request = request
-        self.permission = permission
+    init(resolve: @escaping Resolve) {
+        self.resolve = resolve
+    }
+    
+    init<S: PermissionScope>(
+        request: Request,
+        scope: S.Type,
+        keyPath: KeyPath<S, Permission<Input>>
+    ) where Output == Permission<Input>.AuthenticatedUser? {
+        self.init { input in
+            let storage = try request.application.permissions
+            let scope = try await storage.scope(S.self)
+            let permission = scope[keyPath: keyPath]
+            return try permission.grant(input, on: request)
+        }
+    }
+    
+    init<S: PermissionScope>(
+        request: Request,
+        scope: S.Type,
+        keyPath: KeyPath<S, AuthenticatingPermission<Input>>
+    ) where Output == AuthenticatingPermission<Input>.AuthenticatedUser {
+        self.init { input in
+            let storage = try request.application.permissions
+            let scope = try await storage.scope(S.self)
+            let permission = scope[keyPath: keyPath]
+            return try permission.grant(input, on: request)
+        }
     }
     
     @discardableResult
-    public func callAsFunction(_ input: Input) throws -> Permission<Input>.AuthenticatedUser {
-        try permission.grant(input, on: request)
+    public func grant(_ input: Input) async throws -> Output {
+        try await resolve(input)
     }
     
     @discardableResult
-    public func callAsFunction() throws -> Permission<Input>.AuthenticatedUser
+    public func grant() async throws -> Output
     where Input == Void {
-        try callAsFunction(())
+        try await grant(())
+    }
+    
+    @discardableResult
+    public func callAsFunction(_ input: Input) async throws -> Output {
+        try await grant(input)
+    }
+    
+    @discardableResult
+    public func callAsFunction() async throws -> Output
+    where Input == Void {
+        try await grant()
     }
 }

--- a/tmbr/Sources/AuthKit/Permissions/PermissionScope.swift
+++ b/tmbr/Sources/AuthKit/Permissions/PermissionScope.swift
@@ -1,5 +1,10 @@
 import Foundation
-
-public protocol PermissionScope {}
+import Vapor
 
 public enum PermissionScopes {}
+
+extension Request {
+    public var permissions: PermissionDynamicLookup<PermissionScopes> {
+        PermissionDynamicLookup(request: self)
+    }
+}

--- a/tmbr/Sources/AuthKit/Permissions/PermissionService.swift
+++ b/tmbr/Sources/AuthKit/Permissions/PermissionService.swift
@@ -16,7 +16,7 @@ public actor PermissionService {
     }
     
     func scope<S: PermissionScope>(_ type: S.Type) throws -> S {
-        guard let scope = scopes[String(describing: type)] as? S else {
+        guard let scope = scopes[String(reflecting: type)] as? S else {
             throw Abort(.serviceUnavailable, reason: "Permission Scope (\(type)) is unavailable.")
         }
         return scope

--- a/tmbr/Sources/Core/Web/Recover/Page+Error.swift
+++ b/tmbr/Sources/Core/Web/Recover/Page+Error.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Vapor
+import Core
 
 public struct ErrorViewModel: Encodable, Sendable {
     
@@ -12,10 +13,11 @@ public struct ErrorViewModel: Encodable, Sendable {
     public init(
         title: String,
         message: String,
-        suggestedFixes: [String] = []
+        suggestedFixes: [String] = [],
+        markdownFormatter formatter: MarkdownFormatter = .html
     ) {
         self.title = title
-        self.message = message
+        self.message = formatter.format(message)
         self.suggestedFixes = suggestedFixes
     }
     
@@ -31,5 +33,5 @@ public struct ErrorViewModel: Encodable, Sendable {
 
 extension Template where Model == ErrorViewModel {
     
-    static let error = Template(name: "error")
+    static let error = Template(name: "Error/error")
 }

--- a/tmbr/Sources/Core/Web/Recover/Recover+4XX.swift
+++ b/tmbr/Sources/Core/Web/Recover/Recover+4XX.swift
@@ -6,7 +6,7 @@ extension Page.Recover {
     public static var unathorized: Self {
         Page.Recover(
             status: .unauthorized,
-            response: Page.Redirect(destination: "/singin", return: .origin)
+            response: Page.Redirect(destination: "/signin", return: .origin)
         )
     }
     

--- a/tmbr/Sources/Core/Web/Recover/Recover+5XX.swift
+++ b/tmbr/Sources/Core/Web/Recover/Recover+5XX.swift
@@ -9,14 +9,14 @@ extension Page.Recover {
             return ErrorViewModel(
                 title: "Congrats, you found a bug!",
                 message: """
-                Unfortunately, there is prize money for it and what even worse is, there is nothing you can do to resolve the issue instantly.
+                Unfortunately, there is no prize money. Even worse, there is nothing you can do to resolve the issue.
                 
                 Rest assured it's logged in the system and I'll try to fix it in the future. 
-                To avoid breaking promises, I won't provide a time frame for when the fix will be shipped. 
+                To avoid breaking promises, my SLA is Five Zeros. So I don't know when I'm going to fix it.
 
                 You can help me out by either sending an [email](mailto:daniel@tmbr.me) or raising a [Issue on GitHub](https://github.com/danieltmbr/tmbr/issues/new/choose) with the details of what happened.
                 
-                Thanks and have a better rest of the day.
+                Thanks, I hope you have a better day than my backend.
                 """
             )
         }


### PR DESCRIPTION
Proved once again that tests would be great (or at least manually testing).

When implementing Permissions I had an assumption that a Page is either completely public or private. No in-between. Hence the permission is required to return an authenticated user on success, to avoid unnecessary checks later on in a request handler if the user had to be permission checked already.

However, there are use cases where having logged in is optional, for example for accessing a Post. If the post is public the access doesn't require login, however if a post is draft it requires the author to be logged in.

A fix was to introduce a dedicated type called AuthenticatingPermission that works as Permission used to work, and now Permission returns an optional user.

Also the Error leaf was broken, and the css was a bit off.