### PR TITLE
Command DB

### DIFF
--- a/tmbr/Sources/App/Commands/DeleteCommand.swift
+++ b/tmbr/Sources/App/Commands/DeleteCommand.swift
@@ -39,7 +39,7 @@ extension CommandFactory where Output == Void {
             let s = request.permissions[dynamicMember: scope]
             let p = s[dynamicMember: permission]
             return DeleteCommand<Item>(
-                database: request.db,
+                database: request.commandDB,
                 permission: p.eraseOutput()
             ).logged(logger: request.logger)
         }
@@ -52,7 +52,7 @@ extension CommandFactory where Output == Void {
         CommandFactory { request in
             let s = request.permissions[dynamicMember: scope]
             return DeleteCommand<Item>(
-                database: request.db,
+                database: request.commandDB,
                 permission: s.delete.eraseOutput()
             ).logged(logger: request.logger)
         }

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/EditBookCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/EditBookCommand.swift
@@ -64,7 +64,7 @@ extension CommandFactory<EditBookInput, Book> {
     static var editBook: Self {
         CommandFactory { request in
             EditBookCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.books.edit
             )
             .logged(logger: request.logger)

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/FetchBookCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/FetchBookCommand.swift
@@ -23,7 +23,7 @@ extension CommandFactory<FetchParameters<BookID>, Book> {
     static var fetchBook: Self {
         CommandFactory { request in
             FetchBookCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 readPermission: request.permissions.books.access,
                 writePermission: request.permissions.books.edit
             )

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/CreateMovieCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/CreateMovieCommand.swift
@@ -79,7 +79,7 @@ extension CommandFactory<CreateMovieInput, Movie> {
     static var createMovie: Self {
         CommandFactory { request in
             CreateMovieCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.movies.create
             )
             .logged(logger: request.logger)

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/EditMovieCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/EditMovieCommand.swift
@@ -64,7 +64,7 @@ extension CommandFactory<EditMovieInput, Movie> {
     static var editMovie: Self {
         CommandFactory { request in
             EditMovieCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.movies.edit
             )
             .logged(logger: request.logger)

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/FetchMovieCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/FetchMovieCommand.swift
@@ -23,7 +23,7 @@ extension CommandFactory<FetchParameters<MovieID>, Movie> {
     static var fetchMovie: Self {
         CommandFactory { request in
             FetchMovieCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 readPermission: request.permissions.movies.access,
                 writePermission: request.permissions.movies.edit
             )

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/CreatePodcastCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/CreatePodcastCommand.swift
@@ -79,7 +79,7 @@ extension CommandFactory<CreatePodcastInput, Podcast> {
     static var createPodcast: Self {
         CommandFactory { request in
             CreatePodcastCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.podcasts.create
             )
             .logged(logger: request.logger)

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/EditPodcastCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/EditPodcastCommand.swift
@@ -64,7 +64,7 @@ extension CommandFactory<EditPodcastInput, Podcast> {
     static var editPodcast: Self {
         CommandFactory { request in
             EditPodcastCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.podcasts.edit
             )
             .logged(logger: request.logger)

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/FetchPodcastCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/FetchPodcastCommand.swift
@@ -23,7 +23,7 @@ extension CommandFactory<FetchParameters<PodcastID>, Podcast> {
     static var fetchPodcast: Self {
         CommandFactory { request in
             FetchPodcastCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 readPermission: request.permissions.podcasts.access,
                 writePermission: request.permissions.podcasts.edit
             )

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/CreateSongCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/CreateSongCommand.swift
@@ -79,7 +79,7 @@ extension CommandFactory<CreateSongInput, Song> {
     static var createSong: Self {
         CommandFactory { request in
             CreateSongCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.songs.create
             )
             .logged(logger: request.logger)

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/EditSongCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/EditSongCommand.swift
@@ -64,7 +64,7 @@ extension CommandFactory<EditSongInput, Song> {
     static var editSong: Self {
         CommandFactory { request in
             EditSongCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.songs.edit
             )
             .logged(logger: request.logger)

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/FetchSongCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/FetchSongCommand.swift
@@ -23,7 +23,7 @@ extension CommandFactory<FetchParameters<SongID>, Song> {
     static var fetchSong: Self {
         CommandFactory { request in
             FetchSongCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 readPermission: request.permissions.songs.access,
                 writePermission: request.permissions.songs.edit
             )

--- a/tmbr/Sources/App/Modules/Gallery/Commands/Command/Command+AddImage.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Commands/Command/Command+AddImage.swift
@@ -57,7 +57,7 @@ extension CommandFactory<ImageUploadPayload, Image> {
     static var addImage: Self {
         CommandFactory { request in
             AddImageCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 logger: request.application.logger,
                 permission: request.permissions.gallery.create,
                 storage: request.application.imageService!

--- a/tmbr/Sources/App/Modules/Gallery/Commands/Command/Command+DeleteImage.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Commands/Command/Command+DeleteImage.swift
@@ -35,7 +35,7 @@ extension CommandFactory<ImageID, Void> {
     static var deleteImage: Self {
         CommandFactory { request in
             .deleteImage(
-                database: request.db,
+                database: request.commandDB,
                 logger: request.logger,
                 permission: request.permissions.gallery.delete,
                 storage: request.application.imageService!

--- a/tmbr/Sources/App/Modules/Gallery/Commands/Command/Command+EditImage.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Commands/Command/Command+EditImage.swift
@@ -54,7 +54,7 @@ extension CommandFactory<EditImageInput, Image> {
     static var editImage: Self {
         CommandFactory { request in
             EditImageCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 logger: request.application.logger,
                 permission: request.permissions.gallery.edit,
                 storage: request.application.imageService!

--- a/tmbr/Sources/App/Modules/Gallery/Commands/Command/Command+FetchImage.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Commands/Command/Command+FetchImage.swift
@@ -61,7 +61,7 @@ extension CommandFactory<FetchParameters<ImageID>, Image> {
     static var fetchImage: Self {
         CommandFactory { request in
             FetchImageCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 logger: request.application.logger,
                 readPermission: request.permissions.gallery.access,
                 writePermission: request.permissions.gallery.edit

--- a/tmbr/Sources/App/Modules/Gallery/Commands/Command/Command+ListImages.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Commands/Command/Command+ListImages.swift
@@ -26,7 +26,7 @@ extension CommandFactory<Void, [Image]> {
     static var listImages: Self {
         CommandFactory { request in
             .listImages(
-                database: request.db,
+                database: request.commandDB,
                 permission: request.permissions.gallery.list
             )
             .logged(name: "List images", logger: request.logger)

--- a/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+CreateNote.swift
+++ b/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+CreateNote.swift
@@ -61,7 +61,7 @@ extension CommandFactory<CreateNoteInput, Note> {
             CreateNoteCommand(
                 attachPermission: request.permissions.notes.attach,
                 createPermission: request.permissions.notes.create,
-                database: request.application.db,
+                database: request.commandDB,
                 fetchPreview: request.commands.previews.fetch
             )
             .logged(logger: request.logger)

--- a/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+DeleteNote.swift
+++ b/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+DeleteNote.swift
@@ -25,7 +25,7 @@ extension CommandFactory<NoteID, Void> {
     static var deleteNote: Self {
         CommandFactory { request in
             .deleteNote(
-                database: request.db,
+                database: request.commandDB,
                 permission: request.permissions.notes.delete
             )
             .logged(name: "Delete Note", logger: request.logger)

--- a/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+EditNote.swift
+++ b/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+EditNote.swift
@@ -53,7 +53,7 @@ extension CommandFactory<EditNoteInput, Note> {
     static var editNote: Self {
         CommandFactory { request in
             EditNoteCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.notes.edit
             )
             .logged(logger: request.logger)

--- a/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+SearchNote.swift
+++ b/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+SearchNote.swift
@@ -36,7 +36,7 @@ extension CommandFactory<NoteQueryPayload, [Note]> {
     static var searchNote: Self {
         CommandFactory { request in
             .searchNote(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.notes.query
             )
             .logged(

--- a/tmbr/Sources/App/Modules/Notes/Commands/Quote/Command+ListQuotes.swift
+++ b/tmbr/Sources/App/Modules/Notes/Commands/Quote/Command+ListQuotes.swift
@@ -32,7 +32,7 @@ extension CommandFactory<QuoteQueryPayload, [Quote]> {
     static var listQuotes: Self {
         CommandFactory { request in
             .listQuotes(
-                database: request.db,
+                database: request.commandDB,
                 permission: request.permissions.quotes.query
             )
             .logged(

--- a/tmbr/Sources/App/Modules/Notes/Commands/Quote/Command+RandomQuote.swift
+++ b/tmbr/Sources/App/Modules/Notes/Commands/Quote/Command+RandomQuote.swift
@@ -35,7 +35,7 @@ extension CommandFactory<QuoteQueryPayload, Quote> {
     static var randomQuote: Self {
         CommandFactory { request in
             .randomQuote(
-                database: request.db,
+                database: request.commandDB,
                 permission: request.permissions.quotes.query
             )
             .logged(

--- a/tmbr/Sources/App/Modules/Notes/Commands/Quote/Command+SearchQuote.swift
+++ b/tmbr/Sources/App/Modules/Notes/Commands/Quote/Command+SearchQuote.swift
@@ -38,7 +38,7 @@ extension CommandFactory<QuoteQueryPayload, [Quote]> {
     static var searchQuote: Self {
         CommandFactory { request in
             .searchQuote(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.quotes.query
             )
             .logged(

--- a/tmbr/Sources/App/Modules/Notifications/Commands/Command+Notify.swift
+++ b/tmbr/Sources/App/Modules/Notifications/Commands/Command+Notify.swift
@@ -27,7 +27,7 @@ extension CommandFactory<PushNotification, Void> {
     static var send: Self {
         CommandFactory { request in
             .send(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.notifications.generic,
                 service: request.application.notificationService
             )

--- a/tmbr/Sources/App/Modules/Notifications/Commands/Command+NotifyPosts.swift
+++ b/tmbr/Sources/App/Modules/Notifications/Commands/Command+NotifyPosts.swift
@@ -42,7 +42,7 @@ extension CommandFactory<Post, Void> {
     static var postNotification: Self {
         CommandFactory { request in
             .notification(
-                database: request.application.db,
+                database: request.commandDB,
                 permission: request.permissions.notifications.post,
                 service: request.application.notificationService
             )
@@ -56,7 +56,7 @@ extension CommandFactory<PostID, Void> {
     static var postNotificationByID: Self {
         CommandFactory { request in
             .notificationByID(
-                database: request.application.db,
+                database: request.commandDB,
                 notify: request.commands.notifications.post
             )
         }

--- a/tmbr/Sources/App/Modules/Posts/Commands/Command/Command+CreatePost.swift
+++ b/tmbr/Sources/App/Modules/Posts/Commands/Command/Command+CreatePost.swift
@@ -58,7 +58,7 @@ extension CommandFactory<PostPayload, Post> {
     static var createPost: Self {
         CommandFactory { request in
             CreatePostCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 logger: request.application.logger,
                 notify: request.commands.notifications.post,
                 permission: request.permissions.posts.create

--- a/tmbr/Sources/App/Modules/Posts/Commands/Command/Command+DeletePost.swift
+++ b/tmbr/Sources/App/Modules/Posts/Commands/Command/Command+DeletePost.swift
@@ -26,7 +26,7 @@ extension CommandFactory<PostID, Void> {
     static var deletePost: Self {
         CommandFactory { request in
             .deletePost(
-                database: request.db,
+                database: request.commandDB,
                 logger: request.logger,
                 permission: request.permissions.posts.delete
             )

--- a/tmbr/Sources/App/Modules/Posts/Commands/Command/Command+EditPost.swift
+++ b/tmbr/Sources/App/Modules/Posts/Commands/Command/Command+EditPost.swift
@@ -54,7 +54,7 @@ extension CommandFactory<EditPostPayload, Post> {
     static var editPost: Self {
         CommandFactory { request in
             EditPostCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 logger: request.application.logger,
                 notify: request.commands.notifications.post,
                 permission: request.permissions.posts.edit

--- a/tmbr/Sources/App/Modules/Posts/Commands/Command/Command+FetchPost.swift
+++ b/tmbr/Sources/App/Modules/Posts/Commands/Command/Command+FetchPost.swift
@@ -62,7 +62,7 @@ extension CommandFactory<FetchParameters<PostID>, Post> {
     static var fetchPost: Self {
         CommandFactory { request in
             FetchPostCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 logger: request.application.logger,
                 readPermission: request.permissions.posts.access,
                 writePermission: request.permissions.posts.edit

--- a/tmbr/Sources/App/Modules/Posts/Commands/Command/Command+ListPosts.swift
+++ b/tmbr/Sources/App/Modules/Posts/Commands/Command/Command+ListPosts.swift
@@ -21,7 +21,7 @@ extension CommandFactory<Void, [Post]> {
     
     static var listPosts: Self {
         CommandFactory { request in
-            .listPosts(database: request.db)
+            .listPosts(database: request.commandDB)
             .logged(
                 name: "List posts",
                 logger: request.logger

--- a/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+FetchPreview.swift
+++ b/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+FetchPreview.swift
@@ -57,7 +57,7 @@ extension CommandFactory<FetchParameters<PreviewID>, Preview> {
     static var fetchPreview: Self {
         CommandFactory { request in
             FetchPreviewCommand(
-                database: request.application.db,
+                database: request.commandDB,
                 readPermission: request.permissions.previews.access,
                 writePermission: request.permissions.previews.edit
             )

--- a/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+ListPreviews.swift
+++ b/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+ListPreviews.swift
@@ -5,7 +5,7 @@ import Logging
 import Fluent
 import AuthKit
 
-struct PreviewQueryInput: Decodable, Sendable {
+struct PreviewQueryInput: Sendable {
     let types: Set<String>?
 }
 
@@ -32,7 +32,7 @@ extension CommandFactory<PreviewQueryInput, [Preview]> {
     static var listPreviews: Self {
         CommandFactory { request in
             .listPreviews(
-                database: request.db,
+                database: request.commandDB,
                 permission: request.permissions.previews.query
             )
             .logged(

--- a/tmbr/Sources/Core/Commands/CommandContext.swift
+++ b/tmbr/Sources/Core/Commands/CommandContext.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Fluent
+import Vapor
+
+struct CommandContext: Sendable {
+    
+    @TaskLocal
+    static var database: (any Database)? = nil
+}
+
+
+extension Request {
+    
+    /// Database to inject into Commands.
+    ///
+    /// The command db is either the application's main db or
+    /// it is an emphemeral db of a transaction.
+    ///
+    /// The latter allows us to execute multiple commands under
+    /// a single transaction while keeping the Commands agnostic
+    /// from this information.
+    ///
+    /// In order to leverage this feature the CommandFactory creating
+    /// a command needs to use this computed property instead
+    /// of accessing the request's db directly.
+    ///
+    public var commandDB: any Database {
+        CommandContext.database ?? application.db
+    }
+}


### PR DESCRIPTION
This PR introduces a TaskLocal database accessor for commands.
This way the individual commands can be transaction agnostic. 
The transaction can be then be controlled from the caller side by either invoking the commands inside of a command transaction or just on its own.

https://github.com/danieltmbr/tmbr/issues/79#issue-3707960150