### PR TITLE
Add Platform implementation

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+AppleMusic.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+AppleMusic.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension PlatformParser {
+    static let appleMusic = PlatformParser { url throws(ParseError) in
+        guard url.host?.lowercased().contains("music.apple.com") ?? false else {
+            throw ParseError.unsupportedURL(url)
+        }
+        return url.queryItem(name: "i")
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+GoodReads.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+GoodReads.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension PlatformParser {
+
+    static let goodreads = PlatformParser { url throws(ParseError) in
+        guard let host = url.host?.lowercased(), host.contains("goodreads.") else {
+            throw ParseError.unsupportedURL(url)
+        }
+        // Expect /book/show/<id>-<slug>
+        let comps = url.pathComponents.filter { $0 != "/" }
+        guard let idx = comps.firstIndex(of: "show"),
+              comps.indices.contains(comps.index(after: idx)) else {
+            return nil
+        }
+        let part = comps[comps.index(after: idx)]
+        // Extract numeric prefix before '-' if present
+        if let dash = part.firstIndex(of: "-") {
+            let prefix = String(part[..<dash])
+            return prefix.isEmpty ? nil : prefix
+        }
+        return part.isEmpty ? nil : part
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+IMDb.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+IMDb.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension PlatformParser {
+    
+    static let imdb = PlatformParser { url throws(ParseError) in
+        guard let host = url.host?.lowercased(), host.contains("imdb.") else {
+            throw ParseError.unsupportedURL(url)
+        }
+        // Expect paths like /title/tt1234567 or /name/nm1234567
+        let comps = url.pathComponents.filter { $0 != "/" }
+        guard comps.count >= 2 else { return nil }
+        return comps.first(where: { $0.hasPrefix("tt") || $0.hasPrefix("nm") })
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+Podcast.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+Podcast.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension PlatformParser {
+    
+    static let applePodcasts = PlatformParser { url throws(ParseError) in
+        guard let host = url.host?.lowercased(),
+              host.contains("podcasts.apple.") || host.contains("podcasts.apple.com") else {
+            throw ParseError.unsupportedURL(url)
+        }
+        return url.queryItem(name: "i")
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+RottenTomatoes.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+RottenTomatoes.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension PlatformParser {
+    
+    static let rottenTomatoes = PlatformParser { url throws(ParseError) in
+        guard let host = url.host?.lowercased(), host.contains("rottentomatoes.") else {
+            throw ParseError.unsupportedURL(url)
+        }
+        // m/movie_name, tv/tv_show_name
+        let entitites = ["m", "tv"]
+        let components = url.pathComponents.filter { $0 != "/" }.suffix(2)
+        guard components.count == 2 else { return nil }
+        guard entitites.contains(components.first) else { return nil }
+        return components.last
+    }
+}
+
+extension Sequence {
+    func contains(_ element: Element?) -> Bool {
+        guard let element else { return false }
+        return self.contains(element)
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+Spotify.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+Spotify.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension PlatformParser {
+    
+    static let spotify = PlatformParser { url throws(ParseError) in
+        guard let host = url.host?.lowercased(), host.contains("spotify.") else {
+            throw ParseError.unsupportedURL(url)
+        }
+        // Expect paths like /track/<id>, /album/<id>, /artist/<id>, /playlist/<id>
+        let entities = ["track", "album", "artist", "playlist", "show", "episode"]
+        let components = url.pathComponents.filter { $0 != "/" }
+        guard components.count >= 2 else { return nil }
+        guard entities.contains(components.first) else { return nil }
+        return components.last
+    }
+    
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+YouTube.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Parsers/PlatformParser+YouTube.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension PlatformParser {
+    
+    static let youtube = PlatformParser { url throws(ParseError) in
+        guard let host = url.host?.lowercased(),
+              host.contains("youtube.") || host.contains("youtu.be") else {
+            throw ParseError.unsupportedURL(url)
+        }
+        if host.contains("youtu.be") {
+            return url.pathComponents.last
+        } else {
+            // youtube.com/watch?v=VIDEO_ID
+            return url.queryItem(name: "v")
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Platform.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Platform.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+struct Platform<MediaItem>: Sendable {
+    
+    private let extract: @Sendable (URL) -> Resource?
+    
+    init(extract: @escaping @Sendable (URL) -> Resource?) {
+        self.extract = extract
+    }
+    
+    init(
+        displayName: String,
+        parser: PlatformParser
+    ) {
+        self.init { url in
+            do {
+                let externalID = try parser.extractID(from: url)
+                return Resource(
+                    platform: displayName,
+                    url: url,
+                    externalID: externalID
+                )
+            } catch {
+                return nil
+            }
+        }
+    }
+    
+    init(platforms: [Platform]) {
+        self.init { url in
+            for platform in platforms {
+                if let resource = platform.resource(from: url) {
+                    return resource
+                }
+            }
+            return nil
+        }
+    }
+    
+    func resource(from url: URL) -> Resource? {
+        extract(url)
+    }
+    
+    func resource(from urlString: String) -> Resource? {
+        guard let url = URL(string: urlString) else {
+            return nil
+        }
+        return resource(from: url)
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/PlatformParser.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/PlatformParser.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct PlatformParser: Sendable {
+    
+    enum ParseError: Error {
+        case unsupportedURL(URL)
+    }
+    
+    private let parser: @Sendable (URL) throws(ParseError) -> String?
+    
+    init(parse: @escaping @Sendable (URL) throws(ParseError) -> String?) {
+        self.parser = parse
+    }
+    
+    func extractID(from url: URL) throws(ParseError) -> String? {
+        try parser(url)
+    }
+}
+
+extension URL {
+    func queryItem(name: String) -> String? {
+        let components = URLComponents(url: self, resolvingAgainstBaseURL: false)
+        let queryItems = components?.queryItems
+        let item = queryItems?.first(where: { $0.name == name })
+        return item?.value
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Book.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Book.swift
@@ -1,0 +1,8 @@
+extension Platform<Book> {
+    
+    static let all = Platform(platforms: [
+        .goodreads
+    ])
+    
+    static let goodreads = Platform(displayName: "GoodReads", parser: .goodreads)
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Movie.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Movie.swift
@@ -1,0 +1,14 @@
+extension Platform<Movie> {
+    
+    static let all = Platform(platforms: [
+        .imdb,
+        .rottenTomatoes,
+        .youtube
+    ])
+    
+    static let imdb = Platform(displayName: "IMDb", parser: .imdb)
+
+    static let rottenTomatoes = Platform(displayName: "Rotten Tomatoes", parser: .rottenTomatoes)
+    
+    static let youtube = Platform(displayName: "YouTube", parser: .youtube)
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Podcast.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Podcast.swift
@@ -1,0 +1,11 @@
+extension Platform<Podcast> {
+    
+    static let all = Platform(platforms: [
+        .spotify,
+        .applePodcasts
+    ])
+    
+    static let spotify = Platform(displayName: "Spotify", parser: .spotify)
+
+    static let applePodcasts = Platform(displayName: "Podcasts", parser: .applePodcasts)
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Song.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Song.swift
@@ -1,0 +1,14 @@
+extension Platform<Song> {
+    
+    static let all = Platform(platforms: [
+        .appleMusic,
+        .spotify,
+        .youtube
+    ])
+    
+    static let appleMusic = Platform(displayName: "Apple Music", parser: .appleMusic)
+
+    static let spotify = Platform(displayName: "Spotify", parser: .spotify)
+    
+    static let youtube = Platform(displayName: "YouTube", parser: .youtube)
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Resource.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Resource.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct Resource: Codable, Sendable {
+    
+    let platform: String
+    
+    let url: URL
+    
+    let externalID: String?
+}


### PR DESCRIPTION
This PR adds an implementation for parsing platforms based on URL. 
It also supports extracting a specific item ID from the URL if present.

This will be used for response and view models to turn the stored external url links into some detailed resource data.