### PR TITLE
ShortcutsController: ignore keypresses in text inputs

### DIFF
--- a/tmbr/Public/Scripts/Shortcuts/shortcuts.js
+++ b/tmbr/Public/Scripts/Shortcuts/shortcuts.js
@@ -33,6 +33,8 @@ class ShortcutsController {
     }
 
     _handleKeyDown(event) {
+        const tag = event.target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || event.target.isContentEditable) return;
         const h = this._handlers[event.key.toLowerCase()];
         if (!h) return;
         const isMac = navigator.platform.toUpperCase().includes('MAC');


### PR DESCRIPTION
Keyboard shortcuts (e, l, etc.) were firing while typing in textareas and inputs, which conflicted with normal text editing.