### PR TITLE
Song Editor: duplicate detection

### DIFF
--- a/.claude/docs/frontend.md
+++ b/.claude/docs/frontend.md
@@ -146,6 +146,15 @@ See `Public/Scripts/post-editor.js` for a complete working example.
 
 Templates live in `Resources/Views/` and compose from shared fragments.
 
+### Template Organisation
+
+- `Shared/` — Generic, reusable UI fragments with no domain knowledge: base layouts, shared components (e.g. `alert-dialog.leaf`). ViewModels for shared templates live in `Sources/Core/Web/`.
+- `Catalogue/<Type>/`, `Posts/`, `Gallery/`, etc. — Domain-specific templates. Generic-looking elements that carry domain-specific content (a title, a link to a song) still belong here.
+- `Icons/` — SVG icon fragments.
+- `Panels/` — Side-panel fragments loaded dynamically.
+
+**One concern per file.** Inline UI elements (dialogs, panels, modals) that could be reused belong in their own template files, not embedded in the page template that first uses them. A good rule of thumb: if removing the element and placing it in its own file would make the host template cleaner without losing context, do it.
+
 ### Base Layout
 
 `Shared/page.leaf` is the base layout with named slots: `main`, `toolbar`, `styles`, `scripts`.

--- a/.claude/docs/modules.md
+++ b/.claude/docs/modules.md
@@ -34,6 +34,23 @@ Each module in `Sources/App/Modules/` follows this pattern:
 
 Response DTOs (e.g., `PostResponse`, `ImageResponse`) belong in `Routes/API/Responses/`, not in `Payloads/`. They are REST-specific objects — the API equivalent of Web Page view models.
 
+## Web vs API Controllers
+
+**Web controllers return HTML. API controllers return JSON. Never mix.**
+
+- `Routes/Web/` — All handlers return `View`, `Response` (with Leaf-rendered body), or a redirect. Never return `Content`/JSON. **Exception:** metadata autofill endpoints (e.g. `GET /songs/metadata`) return JSON because they purely pre-fill form fields client-side and have no HTML representation — they are thin pass-throughs to the command layer.
+- `Routes/API/` — All handlers return `Content`-conforming types (JSON). Never render Leaf templates.
+
+When a feature needs both (e.g., a duplicate-detection lookup), implement it twice: once in the API controller returning JSON for programmatic consumers, and once in the Web controller returning a rendered Leaf fragment for the browser.
+
+### Dynamic HTML Fragments
+
+Web controllers can serve Leaf fragments (partial HTML, no base layout) for endpoints that the browser fetches via `fetch()` and injects into the page. This is the standard pattern for dynamic panel loading (see gallery `?embedded=true`, song duplicate dialog). Fragment endpoints:
+
+- Live in the Web controller alongside full-page endpoints
+- Return `Response` (not throwing for expected "not found" states, to avoid `RecoverMiddleware` converting them to error pages)
+- Render a standalone template — not one that `#extend("Shared/page")`
+
 ## Adding a New Module
 
 1. Create module folder with standard structure (see above)

--- a/tmbr/Public/Scripts/Catalogue/Songs/song-editor.js
+++ b/tmbr/Public/Scripts/Catalogue/Songs/song-editor.js
@@ -15,43 +15,54 @@ class MetadataController {
 }
 
 class LookupController {
-    constructor({ endpoint = '/songs/lookup' } = {}) {
+    constructor({ endpoint = '/songs/lookup', excludeID = null } = {}) {
         this.endpoint = endpoint;
+        this.excludeID = excludeID;
     }
 
-    async check(url) {
-        const encoded = encodeURIComponent(url);
-        const response = await window.fetch(`${this.endpoint}?url=${encoded}`);
+    async fetch(url) {
+        const params = new URLSearchParams({ url });
+        if (this.excludeID) params.set('excludeID', String(this.excludeID));
+        const response = await window.fetch(`${this.endpoint}?${params}`, {
+            headers: { Accept: 'text/html' }
+        });
         if (!response.ok) return null;
-        return await response.json();
+        return await response.text();
     }
 }
 
 class DuplicateAlertController {
-    constructor({ dialogEl, nameEl, linkEl, dismissEl }, { onNavigate } = {}) {
-        this.dialogEl = dialogEl;
-        this.nameEl = nameEl;
-        this.linkEl = linkEl;
-        this.dismissEl = dismissEl;
-        this._onDismiss = () => this.dialogEl?.close();
+    constructor({ containerEl }, { onNavigate } = {}) {
+        this.containerEl = containerEl;
+        this.dialogEl = null;
+        this.dismissEl = null;
+        this.linkEl = null;
+        this._onDismiss = null;
         this._onNavigate = () => { if (typeof onNavigate === 'function') onNavigate(); };
     }
 
-    init() {
-        this.dismissEl?.addEventListener('click', this._onDismiss);
-        this.linkEl?.addEventListener('click', this._onNavigate);
-    }
+    init() {}
 
     destroy() {
+        this._detach();
+    }
+
+    _detach() {
         this.dismissEl?.removeEventListener('click', this._onDismiss);
         this.linkEl?.removeEventListener('click', this._onNavigate);
     }
 
-    show({ title, artist, detailURL }) {
-        if (!this.dialogEl) return;
-        this.nameEl.textContent = `${title} by ${artist}`;
-        this.linkEl.href = detailURL;
-        this.dialogEl.showModal();
+    show(html) {
+        if (!this.containerEl || !html) return;
+        this._detach();
+        this.containerEl.innerHTML = html;
+        this.dialogEl = this.containerEl.querySelector('dialog');
+        this.dismissEl = this.containerEl.querySelector('#duplicate-dismiss');
+        this.linkEl = this.containerEl.querySelector('#duplicate-song-link');
+        this._onDismiss = () => this.dialogEl?.close();
+        this.dismissEl?.addEventListener('click', this._onDismiss);
+        this.linkEl?.addEventListener('click', this._onNavigate);
+        this.dialogEl?.showModal();
     }
 }
 
@@ -61,15 +72,13 @@ class AutofillController {
         artistInput,
         albumInput,
         releaseDateInput,
-        statusEl,
-        currentSongID
+        statusEl
     }, { metadata, artwork, onApply, lookup, onDuplicate }) {
         this.titleInput = titleInput;
         this.artistInput = artistInput;
         this.albumInput = albumInput;
         this.releaseDateInput = releaseDateInput;
         this.statusEl = statusEl;
-        this.currentSongID = currentSongID ?? null;
         this.metadata = metadata;
         this.artwork = artwork;
         this.onApply = onApply;
@@ -80,14 +89,14 @@ class AutofillController {
     async fetchAndApply(url) {
         try {
             const lookupPromise = this.lookup
-                ? this.lookup.check(url).catch(() => null)
+                ? this.lookup.fetch(url).catch(() => null)
                 : Promise.resolve(null);
-            const [song, existing] = await Promise.all([this.metadata.fetch(url), lookupPromise]);
+            const [song, html] = await Promise.all([this.metadata.fetch(url), lookupPromise]);
             this.applyMetadata(song);
             this.setStatus('');
             if (typeof this.onApply === 'function') this.onApply();
-            if (existing && existing.id !== this.currentSongID && typeof this.onDuplicate === 'function') {
-                this.onDuplicate(existing);
+            if (html && typeof this.onDuplicate === 'function') {
+                this.onDuplicate(html);
             }
         } catch (error) {
             console.error(error);
@@ -599,15 +608,12 @@ document.addEventListener('DOMContentLoaded', () => {
     );
     resourceInputs.init();
 
-    const lookup = new LookupController();
+    const lookup = new LookupController({
+        excludeID: parseInt(idInput?.value) || null
+    });
 
     const duplicateAlert = new DuplicateAlertController(
-        {
-            dialogEl: document.getElementById('duplicate-alert'),
-            nameEl: document.getElementById('duplicate-song-name'),
-            linkEl: document.getElementById('duplicate-song-link'),
-            dismissEl: document.getElementById('duplicate-dismiss'),
-        },
+        { containerEl: document.getElementById('duplicate-container') },
         { onNavigate: () => persistence.clear(editor.getStorageKey()) }
     );
     duplicateAlert.init();
@@ -617,14 +623,13 @@ document.addEventListener('DOMContentLoaded', () => {
         artistInput,
         albumInput,
         releaseDateInput,
-        statusEl,
-        currentSongID: parseInt(idInput?.value) || null
+        statusEl
     }, {
         metadata,
         artwork,
         onApply: () => editor.saveDraft(),
         lookup,
-        onDuplicate: (dup) => duplicateAlert.show(dup)
+        onDuplicate: (html) => duplicateAlert.show(html)
     });
 
     const editor = new EditorController({

--- a/tmbr/Public/Scripts/Catalogue/Songs/song-editor.js
+++ b/tmbr/Public/Scripts/Catalogue/Songs/song-editor.js
@@ -14,31 +14,80 @@ class MetadataController {
     }
 }
 
+class LookupController {
+    constructor({ endpoint = '/songs/lookup' } = {}) {
+        this.endpoint = endpoint;
+    }
+
+    async check(url) {
+        const encoded = encodeURIComponent(url);
+        const response = await window.fetch(`${this.endpoint}?url=${encoded}`);
+        if (!response.ok) return null;
+        return await response.json();
+    }
+}
+
+class DuplicateAlertController {
+    constructor({ dialogEl, nameEl, linkEl, dismissEl }, { onNavigate } = {}) {
+        this.dialogEl = dialogEl;
+        this.nameEl = nameEl;
+        this.linkEl = linkEl;
+        this.dismissEl = dismissEl;
+        this._onDismiss = () => this.dialogEl?.close();
+        this._onNavigate = () => { if (typeof onNavigate === 'function') onNavigate(); };
+    }
+
+    init() {
+        this.dismissEl?.addEventListener('click', this._onDismiss);
+        this.linkEl?.addEventListener('click', this._onNavigate);
+    }
+
+    destroy() {
+        this.dismissEl?.removeEventListener('click', this._onDismiss);
+        this.linkEl?.removeEventListener('click', this._onNavigate);
+    }
+
+    show({ title, artist, detailURL }) {
+        if (!this.dialogEl) return;
+        this.nameEl.textContent = `${title} by ${artist}`;
+        this.linkEl.href = detailURL;
+        this.dialogEl.showModal();
+    }
+}
+
 class AutofillController {
     constructor({
         titleInput,
         artistInput,
         albumInput,
         releaseDateInput,
-        statusEl
-    }, { metadata, artwork, onApply }) {
+        statusEl,
+        currentSongID
+    }, { metadata, artwork, onApply, lookup, onDuplicate }) {
         this.titleInput = titleInput;
         this.artistInput = artistInput;
         this.albumInput = albumInput;
         this.releaseDateInput = releaseDateInput;
         this.statusEl = statusEl;
+        this.currentSongID = currentSongID ?? null;
         this.metadata = metadata;
         this.artwork = artwork;
         this.onApply = onApply;
+        this.lookup = lookup;
+        this.onDuplicate = onDuplicate;
     }
 
     async fetchAndApply(url) {
         try {
-            const song = await this.metadata.fetch(url);
+            const lookupPromise = this.lookup
+                ? this.lookup.check(url).catch(() => null)
+                : Promise.resolve(null);
+            const [song, existing] = await Promise.all([this.metadata.fetch(url), lookupPromise]);
             this.applyMetadata(song);
             this.setStatus('');
-            if (typeof this.onApply === 'function') {
-                this.onApply();
+            if (typeof this.onApply === 'function') this.onApply();
+            if (existing && existing.id !== this.currentSongID && typeof this.onDuplicate === 'function') {
+                this.onDuplicate(existing);
             }
         } catch (error) {
             console.error(error);
@@ -550,16 +599,32 @@ document.addEventListener('DOMContentLoaded', () => {
     );
     resourceInputs.init();
 
+    const lookup = new LookupController();
+
+    const duplicateAlert = new DuplicateAlertController(
+        {
+            dialogEl: document.getElementById('duplicate-alert'),
+            nameEl: document.getElementById('duplicate-song-name'),
+            linkEl: document.getElementById('duplicate-song-link'),
+            dismissEl: document.getElementById('duplicate-dismiss'),
+        },
+        { onNavigate: () => persistence.clear(editor.getStorageKey()) }
+    );
+    duplicateAlert.init();
+
     const autofill = new AutofillController({
         titleInput,
         artistInput,
         albumInput,
         releaseDateInput,
-        statusEl
+        statusEl,
+        currentSongID: parseInt(idInput?.value) || null
     }, {
         metadata,
         artwork,
-        onApply: () => editor.saveDraft()
+        onApply: () => editor.saveDraft(),
+        lookup,
+        onDuplicate: (dup) => duplicateAlert.show(dup)
     });
 
     const editor = new EditorController({

--- a/tmbr/Public/Styles/editor.css
+++ b/tmbr/Public/Styles/editor.css
@@ -479,6 +479,51 @@ body.dragging-target-notes #notes-section::after {
 
 /*
  ------------------------------------------------
+ Dialog
+ ------------------------------------------------
+ */
+
+dialog {
+    border: none;
+    border-radius: 10px;
+    padding: 20px 24px;
+    max-width: 340px;
+    width: calc(100% - 48px);
+    background: Canvas;
+    color: CanvasText;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+dialog p {
+    margin: 0 0 16px;
+    font-size: 1.5rem;
+}
+
+dialog > div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 20px;
+}
+
+dialog button,
+dialog a {
+    font-size: 1.5rem;
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+dialog::backdrop {
+    background: rgba(0, 0, 0, 0.25);
+}
+
+/*
+ ------------------------------------------------
  Mobile adjustments
  ------------------------------------------------
  */

--- a/tmbr/Resources/Views/Catalogue/Songs/song-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Songs/song-editor.leaf
@@ -116,6 +116,14 @@
         <input type="hidden" name="notes" id="preview-notes" />
     </form>
 
+    <dialog id="duplicate-alert">
+        <p>You already have <strong id="duplicate-song-name"></strong>.</p>
+        <div>
+            <button id="duplicate-dismiss" type="button">Continue editing</button>
+            <a id="duplicate-song-link" href="#">Go to song</a>
+        </div>
+    </dialog>
+
     <aside id="gallery" hidden>
         <div id="gallery-header">
             <button class="icon small" type="button" id="gallery-close" aria-label="Close">

--- a/tmbr/Resources/Views/Catalogue/Songs/song-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Songs/song-editor.leaf
@@ -116,13 +116,7 @@
         <input type="hidden" name="notes" id="preview-notes" />
     </form>
 
-    <dialog id="duplicate-alert">
-        <p>You already have <strong id="duplicate-song-name"></strong>.</p>
-        <div>
-            <button id="duplicate-dismiss" type="button">Continue editing</button>
-            <a id="duplicate-song-link" href="#">Go to song</a>
-        </div>
-    </dialog>
+    <div id="duplicate-container"></div>
 
     <aside id="gallery" hidden>
         <div id="gallery-header">

--- a/tmbr/Resources/Views/Shared/alert-dialog.leaf
+++ b/tmbr/Resources/Views/Shared/alert-dialog.leaf
@@ -1,0 +1,15 @@
+<dialog id="#(id)">
+    <p>#(message)</p>
+    <div>
+        #if(primaryAction.href):
+        <a id="#(primaryAction.id)" href="#(primaryAction.href)">#(primaryAction.label)</a>
+        #else:
+        <button id="#(primaryAction.id)" type="button">#(primaryAction.label)</button>
+        #endif
+        #if(secondaryAction.href):
+        <a id="#(secondaryAction.id)" href="#(secondaryAction.href)">#(secondaryAction.label)</a>
+        #else:
+        <button id="#(secondaryAction.id)" type="button">#(secondaryAction.label)</button>
+        #endif
+    </div>
+</dialog>

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/Command+LookupSong.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/Command+LookupSong.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Core
+import Fluent
+import AuthKit
+
+extension Command where Self == PlainCommand<String, Song?> {
+
+    static func lookupSong(
+        database: Database,
+        permission: BasePermissionResolver<QueryBuilder<Song>>
+    ) -> Self {
+        PlainCommand { url in
+            let escaped = url.replacingOccurrences(of: "'", with: "''")
+            let query = Song.query(on: database)
+                .filter(.sql(unsafeRaw: "'\(escaped)' = ANY(songs.resource_urls)"))
+            try await permission.grant(query)
+            return try await query.first()
+        }
+    }
+}
+
+extension CommandFactory<String, Song?> {
+
+    static var lookupSong: Self {
+        CommandFactory { request in
+            .lookupSong(
+                database: request.commandDB,
+                permission: request.permissions.songs.lookup
+            )
+            .logged(name: "Lookup Song", logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Commands+Songs.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Commands+Songs.swift
@@ -8,15 +8,17 @@ extension Commands {
 extension Commands {
     
     struct Songs: CommandCollection, Sendable {
-        
+
         let create: CommandFactory<SongInput, Song>
-        
+
         let delete: CommandFactory<SongID, Void>
-        
+
         let edit: CommandFactory<EditSongInput, Song>
-        
+
         let fetch: CommandFactory<FetchParameters<SongID>, Song>
-        
+
+        let lookup: CommandFactory<String, Song?>
+
         let metadata: CommandFactory<URL, SongMetadata>
 
         let search: CommandFactory<String?, SongSearchResult>
@@ -26,6 +28,7 @@ extension Commands {
             delete: CommandFactory<SongID, Void> = .delete(\.songs),
             edit: CommandFactory<EditSongInput, Song> = .editSong,
             fetch: CommandFactory<FetchParameters<SongID>, Song> = .fetchSong,
+            lookup: CommandFactory<String, Song?> = .lookupSong,
             metadata: CommandFactory<URL, SongMetadata> = .fetchMetadata,
             search: CommandFactory<String?, SongSearchResult> = .searchSongs
         ) {
@@ -33,6 +36,7 @@ extension Commands {
             self.delete = delete
             self.edit = edit
             self.fetch = fetch
+            self.lookup = lookup
             self.metadata = metadata
             self.search = search
         }

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Permissions/Permissions+Songs.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Permissions/Permissions+Songs.swift
@@ -18,4 +18,11 @@ extension PreviewablePermissionScope<Song> {
             )
         )
     }
+
+    var lookup: Permission<QueryBuilder<Song>> {
+        Permission { user, query in
+            guard let userID = user?.userID else { return }
+            query.filter(\.$owner.$id == userID)
+        }
+    }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/API/SongsAPIController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/API/SongsAPIController.swift
@@ -3,12 +3,30 @@ import AuthKit
 import Fluent
 import Core
 
+private struct SongLookupResponse: Content, Sendable {
+    let id: Int
+    let title: String
+    let artist: String
+    let detailURL: String
+}
+
 struct SongsAPIController: RouteCollection {
-    
+
     func boot(routes: RoutesBuilder) throws {
 
         let songsRoute = routes.grouped("api", "songs")
-        
+
+        // GET /api/songs/lookup?url=...
+        songsRoute.get("lookup") { request async throws -> SongLookupResponse in
+            let url = try request.query.get(String.self, at: "url")
+            guard let song = try await request.commands.songs.lookup(url),
+                  let songID = song.id
+            else {
+                throw Abort(.notFound)
+            }
+            return SongLookupResponse(id: songID, title: song.title, artist: song.artist, detailURL: "/songs/\(songID)")
+        }
+
         // GET /api/posts/:songID
         songsRoute.get(":songID") { request async throws -> SongResponse in
             guard let songID = request.parameters.get("songID", as: Int.self) else {

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
@@ -3,6 +3,13 @@ import Fluent
 import AuthKit
 import Core
 
+private struct ExistingSongPreview: Content, Sendable {
+    let id: Int
+    let title: String
+    let artist: String
+    let detailURL: String
+}
+
 struct SongsWebController: RouteCollection {
 
     private enum EditorMode {
@@ -21,6 +28,7 @@ struct SongsWebController: RouteCollection {
         songsRoute.post("new", use: createSong)
 
         songsRoute.get("metadata", use: metadata)
+        songsRoute.get("lookup", use: lookup)
 
         songsRoute.get(":songID", "edit", page: .editSong)
         songsRoute.post(":songID", use: updateSong)
@@ -32,6 +40,17 @@ struct SongsWebController: RouteCollection {
     private func metadata(_ request: Request) async throws -> SongMetadata {
         let url = try request.query.get(String.self, at: "url")
         return try await request.commands.songs.metadata(url)
+    }
+
+    @Sendable
+    private func lookup(_ request: Request) async throws -> ExistingSongPreview {
+        let url = try request.query.get(String.self, at: "url")
+        guard let song = try await request.commands.songs.lookup(url),
+              let songID = song.id
+        else {
+            throw Abort(.notFound)
+        }
+        return ExistingSongPreview(id: songID, title: song.title, artist: song.artist, detailURL: "/songs/\(songID)")
     }
 
     @Sendable

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
@@ -3,13 +3,6 @@ import Fluent
 import AuthKit
 import Core
 
-private struct ExistingSongPreview: Content, Sendable {
-    let id: Int
-    let title: String
-    let artist: String
-    let detailURL: String
-}
-
 struct SongsWebController: RouteCollection {
 
     private enum EditorMode {
@@ -28,7 +21,7 @@ struct SongsWebController: RouteCollection {
         songsRoute.post("new", use: createSong)
 
         songsRoute.get("metadata", use: metadata)
-        songsRoute.get("lookup", use: lookup)
+        songsRoute.get("lookup", use: lookupDialog)
 
         songsRoute.get(":songID", "edit", page: .editSong)
         songsRoute.post(":songID", use: updateSong)
@@ -43,14 +36,23 @@ struct SongsWebController: RouteCollection {
     }
 
     @Sendable
-    private func lookup(_ request: Request) async throws -> ExistingSongPreview {
+    private func lookupDialog(_ request: Request) async throws -> Response {
         let url = try request.query.get(String.self, at: "url")
+        let excludeID = try? request.query.get(Int.self, at: "excludeID")
         guard let song = try await request.commands.songs.lookup(url),
-              let songID = song.id
+              let songID = song.id,
+              songID != excludeID
         else {
-            throw Abort(.notFound)
+            return Response(status: .notFound)
         }
-        return ExistingSongPreview(id: songID, title: song.title, artist: song.artist, detailURL: "/songs/\(songID)")
+        let model = AlertDialog(
+            id: "duplicate-alert",
+            message: "You already have \(song.title) by \(song.artist).",
+            primaryAction: .init(id: "duplicate-dismiss", label: "Continue editing"),
+            secondaryAction: .init(id: "duplicate-song-link", label: "Go to song", href: "/songs/\(songID)")
+        )
+        let view = try await Template.alertDialog.render(model, with: request.view)
+        return try await view.encodeResponse(for: request)
     }
 
     @Sendable

--- a/tmbr/Sources/Core/Web/AlertDialog.swift
+++ b/tmbr/Sources/Core/Web/AlertDialog.swift
@@ -1,0 +1,30 @@
+public struct AlertDialog: Encodable, Sendable {
+
+    public struct Action: Encodable, Sendable {
+        public let id: String
+        public let label: String
+        public let href: String?
+
+        public init(id: String, label: String, href: String? = nil) {
+            self.id = id
+            self.label = label
+            self.href = href
+        }
+    }
+
+    public let id: String
+    public let message: String
+    public let primaryAction: Action
+    public let secondaryAction: Action
+
+    public init(id: String, message: String, primaryAction: Action, secondaryAction: Action) {
+        self.id = id
+        self.message = message
+        self.primaryAction = primaryAction
+        self.secondaryAction = secondaryAction
+    }
+}
+
+extension Template where Model == AlertDialog {
+    public static let alertDialog = Template(name: "Shared/alert-dialog")
+}


### PR DESCRIPTION
When a resource URL is pasted into the song editor, a parallel lookup
checks whether the current user already owns a song with that URL.
If so, a native <dialog> alerts them with options to continue editing
or navigate directly to the existing song (clearing the draft).