### PR TITLE
Notes query & batch create

### DIFF
--- a/tmbr/Sources/App/Modules/Notes/Commands/Commands+Notes.swift
+++ b/tmbr/Sources/App/Modules/Notes/Commands/Commands+Notes.swift
@@ -7,24 +7,32 @@ extension Commands {
 
 extension Commands {
     struct Notes: CommandCollection, Sendable {
-                
+        
+        let batchCreate: CommandFactory<BatchCreateNoteInput, [Note]>
+        
         let create: CommandFactory<CreateNoteInput, Note>
         
         let delete: CommandFactory<NoteID, Void>
                 
         let edit: CommandFactory<EditNoteInput, Note>
         
+        let query: CommandFactory<QueryNotesInput, [Note]>
+        
         let search: CommandFactory<NoteQueryPayload, [Note]>
         
         init(
+            batchCreate: CommandFactory<BatchCreateNoteInput, [Note]> = .createNotes,
             create: CommandFactory<CreateNoteInput, Note> = .createNote,
             delete: CommandFactory<NoteID, Void> = .deleteNote,
             edit: CommandFactory<EditNoteInput, Note> = .editNote,
+            query: CommandFactory<QueryNotesInput, [Note]> = .queryNotes,
             search: CommandFactory<NoteQueryPayload, [Note]> = .searchNote
         ) {
+            self.batchCreate = batchCreate
             self.create = create
             self.delete = delete
             self.edit = edit
+            self.query = query
             self.search = search
         }
     }

--- a/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+BatchCreateNote.swift
+++ b/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+BatchCreateNote.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Vapor
+import Core
+import Logging
+import Fluent
+import AuthKit
+
+struct BatchCreateNoteInput: Sendable {
+
+    let attachment: Preview
+    
+    let notes: [NoteInput]
+}
+
+struct BatchCreateNoteCommand: Command {
+    
+    typealias Input = BatchCreateNoteInput
+    
+    typealias Output = [Note]
+    
+    private let attachPermission: AuthPermissionResolver<AttachNotePermissionInput>
+
+    private let createPermission: AuthPermissionResolver<Void>
+
+    private let database: Database
+
+    init(
+        attachPermission: AuthPermissionResolver<AttachNotePermissionInput>,
+        createPermission: AuthPermissionResolver<Void>,
+        database: Database
+    ) {
+        self.attachPermission = attachPermission
+        self.createPermission = createPermission
+        self.database = database
+    }
+
+    func execute(_ input: BatchCreateNoteInput) async throws -> [Note] {
+        let user = try await createPermission.grant()
+        let attachmentID = try input.attachment.requireID()
+        let notes = input.notes.map {
+            Note(
+                attachmentID: attachmentID,
+                authorID: user.userID,
+                access: input.attachment.parentAccess && $0.access,
+                body: $0.body
+            )
+        }
+        try await attachPermission(notes, to: input.attachment)
+        try await notes.create(on: database)
+        return notes
+    }
+}
+
+extension CommandFactory<BatchCreateNoteInput, [Note]> {
+
+    static var createNotes: Self {
+        CommandFactory { request in
+            BatchCreateNoteCommand(
+                attachPermission: request.permissions.notes.attach,
+                createPermission: request.permissions.notes.create,
+                database: request.commandDB
+            )
+            .logged(logger: request.logger)
+        }
+    }
+}
+
+extension CommandResolver where Input == BatchCreateNoteInput {
+    
+    func callAsFunction(
+        _ notes: [NoteInput],
+        for preview: Preview
+    ) async throws -> Output {
+        let input = BatchCreateNoteInput(
+            attachment: preview,
+            notes: notes
+        )
+        return try await self.callAsFunction(input)
+    }
+}

--- a/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+FetchNote.swift
+++ b/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+FetchNote.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Vapor
+import Core
+import Logging
+import Fluent
+import AuthKit
+
+struct QueryNotesInput: Sendable {
+    let ownerID: Int
+    
+    let ownerType: String
+}
+
+extension Command where Self == PlainCommand<QueryNotesInput, [Note]> {
+    
+    static func queryNotes(
+        database: Database,
+        permission: BasePermissionResolver<QueryBuilder<Note>>
+    ) -> Self {
+        PlainCommand { input in
+            let query = Note
+                .query(on: database)
+                .with(\.$attachment) { attachment in
+                    attachment.with(\.$image)
+                }
+                .filter(Preview.self, \.$parentType == input.ownerType)
+                .filter(Preview.self, \.$parentID == input.ownerID)
+                .sort(\Note.$createdAt, .descending)
+            try await permission.grant(query)
+            return try await query.all()
+        }
+    }
+}
+
+extension CommandFactory<QueryNotesInput, [Note]> {
+    
+    static var queryNotes: Self {
+        CommandFactory { request in
+            .queryNotes(
+                database: request.commandDB,
+                permission: request.permissions.notes.query
+            )
+            .logged(
+                name: "Query notes",
+                logger: request.logger
+            )
+        }
+    }
+}
+
+extension CommandResolver where Input == QueryNotesInput {
+    
+    func callAsFunction<Item: Previewable>(for item: Item) async throws -> Output {
+        try await callAsFunction(QueryNotesInput(
+            ownerID: item.requireID(),
+            ownerType: Item.previewType)
+        )
+    }
+}


### PR DESCRIPTION
These new commands help with 
- creating a bunch of notes at once when creating a new media object with multiple notes
- detach Notes from the media item DB models to loosen up the tie between them. 