### PR TITLE
Fix infrastructure: Hyperlink, NoteViewModel, BatchCreateNotes

### DIFF
--- a/tmbr/Resources/Views/Catalogue/resources.leaf
+++ b/tmbr/Resources/Views/Catalogue/resources.leaf
@@ -3,10 +3,10 @@
     #for(res in resources):
     <li>
         <a
-            href="#(res.url)"
+            href="#(res.urlString)"
             rel="noopener noreferrer"
             target="_blank"
-        >#(res.platform)</a>
+        >#(res.label)</a>
     </li>
     #endfor
 </ul>

--- a/tmbr/Resources/Views/Posts/post-editor.leaf
+++ b/tmbr/Resources/Views/Posts/post-editor.leaf
@@ -48,7 +48,7 @@
                     type="hidden"
                     value="draft"
                 />
-                <label class="published">
+                <label class="access">
                     <input
                         id="editor-post-published"
                         name="state"

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Routes/API/CatalogueAPIController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Routes/API/CatalogueAPIController.swift
@@ -12,7 +12,7 @@ struct CatalogueAPIController: RouteCollection {
     }
     
     func boot(routes: RoutesBuilder) throws {
-        let catalogue = routes.grouped("catalogue")
+        let catalogue = routes.grouped("api", "catalogue")
         catalogue.get(use: list)
         catalogue.get("search", use: search)
         // TODO: return domain object based on preview

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicSong.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicSong.swift
@@ -24,10 +24,19 @@ extension MetadataExtractor where M == SongMetadata {
             with: fetcher
         )
 
+        // Transform og:image URL to get square artwork
+        // Original: .../1200x630bf-60.jpg -> Changed to: .../1000x1000.jpg
+        let artwork = song.data["og:image"].flatMap { urlString -> String? in
+            guard var url = URL(string: urlString) else { return nil }
+            url.deleteLastPathComponent()
+            url.appendPathComponent("1000x1000.jpg")
+            return url.absoluteString
+        }
+
         return SongMetadata(
             album: try? await album,
             artist: try? await artist,
-            artwork: nil,
+            artwork: artwork,
             externalID: song.data["apple:content_id"],
             releaseDate: song.data["music:release_date"],
             title: song.data["apple:title"]

--- a/tmbr/Sources/App/Modules/Gallery/Routes/Web/Pages/Page+Image.swift
+++ b/tmbr/Sources/App/Modules/Gallery/Routes/Web/Pages/Page+Image.swift
@@ -84,6 +84,20 @@ struct ImageViewModel: Encodable, Sendable {
         )
     }
     
+    init(previewURL: String) {
+        self.init(
+            id: 0,
+            key: "",
+            thumbnailKey: "",
+            alt: "",
+            url: previewURL,
+            thumbnailURL: previewURL,
+            width: 0,
+            height: 0,
+            uploadedAt: ""
+        )
+    }
+
     init?(image: Image, baseURL: String) {
         guard let imageID = image.id else { return nil }
         self.init(imageID: imageID, image: image, baseURL: baseURL)

--- a/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+BatchCreateNote.swift
+++ b/tmbr/Sources/App/Modules/Notes/Commands/Note/Command+BatchCreateNote.swift
@@ -36,8 +36,14 @@ struct BatchCreateNoteCommand: Command {
 
     func execute(_ input: BatchCreateNoteInput) async throws -> [Note] {
         let user = try await createPermission.grant()
+
+        let inputNotes = input.notes.filter {
+            !$0.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        guard !inputNotes.isEmpty else { return [] }
+
         let attachmentID = try input.attachment.requireID()
-        let notes = input.notes.map {
+        let notes = inputNotes.map {
             Note(
                 attachmentID: attachmentID,
                 authorID: user.userID,

--- a/tmbr/Sources/App/Modules/Notes/Routes/Web/NoteViewModel.swift
+++ b/tmbr/Sources/App/Modules/Notes/Routes/Web/NoteViewModel.swift
@@ -1,24 +1,38 @@
 import Foundation
+import Core
 
 struct NoteViewModel: Encodable, Sendable {
-    
+
     private let id: NoteID
-    
+
     private let body: String
-    
+
     private let created: String
-    
+
     init(id: NoteID, body: String, created: String) {
         self.id = id
         self.body = body
         self.created = created
     }
     
-    init(note: Note) throws {
+    init(
+        note: Note,
+        markdownFormatter formatter: MarkdownFormatter
+    ) throws {
         self.init(
             id: try note.requireID(),
-            body: note.body,
+            body: formatter.format(note.body),
             created: (note.createdAt ?? .now).formatted(.publishDate)
+        )
+    }
+
+
+    init(
+        note: Note
+    ) throws {
+        try self.init(
+            note: note,
+            markdownFormatter: .html
         )
     }
 }

--- a/tmbr/Sources/Core/Response/Hyperlink.swift
+++ b/tmbr/Sources/Core/Response/Hyperlink.swift
@@ -1,13 +1,16 @@
 import Foundation
 
 public struct Hyperlink: Codable, Sendable {
-    
+
     public let label: String
-    
+
     public let url: URL
-    
+
+    public let urlString: String
+
     public init(label: String, url: URL) {
         self.label = label
         self.url = url
+        self.urlString = url.absoluteString
     }
 }


### PR DESCRIPTION
Some minor fixes and ground work for the Song Editor improvements

- Hyperlink: improve URL handling
- NoteViewModel: additional display fields
- Command+BatchCreateNote: fix note creation logic
- CatalogueAPIController: fix route registration
- MetadataExtractor+AppleMusicSong: improve metadata parsing
- Page+Image: add missing image page fields
- resources.leaf, post-editor.leaf: minor template fixes