### PR TITLE
NoteViewModel: add editDetails for inline editing; fix auth in previews

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/Pages/Page+Book.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/Pages/Page+Book.swift
@@ -58,7 +58,7 @@ struct BookViewModel: Encodable, Sendable {
                 ImageViewModel(image: $0, baseURL: baseURL)
             },
             genre: book.genre,
-            notes: try notes.map(NoteViewModel.init),
+            notes: try notes.map { try NoteViewModel(note: $0) },
             post: try book.post.map(PostItemViewModel.init),
             releaseDate: book.releaseDate?.formatted(.releaseDate),
             resources: book.resourceURLs.compactMap(platform.hyperlink),

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/Web/Pages/Page+Movie.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/Web/Pages/Page+Movie.swift
@@ -58,7 +58,7 @@ struct MovieViewModel: Encodable, Sendable {
             },
             director: movie.director,
             genre: movie.genre,
-            notes: try notes.map(NoteViewModel.init),
+            notes: try notes.map { try NoteViewModel(note: $0) },
             post: try movie.post.map(PostItemViewModel.init),
             releaseYear: movie.releaseDate.formatted(.year),
             resources: movie.resourceURLs.compactMap(platform.hyperlink),

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+Podcast.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+Podcast.swift
@@ -67,7 +67,7 @@ struct PodcastViewModel: Encodable, Sendable {
             episodeNumber: podcast.episodeNumber,
             episodeTitle: podcast.episodeTitle,
             genre: podcast.genre,
-            notes: try notes.map(NoteViewModel.init),
+            notes: try notes.map { try NoteViewModel(note: $0) },
             post: try podcast.post.map(PostItemViewModel.init),
             releaseDate: podcast.releaseDate?.formatted(.releaseDate),
             resources: podcast.resourceURLs.compactMap(platform.hyperlink),

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/Pages/Page+SongPreview.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/Pages/Page+SongPreview.swift
@@ -17,7 +17,7 @@ private struct SongPreviewPayload: Content {
 extension Page {
     static var songPreview: Self {
         Page(template: .song) { req in
-            try req.auth.require(User.self)
+            try await req.permissions.songs.create.grant()
             let payload = try req.content.decode(SongPreviewPayload.self)
             let formatter = MarkdownFormatter.html
             let notes: [NoteViewModel] = payload.notes.isEmpty ? [] : [
@@ -39,6 +39,7 @@ extension Page {
                 artwork: payload.artworkURL.flatMap { url in
                     url.isEmpty ? nil : ImageViewModel(previewURL: url)
                 },
+                allowsNewNote: false,
                 genre: payload.genre,
                 notes: notes,
                 post: nil,

--- a/tmbr/Sources/App/Modules/Notes/Routes/Web/NoteViewModel.swift
+++ b/tmbr/Sources/App/Modules/Notes/Routes/Web/NoteViewModel.swift
@@ -1,7 +1,13 @@
 import Foundation
 import Core
+import AuthKit
 
 struct NoteViewModel: Encodable, Sendable {
+
+    struct EditDetails: Encodable, Sendable {
+        let rawBody: String
+        let access: String
+    }
 
     private let id: NoteID
 
@@ -9,30 +15,44 @@ struct NoteViewModel: Encodable, Sendable {
 
     private let created: String
 
-    init(id: NoteID, body: String, created: String) {
+    private let editDetails: EditDetails?
+
+    private let error: String?
+
+    init(
+        id: NoteID,
+        body: String,
+        created: String,
+        editDetails: EditDetails? = nil,
+        error: String? = nil
+    ) {
         self.id = id
         self.body = body
         self.created = created
+        self.editDetails = editDetails
+        self.error = error
     }
-    
+
     init(
         note: Note,
-        markdownFormatter formatter: MarkdownFormatter
+        markdownFormatter formatter: MarkdownFormatter,
+        isEditable: Bool,
+        error: String? = nil
     ) throws {
         self.init(
             id: try note.requireID(),
             body: formatter.format(note.body),
-            created: (note.createdAt ?? .now).formatted(.publishDate)
+            created: (note.createdAt ?? .now).formatted(.publishDate),
+            editDetails: isEditable ? EditDetails(rawBody: note.body, access: note.access.rawValue) : nil,
+            error: error
         )
     }
 
-
-    init(
-        note: Note
-    ) throws {
-        try self.init(
-            note: note,
-            markdownFormatter: .html
-        )
+    init(note: Note, isEditable: Bool = false, error: String? = nil) throws {
+        try self.init(note: note, markdownFormatter: .html, isEditable: isEditable, error: error)
     }
+}
+
+extension Template where Model == NoteViewModel {
+    static let noteItem = Template(name: "Notes/note-item")
 }

--- a/tmbr/Sources/App/Modules/Posts/Routes/Web/Pages/Page+PostPreview.swift
+++ b/tmbr/Sources/App/Modules/Posts/Routes/Web/Pages/Page+PostPreview.swift
@@ -12,7 +12,7 @@ private struct PostPreviewPayload: Content {
 extension Page {
     static var postPreview: Self {
         Page(template: .post) { req in
-            let user = try req.auth.require(User.self)
+            let user = try await req.permissions.posts.create.grant()
             let payload = try req.content.decode(PostPreviewPayload.self)
             let markdownFormatter = MarkdownFormatter.html
             let nameFormatter: NameFormatter = .author


### PR DESCRIPTION
Add optional EditDetails (rawBody + access) to NoteViewModel so Leaf templates can embed the raw markdown and access level as data attributes, enabling JS to pre-fill the edit textarea without a separate fetch.

Fix book, movie, and podcast pages to use explicit NoteViewModel(note:) closure instead of method reference (resolves init ambiguity added by the new isEditable parameter).

Fix SongPreview and PostPreview to use the permission system (request.permissions.*) instead of raw request.auth — consistent with the rest of the codebase.