### PR TITLE
Introduce Access and Owner to Preview

### DIFF
--- a/tmbr/Sources/App/Modules/Authentication/Authentication.swift
+++ b/tmbr/Sources/App/Modules/Authentication/Authentication.swift
@@ -21,6 +21,8 @@ struct Authentication: Module {
     }
     
     func configure(_ app: Application) async throws {
+        app.migrations.add(CreateAccess())
+        
         app.sessions.use(.memory)
         app.sessions.configuration.cookieFactory = { sessionID in
                 .init(
@@ -43,7 +45,7 @@ struct Authentication: Module {
             hmac: HMACKey(from: Environment.signIn.secret),
             digestAlgorithm: .sha256
         )
-        
+
         await app.storage.setWithAsyncShutdown(
             PermissionService.Key.self,
             to: PermissionService()

--- a/tmbr/Sources/App/Modules/Notes/Models/Migrations/UpdateNoteVisibilityToAccess.swift
+++ b/tmbr/Sources/App/Modules/Notes/Models/Migrations/UpdateNoteVisibilityToAccess.swift
@@ -1,0 +1,60 @@
+import Fluent
+import SQLKit
+
+struct UpdateNoteVisibilityToAccess: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        let accessType = try await database.enum("access").read()
+
+        try await database.schema(Note.schema)
+            .field("access", accessType, .required)
+            .update()
+
+        if let sql = database as? SQLDatabase {
+            try? await sql.raw("""
+                UPDATE \"\(unsafeRaw: Note.schema)\"
+                SET access = CASE note_visibility
+                    WHEN 'public' THEN 'public'
+                    WHEN 'private' THEN 'private'
+                    ELSE 'private'
+                END
+                """).run()
+        }
+
+        try await database.schema(Note.schema)
+            .deleteField("note_visibility")
+            .update()
+
+        try? await database.enum("note_visibility").delete()
+    }
+
+    func revert(on database: Database) async throws {
+        let visibilityType: DatabaseSchema.DataType
+        if let read = try? await database.enum("note_visibility").read() {
+            visibilityType = read
+        } else {
+            visibilityType = try await database.enum("note_visibility")
+                .case("public")
+                .case("private")
+                .create()
+        }
+
+        try? await database.schema(Note.schema)
+            .field("note_visibility", visibilityType, .required)
+            .update()
+
+        if let sql = database as? SQLDatabase {
+            try? await sql.raw("""
+                UPDATE \"\(unsafeRaw: Note.schema)\"
+                SET note_visibility = CASE access
+                    WHEN 'public' THEN 'public'
+                    WHEN 'private' THEN 'private'
+                    ELSE 'private'
+                END
+                """).run()
+        }
+
+        try? await database.schema(Note.schema)
+            .deleteField("access")
+            .update()
+    }
+}

--- a/tmbr/Sources/App/Modules/Notes/Models/Note.swift
+++ b/tmbr/Sources/App/Modules/Notes/Models/Note.swift
@@ -7,11 +7,6 @@ typealias NoteID = Note.IDValue
 
 final class Note: Model, Content, @unchecked Sendable {
     
-    enum Visibility: String, Codable, Sendable {
-        case `private`
-        case `public`
-    }
-    
     static let schema = "notes"
 
     @ID(custom: "id", generatedBy: .database)
@@ -26,8 +21,8 @@ final class Note: Model, Content, @unchecked Sendable {
     @Field(key: "body")
     var body: String
 
-    @Enum(key: "visibility")
-    var visibility: Visibility
+    @Enum(key: "access")
+    var access: Access
 
     @Timestamp(key: "created_at", on: .create)
     private(set) var createdAt: Date?
@@ -44,11 +39,11 @@ final class Note: Model, Content, @unchecked Sendable {
         attachmentID: UUID,
         authorID: Int,
         body: String,
-        visibility: Visibility = .private
+        access: Access
     ) {
         self.$attachment.id = attachmentID
         self.$author.id = authorID
         self.body = body
-        self.visibility = visibility
+        self.access = access
     }
 }

--- a/tmbr/Sources/App/Modules/Notes/Notes.swift
+++ b/tmbr/Sources/App/Modules/Notes/Notes.swift
@@ -21,6 +21,7 @@ struct Notes: Module {
     func configure(_ app: Vapor.Application) async throws {
         app.migrations.add(CreateNote())
         app.migrations.add(CreateQuote())
+        app.migrations.add(UpdateNoteVisibilityToAccess())
         app.databases.middleware.use(NoteModelMiddleware())
         
         try await app.permissions.add(scope: notePermissions)

--- a/tmbr/Sources/App/Modules/Notes/Permissions/Note/Permission+Note.swift
+++ b/tmbr/Sources/App/Modules/Notes/Permissions/Note/Permission+Note.swift
@@ -39,7 +39,7 @@ extension Permission<QueryBuilder<Note>> {
     static var queryNote: Permission<QueryBuilder<Note>> {
         Permission<QueryBuilder<Note>> { user, query in
             query.group(.or) { group in
-                group.filter(\.$visibility == .public)
+                group.filter(\.$access == .public)
                 if let userID = user?.id {
                     group.filter(\.$author.$id == userID)
                 }

--- a/tmbr/Sources/App/Modules/Notes/Permissions/Quote/Permission+Quote.swift
+++ b/tmbr/Sources/App/Modules/Notes/Permissions/Quote/Permission+Quote.swift
@@ -10,7 +10,7 @@ extension Permission<Quote> {
         Permission<Quote>(
             "Only quotes from public notes can be accessed by other than its author."
         ) { user, quote in
-            if quote.note.visibility == .public { return true }
+            if quote.note.access == .public { return true }
             guard let user else { throw Abort(.unauthorized) }
             return quote.note.author.id == user.userID || user.role == .admin
         }
@@ -22,7 +22,7 @@ extension Permission<QueryBuilder<Quote>> {
     static var queryQuote: Permission<QueryBuilder<Quote>> {
         Permission<QueryBuilder<Quote>> { user, query in
             query.group(.or) { group in
-                group.filter(Note.self, \.$visibility == .public)
+                group.filter(Note.self, \.$access == .public)
                 if let userID = user?.id {
                     group.filter(Note.self, \.$author.$id == userID)
                 }

--- a/tmbr/Sources/App/Modules/Previews/Models/Migrations/AddPreviewParentAccessAndOwner.swift
+++ b/tmbr/Sources/App/Modules/Previews/Models/Migrations/AddPreviewParentAccessAndOwner.swift
@@ -1,0 +1,20 @@
+import Fluent
+import Vapor
+
+struct AddPreviewParentAccessAndOwner: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        let accessType = try await database.enum("access").read()
+        try await database.schema(Preview.schema)
+            .field("parent_access", accessType, .required)
+            .field("parent_owner", .int, .required)
+            .foreignKey("parent_owner", references: "users", "id", onDelete: .restrict)
+            .update()
+    }
+    
+    func revert(on database: Database) async throws {
+        try await database.schema(Preview.schema)
+            .deleteField("parent_access")
+            .deleteField("parent_owner")
+            .update()
+    }
+}

--- a/tmbr/Sources/App/Modules/Previews/Models/Preview.swift
+++ b/tmbr/Sources/App/Modules/Previews/Models/Preview.swift
@@ -1,6 +1,7 @@
 import Fluent
 import Vapor
 import Foundation
+import AuthKit
 
 typealias PreviewID = UUID
 
@@ -11,10 +12,16 @@ final class Preview: Model, @unchecked Sendable {
     var id: UUID?
     
     @Field(key: "parent_id")
-    var parentID: Int
+    private(set) var parentID: Int
+    
+    @Enum(key: "parent_access")
+    private(set) var parentAccess: Access
+    
+    @Parent(key: "parent_owner")
+    private(set) var parentOwner: User
     
     @Field(key: "parent_type")
-    var parentType: String
+    private(set) var parentType: String
 
     @Field(key: "primary_info")
     var primaryInfo: String
@@ -29,29 +36,25 @@ final class Preview: Model, @unchecked Sendable {
     var externalLinks: [String]
 
     @Timestamp(key: "created_at", on: .create)
-    var createdAt: Date?
+    private(set) var createdAt: Date?
 
     @Timestamp(key: "updated_at", on: .update)
-    var updatedAt: Date?
+    private(set) var updatedAt: Date?
 
     init() {}
 
     init(
         id: UUID,
         parentID: Int,
-        parentType: String,
-        primaryInfo: String,
-        secondaryInfo: String? = nil,
-        imageID: ImageID? = nil,
-        externalLinks: [String] = []
+        parentAccess: Access,
+        parentOwner: UserID,
+        parentType: String
     ) {
         self.id = id
         self.parentID = parentID
+        self.parentAccess = parentAccess
+        self.$parentOwner.id = parentOwner
         self.parentType = parentType
-        self.primaryInfo = primaryInfo
-        self.secondaryInfo = secondaryInfo
-        self.$image.id = imageID
-        self.externalLinks = externalLinks
     }
 }
 

--- a/tmbr/Sources/App/Modules/Previews/Previews.swift
+++ b/tmbr/Sources/App/Modules/Previews/Previews.swift
@@ -6,6 +6,7 @@ struct Previews: Module {
     
     func configure(_ app: Application) async throws {
         app.migrations.add(CreatePreview())
+        app.migrations.add(AddPreviewParentAccessAndOwner())
     }
     
     func boot(_ routes: any Vapor.RoutesBuilder) async throws {}

--- a/tmbr/Sources/AuthKit/Models/Access.swift
+++ b/tmbr/Sources/AuthKit/Models/Access.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum Access: String, Codable, Sendable {
+    case `private`
+    case `public`
+}

--- a/tmbr/Sources/AuthKit/Models/Migrations/CreateAccess.swift
+++ b/tmbr/Sources/AuthKit/Models/Migrations/CreateAccess.swift
@@ -1,0 +1,19 @@
+import Fluent
+import Foundation
+import SQLKit
+
+public struct CreateAccess: AsyncMigration {
+    
+    public init() {}
+    
+    public func prepare(on database: Database) async throws {
+        let access = try await database.enum("access")
+            .case("public")
+            .case("private")
+            .create()
+    }
+    
+    public func revert(on database: Database) async throws {
+        try await database.enum("access").delete()
+    }
+}


### PR DESCRIPTION
This PR adds a general purpose Access enum type and updates Preview and Note to use that.

It also adds ownerID requirement to Previewable protocol and to Preview itself.

This will allow us to let Note inherit access control and not be more lenient than its parent. It will also allow us to block attaching notes to parent with different owners.

https://github.com/danieltmbr/tmbr/issues/60