### PR TITLE
Notes/Quotes: split into separate API and web controllers

### DIFF
--- a/tmbr/Sources/App/Modules/Notes/Notes.swift
+++ b/tmbr/Sources/App/Modules/Notes/Notes.swift
@@ -40,7 +40,13 @@ struct Notes: Module {
         try await app.commands.add(collection: quoteCommands)
     }
     
-    func boot(_ routes: any Vapor.RoutesBuilder) async throws {}
+    func boot(_ routes: any Vapor.RoutesBuilder) async throws {
+        try routes.register(collection: NotesAPIController())
+        try routes.register(collection: QuotesAPIController())
+        try routes
+            .grouped(RecoverMiddleware())
+            .register(collection: NotesWebController())
+    }
 }
 
 extension Module where Self == Notes {

--- a/tmbr/Sources/App/Modules/Notes/Routes/API/NotesAPIController.swift
+++ b/tmbr/Sources/App/Modules/Notes/Routes/API/NotesAPIController.swift
@@ -2,14 +2,14 @@ import Vapor
 import Fluent
 import AuthKit
 
-struct NotesController: RouteCollection {
-    
+struct NotesAPIController: RouteCollection {
+
     func boot(routes: RoutesBuilder) throws {
-        let notes = routes.grouped("notes")
+        let notes = routes.grouped("api", "notes")
         notes.put(":noteID", use: edit)
         notes.delete(":noteID", use: delete)
     }
-    
+
     @Sendable
     private func delete(request: Request) async throws -> HTTPStatus {
         guard let noteID = request.parameters.get("noteID", as: NoteID.self) else {
@@ -18,13 +18,16 @@ struct NotesController: RouteCollection {
         try await request.commands.notes.delete(noteID)
         return .noContent
     }
-    
+
     @Sendable
-    private func edit(request: Request) async throws -> Note {
+    private func edit(request: Request) async throws -> NoteResponse {
         guard let noteID = request.parameters.get("noteID", as: NoteID.self) else {
             throw Abort(.badRequest, reason: "Missing note ID")
         }
         let payload = try request.content.decode(NotePayload.self)
-        return try await request.commands.notes.edit(noteID, with: payload)
+        let note = try await request.commands.notes.edit(noteID, with: payload)
+        // attachment is loaded by EditNoteCommand; load author for the full response
+        try await note.$author.load(on: request.commandDB)
+        return NoteResponse(note: note, baseURL: request.baseURL)
     }
 }

--- a/tmbr/Sources/App/Modules/Notes/Routes/API/QuotesAPIController.swift
+++ b/tmbr/Sources/App/Modules/Notes/Routes/API/QuotesAPIController.swift
@@ -5,14 +5,15 @@ import AuthKit
 import PostgresKit
 import Core
 
-struct QuotesController: RouteCollection {
+struct QuotesAPIController: RouteCollection {
+
     func boot(routes: RoutesBuilder) throws {
-        let quotes = routes.grouped("quotes")
+        let quotes = routes.grouped("api", "quotes")
         quotes.get(use: list)
         quotes.get("random", use: random)
         quotes.get("search", use: search)
     }
-    
+
     @Sendable
     private func list(request: Request) async throws -> [QuoteResponse] {
         let payload = try request.query.decode(QuoteQueryPayload.self)
@@ -28,7 +29,7 @@ struct QuotesController: RouteCollection {
             )
         }
     }
-    
+
     @Sendable
     private func random(request: Request) async throws -> QuoteResponse {
         let payload = try request.query.decode(QuoteQueryPayload.self)
@@ -42,7 +43,7 @@ struct QuotesController: RouteCollection {
             )
         )
     }
-    
+
     @Sendable
     private func search(request: Request) async throws -> [QuoteResponse] {
         let payload = try request.query.decode(QuoteQueryPayload.self)

--- a/tmbr/Sources/App/Modules/Notes/Routes/API/Responses/NoteResponse.swift
+++ b/tmbr/Sources/App/Modules/Notes/Routes/API/Responses/NoteResponse.swift
@@ -1,22 +1,23 @@
 import Foundation
+import Vapor
 import AuthKit
 
-struct NoteResponse: Encodable, Sendable {
-    
+struct NoteResponse: Encodable, Sendable, AsyncResponseEncodable {
+
     private let id: NoteID
-    
+
     private let access: Access
-    
+
     private let attachment: PreviewResponse
-    
+
     private let author: UserResponse
-    
+
     private let body: String
-    
+
     private let created: Date
-    
+
     private let quotes: [QuoteResponse]
-    
+
     init(
         id: NoteID,
         access: Access,
@@ -34,7 +35,7 @@ struct NoteResponse: Encodable, Sendable {
         self.created = created
         self.quotes = quotes
     }
-    
+
     init(note: Note, baseURL: String) {
         self.init(
             id: note.id!,
@@ -52,5 +53,4 @@ struct NoteResponse: Encodable, Sendable {
             }
         )
     }
-    
 }

--- a/tmbr/Sources/App/Modules/Notes/Routes/Web/NotesWebController.swift
+++ b/tmbr/Sources/App/Modules/Notes/Routes/Web/NotesWebController.swift
@@ -1,0 +1,62 @@
+import Vapor
+import Fluent
+import AuthKit
+import Core
+
+struct NotesWebController: RouteCollection {
+
+    func boot(routes: RoutesBuilder) throws {
+        let notes = routes.grouped("notes")
+        notes.put(":noteID", use: edit)
+    }
+
+    @Sendable
+    private func edit(request: Request) async throws -> Response {
+        guard let noteID = request.parameters.get("noteID", as: NoteID.self) else {
+            return Response(status: .badRequest)
+        }
+        guard let payload = try? request.content.decode(NotePayload.self) else {
+            return Response(status: .badRequest)
+        }
+        do {
+            let note = try await request.commands.notes.edit(noteID, with: payload)
+            let model = try NoteViewModel(note: note, isEditable: true)
+            let view = try await Template.noteItem.render(model, with: request.view)
+            return try await view.encodeResponse(for: request)
+        } catch {
+            let errorMessage = noteErrorMessage(for: error, on: request)
+            let model = NoteViewModel(
+                id: noteID,
+                body: "",
+                created: "",
+                editDetails: NoteViewModel.EditDetails(
+                    rawBody: payload.body,
+                    access: payload.access.rawValue
+                ),
+                error: errorMessage
+            )
+            let view = try await Template.noteItem.render(model, with: request.view)
+            var response = try await view.encodeResponse(for: request)
+            response.status = .unprocessableEntity
+            return response
+        }
+    }
+
+    private func noteErrorMessage(for error: Error, on request: Request) -> String {
+        if let abort = error as? AbortError {
+            switch abort.status {
+            case .unauthorized:
+                return "Please sign in to edit notes."
+            case .forbidden:
+                return "You don't have permission to edit this note."
+            case .notFound:
+                return "This note no longer exists."
+            case .badRequest:
+                return abort.reason.isEmpty ? "Please check your input and try again." : abort.reason
+            default:
+                break
+            }
+        }
+        return "Something went wrong. Please try again."
+    }
+}


### PR DESCRIPTION
Move notes and quotes routes from a single flat NotesController into three focused controllers:
- NotesAPIController: PUT /api/notes/:id, DELETE /api/notes/:id
- QuotesAPIController: GET /api/quotes (list, random, search)
- NotesWebController: PUT /notes/:id (returns HTML fragment)

Remove EditDetails from NoteResponse — the JSON API already exposes body and access; the nested struct duplicated those fields without adding value for API consumers.