### PR TITLE
Add table formatting to articles

### DIFF
--- a/tmbr/Public/Scripts/post-editor.js
+++ b/tmbr/Public/Scripts/post-editor.js
@@ -6,6 +6,25 @@ document.addEventListener('DOMContentLoaded', () => {
     const publishedCheckbox = document.getElementById('editor-post-published');
     const previewButton = document.getElementById('editor-post-preview');
     
+    function preview() {
+        const previewForm = document.getElementById('preview-form');
+        const previewTitleInput = document.getElementById('preview-title');
+        const previewBodyInput = document.getElementById('preview-body');
+        if (!previewForm || !previewTitleInput || !previewBodyInput) {
+            alert('Preview form is missing from the template.');
+            return;
+        }
+        // Populate hidden inputs from current editor fields
+        previewTitleInput.value = titleInput.value || '';
+        previewBodyInput.value = bodyTextArea.value || '';
+        previewForm.submit();
+    }
+    
+    function autosize() {
+        bodyTextArea.style.height = 'auto';
+        bodyTextArea.style.height = bodyTextArea.scrollHeight + 'px';
+    }
+    
     if (!form || !titleInput || !bodyTextArea || !publishedCheckbox || !previewButton) {
         // Missing elements; avoid runtime errors
         return;
@@ -87,23 +106,38 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Preview: submit hidden form to /post/preview (form data only)
     previewButton.addEventListener('click', () => {
-        const previewForm = document.getElementById('preview-form');
-        const previewTitleInput = document.getElementById('preview-title');
-        const previewBodyInput = document.getElementById('preview-body');
-        if (!previewForm || !previewTitleInput || !previewBodyInput) {
-            alert('Preview form is missing from the template.');
-            return;
-        }
-        // Populate hidden inputs from current editor fields
-        previewTitleInput.value = titleInput.value || '';
-        previewBodyInput.value = bodyTextArea.value || '';
-        previewForm.submit();
+        preview();
     });
     
-    function autosize() {
-        bodyTextArea.style.height = 'auto';
-        bodyTextArea.style.height = bodyTextArea.scrollHeight + 'px';
-    }
     bodyTextArea.addEventListener('input', autosize);
     window.addEventListener('load', autosize);
+
+    document.addEventListener('keydown', (event) => {
+        try {
+            const isInputLike = (el) => {
+                if (!el) return false;
+                const tag = el.tagName;
+                const editable = el.isContentEditable;
+                return editable || tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+            };
+
+            const active = document.activeElement;
+            const inField = isInputLike(active);
+            if (inField) { return; }
+            
+            const isMac = navigator.platform.toUpperCase().includes('MAC');
+            const cmdOrCtrl = isMac ? event.metaKey : event.ctrlKey;
+            const alt = event.altKey;
+            const shift = event.shiftKey;
+            const keyP = event.key === 'p' || event.key === 'P';
+            const isPKey = event.code === 'KeyP';
+            
+            if (cmdOrCtrl && alt && !shift && isPKey) {
+                event.preventDefault();
+                preview();
+            }
+        } catch (_) {
+            // ignore
+        }
+    });
 });

--- a/tmbr/Public/Scripts/post.js
+++ b/tmbr/Public/Scripts/post.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+
+    document.addEventListener('keydown', (event) => {
+        try {
+            let isE = event.key === 'e' || event.key === 'E'
+            let isNonModifier = !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+            if (isE && isNonModifier) {
+                let editURL = window.location.href + "/edit";
+                event.preventDefault();
+                window.location.assign(editURL);
+            }
+        } catch (_) {
+            // ignore
+        }
+    });
+});

--- a/tmbr/Public/Styles/editor.css
+++ b/tmbr/Public/Styles/editor.css
@@ -1,0 +1,132 @@
+
+/*
+ ------------------------------------------------
+ Post editor
+ ------------------------------------------------
+ */
+
+main > section > form {
+    display: flex;
+    flex-direction: column;
+    
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+main > section > form > input {
+    width: 100%;
+    border: none;
+    outline: none;
+    background: transparent;
+    font: inherit;
+    line-height: normal;
+    color: inherit;
+    padding: 0;
+    margin: 0;
+}
+
+main > section > form > input[name=title] {
+    font-size: 3.2rem;
+    font-weight: 700;
+    margin: 3.2rem 0;
+    flex: 0 0 auto;
+}
+
+main > section > form > textarea  {
+    width: 100%;
+    border: none;
+    outline: none;
+    background: transparent;
+    font: inherit;
+    line-height: inherit;
+    color: inherit;
+    padding: 0;
+    resize: none;
+    
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: visible;
+}
+
+main > section > form > input::placeholder,
+main > section > form > textarea::placeholder {
+    color: currentColor;
+    opacity: 0.35;
+}
+
+main > section > form .editor-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 0 32px 0;
+    flex: 0 0 auto;
+    font-size: 1.5rem;
+}
+
+main > section > form .editor-actions > div {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+}
+
+main > section > form button {
+    font-weight: 500;
+    font-size: 1.5rem;
+}
+
+button.primary {
+    background-color: #007aff;
+    background-image: linear-gradient(to bottom, #3696ff, #007aff);
+    padding: 3px 8px 4px 8px;
+    border: 0;
+    border-radius: 5px;
+    color: #FFFFFF;
+}
+
+button.primary:hover {
+    background-image: linear-gradient(to bottom, #5eabff, #007aff);
+}
+
+button.primary:active {
+    background-image: linear-gradient(to bottom, #0572eb, #007aff);
+}
+
+main > section > form button.link {
+    background: none;
+    border: none;
+    color: inherit;
+    text-decoration: underline;
+    padding: 0;
+    cursor: pointer;
+}
+
+main > section > form label.published {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+main > section > form .editor-error {
+    margin: 0.5em 0 0.75em 0;
+    font-size: 1.4rem;
+    color: var(--error-color);
+    flex: 0 0 auto;
+}
+
+main > section > form#preview-form {
+    display: none;
+}
+
+/*
+ ------------------------------------------------
+ Mobile adjustments
+ ------------------------------------------------
+ */
+
+@media screen and (max-width: 600px) {
+    
+    main > section > form .editor {
+        padding-bottom: 20px;
+    }
+}

--- a/tmbr/Public/Styles/main.css
+++ b/tmbr/Public/Styles/main.css
@@ -2,12 +2,16 @@
     color-scheme: light dark;
 
     --background-color: #FFFFFF;
+    --table-background-color: #F7F7F7;
+    --table-header-background-color: #EFEFEF;
     --error-color: #8b0000;
 }
 
 @media (prefers-color-scheme: dark) {
     :root {
         --background-color: #1d1d1d;
+        --table-background-color: #242424;
+        --table-header-background-color: #2C2C2C;
         --error-color: #ff6b6b;
     }
 }
@@ -161,6 +165,37 @@ main > section > article > a {
     color: inherit;
 }
 
+main > section > article > table {
+    background: var(--table-background-color);
+    border-radius: 12px;
+    font-size: 0.8em;
+    padding: 6px;
+    margin: 20px 0px;
+}
+
+main > section > article > table > thead th {
+    background: var(--table-header-background-color);
+    padding: 8px;
+}
+
+main > section > article > table > thead th:first-child {
+    border-top-left-radius: 8px;
+    border-bottom-left-radius: 8px;
+}
+
+main > section > article > table > thead th:last-child {
+    border-top-right-radius: 8px;
+    border-bottom-right-radius: 8px;
+}
+
+main > section > article > table td {
+    padding: 4px 6px;
+}
+
+main > section > article > ul {
+    margin: 0.5em 0;
+}
+
 main > a,
 main > a > svg {
     color: inherit;
@@ -191,6 +226,12 @@ ol.instructions > li > picture {
 
 ol.instructions > li > picture img {
     max-width: 100%;
+}
+
+hr {
+    border: none;
+    border-top: 1px solid;
+    margin: 1.5em 0;
 }
 
 /*
@@ -296,125 +337,6 @@ p.published-date {
 
 /*
  ------------------------------------------------
- Post editor
- ------------------------------------------------
- */
-
-main > section > form {
-    display: flex;
-    flex-direction: column;
-    
-    flex: 1 1 auto;
-    min-height: 0;
-}
-
-main > section > form > input {
-    width: 100%;
-    border: none;
-    outline: none;
-    background: transparent;
-    font: inherit;
-    line-height: normal;
-    color: inherit;
-    padding: 0;
-    margin: 0;
-}
-
-main > section > form > input[name=title] {
-    font-size: 3.2rem;
-    font-weight: 700;
-    margin: 3.2rem 0;
-    flex: 0 0 auto;
-}
-
-main > section > form > textarea  {
-    width: 100%;
-    border: none;
-    outline: none;
-    background: transparent;
-    font: inherit;
-    line-height: inherit;
-    color: inherit;
-    padding: 0;
-    resize: none;
-    
-    flex: 1 1 auto;
-    min-height: 0;
-    overflow: visible;
-}
-
-main > section > form > input::placeholder,
-main > section > form > textarea::placeholder {
-    color: currentColor;
-    opacity: 0.35;
-}
-
-main > section > form .editor-actions {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    padding: 16px 0 32px 0;
-    flex: 0 0 auto;
-    font-size: 1.5rem;
-}
-
-main > section > form .editor-actions > div {
-    display: inline-flex;
-    align-items: center;
-    gap: 12px;
-}
-
-main > section > form button {
-    font-weight: 500;
-    font-size: 1.5rem;
-}
-
-button.primary {
-    background-color: #007aff;
-    background-image: linear-gradient(to bottom, #3696ff, #007aff);
-    padding: 3px 8px 4px 8px;
-    border: 0;
-    border-radius: 5px;
-    color: #FFFFFF;
-}
-
-button.primary:hover {
-    background-image: linear-gradient(to bottom, #5eabff, #007aff);
-}
-
-button.primary:active {
-    background-image: linear-gradient(to bottom, #0572eb, #007aff);
-}
-
-main > section > form button.link {
-    background: none;
-    border: none;
-    color: inherit;
-    text-decoration: underline;
-    padding: 0;
-    cursor: pointer;
-}
-
-main > section > form label.published {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-}
-
-main > section > form .editor-error {
-    margin: 0.5em 0 0.75em 0;
-    font-size: 1.4rem;
-    color: var(--error-color);
-    flex: 0 0 auto;
-}
-
-main > section > form#preview-form {
-    display: none;
-}
-
-/*
- ------------------------------------------------
  Mobile adjustments
  ------------------------------------------------
  */
@@ -452,10 +374,6 @@ main > section > form#preview-form {
     
     main > section > article > a > svg.signature {
         transform: translateX(-12px);
-    }
-    
-    main > section > form .editor {
-        padding-bottom: 20px;
     }
 }
 

--- a/tmbr/Resources/Views/Posts/post-editor.leaf
+++ b/tmbr/Resources/Views/Posts/post-editor.leaf
@@ -1,4 +1,9 @@
 #extend("Shared/page"):
+
+    #export("styles"):
+    <link rel="stylesheet" href="/Styles/editor.css">
+    #endexport
+
     #export("main"):
     <section alt="Post edit form">
         <form id="post-form" method="#(submit.method)" action="#(submit.action)">
@@ -66,7 +71,10 @@
 
     </section>
     
-    <script src="/Scripts/post-editor.js"></script>
 
+    #endexport
+    
+    #export("scripts"):
+        <script src="/Scripts/post-editor.js"></script>
     #endexport
 #endextend

--- a/tmbr/Resources/Views/Posts/post.leaf
+++ b/tmbr/Resources/Views/Posts/post.leaf
@@ -11,4 +11,7 @@
         </section>
     #endexport
     
+    #export("scripts"):
+        <script src="/Scripts/post.js"></script>
+    #endexport
 #endextend

--- a/tmbr/Resources/Views/Shared/head.leaf
+++ b/tmbr/Resources/Views/Shared/head.leaf
@@ -2,6 +2,7 @@
     <link rel="alternate" type="application/rss+xml" title="tmbr RSS Feed" href="/rss.xml">
     <link rel="manifest" href="/manifest.json">
     <link rel="stylesheet" href="/Styles/main.css">
+    #import("styles")
     
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/tmbr/Resources/Views/Shared/scripts.leaf
+++ b/tmbr/Resources/Views/Shared/scripts.leaf
@@ -1,1 +1,2 @@
 <script src="/Scripts/notifications.js"></script>
+#import("scripts")


### PR DESCRIPTION
Markdown supports tables, however so far my posts didn't have any so the CSS lacked the table formatting. This resulted in ugly hard to read tables. This PR adds a minimal style to improve the readability, however tables with lots of columns still needs to be avoided for now or make the layout possible to out reach from the box of the text content.

This PR also splits JS and CSS files and adds keyboard listeners to add keyboard shortcut to edit a post and preview an edit.

https://github.com/danieltmbr/tmbr/issues/21