### PR TITLE
Books: platform metadata struct + GoodReads extractor

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Books/Models/Book.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Models/Book.swift
@@ -17,7 +17,7 @@ final class Book: Model, Previewable, @unchecked Sendable {
     @Enum(key: "access")
     var access: Access
     
-    @Field(key: "artist")
+    @Field(key: "author")
     var author: String
     
     @OptionalParent(key: "cover_id")

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Models/Migrations/AddGenreToBook.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Models/Migrations/AddGenreToBook.swift
@@ -1,0 +1,15 @@
+import Fluent
+
+struct AddGenreToBook: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Book.schema)
+            .field("genre", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Book.schema)
+            .deleteField("genre")
+            .update()
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Commands/Command+Metadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Commands/Command+Metadata.swift
@@ -5,10 +5,12 @@ import Logging
 import Fluent
 import AuthKit
 
-struct Metadata: Sendable {
-    
-    let data: [String: String]
-    
+struct Metadata: @unchecked Sendable {
+
+    let json: [String: Any]
+
+    let tags: [String: String]
+
     let type: String
 
     let url: URL
@@ -46,14 +48,15 @@ struct FetchMetadataCommand: Command {
             throw Abort(.badGateway, reason: "Metadata fetch failed. Response HTML is invalid or missing")
         }
         
-        let metadata = parser.parse(html: html)
-        
-        guard let type = metadata["og:type"] else {
+        let (tags, json) = parser.parse(html: html)
+
+        guard let type = tags["og:type"] else {
             throw Abort(.badGateway, reason: "Metadata fetch failed. Unidentified media type.")
         }
-        
+
         return Metadata(
-            data: metadata,
+            json: json,
+            tags: tags,
             type: type,
             url: url
         )

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Metadata/HTMLMetadataParser.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Metadata/HTMLMetadataParser.swift
@@ -2,13 +2,14 @@ import Foundation
 
 struct HTMLMetadataParser {
 
-    func parse(html: String) -> [String: String] {
+    func parse(html: String) -> (tags: [String: String], json: [String: Any]) {
         let head = head(from: html) ?? html
-        return match(in: head, key: "property")
+        let tags = match(in: head, key: "property")
             .merging(
                 match(in: head, key: "name"),
                 uniquingKeysWith: { current, _ in current }
             )
+        return (tags, parseJSONLD(from: html))
     }
 
     // MARK: - Helpers
@@ -104,6 +105,20 @@ struct HTMLMetadataParser {
         let g = m.range(at: group)
         guard g.location != NSNotFound, let r = Range(g, in: text) else { return nil }
         return String(text[r])
+    }
+
+    // Extracts fields from the first <script type="application/ld+json"> block in the full HTML.
+    // Top-level string values are stored as "ld:<key>"; nested author objects are flattened to "ld:author".
+    private func parseJSONLD(from html: String) -> [String: Any] {
+        let pattern = #"<script[^>]+type=["']application/ld\+json["'][^>]*>([\s\S]*?)</script>"#
+        guard let re = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
+              let m = re.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
+              let range = Range(m.range(at: 1), in: html),
+              let data = html[range].data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        return json
     }
 
     // Minimal HTML entity decoding for common cases

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicSong.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicSong.swift
@@ -8,7 +8,7 @@ extension MetadataExtractor where M == SongMetadata {
             throw MetadataExtractionError.invalidType(expected: "music.song", actual: song.type)
         }
 
-        var albumURLComponents = song.data["music:album"].flatMap(URLComponents.init)
+        var albumURLComponents = song.tags["music:album"].flatMap(URLComponents.init)
         albumURLComponents?.queryItems = nil
         async let album = extract(
             key: "apple:title",
@@ -19,14 +19,14 @@ extension MetadataExtractor where M == SongMetadata {
 
         async let artist = extract(
             key: "apple:title",
-            from: song.data["music:musician"],
+            from: song.tags["music:musician"],
             of: "music.musician",
             with: fetcher
         )
 
         // Transform og:image URL to get square artwork
         // Original: .../1200x630bf-60.jpg -> Changed to: .../1000x1000.jpg
-        let artwork = song.data["og:image"].flatMap { urlString -> String? in
+        let artwork = song.tags["og:image"].flatMap { urlString -> String? in
             guard var url = URL(string: urlString) else { return nil }
             url.deleteLastPathComponent()
             url.appendPathComponent("1000x1000.jpg")
@@ -37,9 +37,9 @@ extension MetadataExtractor where M == SongMetadata {
             album: try? await album,
             artist: try? await artist,
             artwork: artwork,
-            externalID: song.data["apple:content_id"],
-            releaseDate: song.data["music:release_date"],
-            title: song.data["apple:title"]
+            externalID: song.tags["apple:content_id"],
+            releaseDate: song.tags["music:release_date"],
+            title: song.tags["apple:title"]
         )
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+GoodReads.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+GoodReads.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension MetadataExtractor where M == BookMetadata {
+
+    static let goodreads = MetadataExtractor { url, fetcher in
+        let book = try await fetcher(url)
+        guard book.type == "books.book" else {
+            throw MetadataExtractionError.invalidType(expected: "books.book", actual: book.type)
+        }
+
+        // Follow the author page URL to get the author's name via og:title
+        let author = try? await extract(
+            key: "og:title",
+            from: book.data["books:author"],
+            of: "books.author",
+            with: fetcher
+        )
+
+        return BookMetadata(
+            author: author,
+            cover: book.data["og:image"],
+            externalID: book.data["books:isbn"],
+            releaseDate: book.data["books:release_date"],
+            title: book.data["og:title"]
+        )
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+GoodReads.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+GoodReads.swift
@@ -8,20 +8,15 @@ extension MetadataExtractor where M == BookMetadata {
             throw MetadataExtractionError.invalidType(expected: "books.book", actual: book.type)
         }
 
-        // Follow the author page URL to get the author's name via og:title
-        let author = try? await extract(
-            key: "og:title",
-            from: book.data["books:author"],
-            of: "books.author",
-            with: fetcher
-        )
+        let authors = book.json["author"] as? [[String: Any]]
+        let author = authors?.first?["name"] as? String
 
         return BookMetadata(
             author: author,
-            cover: book.data["og:image"],
-            externalID: book.data["books:isbn"],
-            releaseDate: book.data["books:release_date"],
-            title: book.data["og:title"]
+            cover: book.tags["og:image"],
+            externalID: book.tags["books:isbn"] ?? book.json["isbn"] as? String,
+            releaseDate: book.tags["books:release_date"] ?? book.json["datePublished"] as? String,
+            title: book.tags["og:title"] ?? book.json["name"] as? String
         )
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+SpotifySong.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+SpotifySong.swift
@@ -10,7 +10,7 @@ extension MetadataExtractor where M == SongMetadata {
 
         let album = try? await extract(
             key: "og:title",
-            from: song.data["music:album"],
+            from: song.tags["music:album"],
             of: "music.album",
             with: fetcher
         )
@@ -21,11 +21,11 @@ extension MetadataExtractor where M == SongMetadata {
         
         return SongMetadata(
             album: album,
-            artist: song.data["music:musician_description"],
-            artwork: song.data["og:image"],
+            artist: song.tags["music:musician_description"],
+            artwork: song.tags["og:image"],
             externalID: songID,
-            releaseDate: song.data["music:release_date"],
-            title: song.data["og:title"]
+            releaseDate: song.tags["music:release_date"],
+            title: song.tags["og:title"]
         )
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/BookMetadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/BookMetadata.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Vapor
+
+struct BookMetadata: Encodable, AsyncResponseEncodable, Sendable {
+
+    let author: String?
+
+    let cover: String?
+
+    let externalID: String?
+
+    let releaseDate: String?
+
+    let title: String?
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/MetadataExtractor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/MetadataExtractor.swift
@@ -26,7 +26,7 @@ struct MetadataExtractor<M>: Sendable {
     ) async throws -> String? {
         let metadata = try await fetcher(url)
         guard metadata.type == type else { return nil }
-        return metadata.data[key]
+        return metadata.tags[key]
     }
     
     static func extract(

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Book.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Book.swift
@@ -1,8 +1,8 @@
-extension Platform where M == Void {
+extension Platform where M == BookMetadata {
 
-    static var book: Platform<Void> {
+    static var book: Platform<BookMetadata> {
         Platform(platforms: [
-            Platform(name: "GoodReads", checker: .goodreads)
+            Platform(name: "GoodReads", checker: .goodreads, extractor: .goodreads)
         ])
     }
 }


### PR DESCRIPTION
Introduces BookMetadata (title, author, cover URL, releaseDate, externalID) and MetadataExtractor+GoodReads which parses OpenGraph tags from GoodReads book pages.

Platform+Book upgrades from Platform<Void> to Platform<BookMetadata> and registers the GoodReads extractor.

Also fixes Book.swift @Field(key:) from the legacy "artist" to "author" and adds AddGenreToBook migration for the optional genre column.