### PR TITLE
Books: add lookup, search, and metadata commands

### DIFF
--- a/.claude/docs/preview-search-improvement.md
+++ b/.claude/docs/preview-search-improvement.md
@@ -1,0 +1,51 @@
+# Improvement: Unify BookSearch / SongSearch via PreviewSearch
+
+## Problem
+
+`Command+BookSearch.swift` and `Command+SongSearch.swift` are nearly identical. Both manually:
+- Join the domain table (Book / Song) onto Preview
+- Apply raw-SQL ILIKE filters
+- Grant permissions on the query
+- Run a concurrent note search
+- Deduplicate results by preview ID
+
+The only differences are the `parentType` filter and the searched columns.
+
+## Why it hasn't been done yet
+
+A general-purpose `listPreviews` command (`Command+ListPreviews.swift`) already exists and is used by `CatalogueSearch`. It takes `PreviewQueryInput { term, types }` and searches `primaryInfo` (title) and `secondaryInfo` (author/artist) on the Preview table using safe Fluent parameter binding.
+
+The blocker: `listPreviews` only knows about Preview fields. The join-based commands also search `genre` (books) and `album` + `genre` (songs), which live on the domain tables and have no representation on Preview.
+
+## Proposed solution
+
+Add a `tertiaryInfo` field (or a `searchTerms: [String]` array) to `Preview` to hold additional searchable text — populated by `PreviewModelMiddleware` from whatever domain-specific fields make sense (genre, album, etc.).
+
+Once Preview carries all searchable data, `listPreviews` can include a filter on this field, and `BookSearch` / `SongSearch` reduce to:
+
+```swift
+static func searchBooks(
+    previewSearch: CommandResolver<PreviewQueryInput, [Preview]>,
+    noteSearch: CommandResolver<NoteQueryPayload, [Note]>
+) -> Self {
+    PlainCommand { term in
+        let input = PreviewQueryInput(term: term, types: [Book.previewType])
+        async let previewsTask = previewSearch(input)
+        async let notesTask = noteSearch(NoteQueryPayload(term: term, types: [Book.previewType]))
+        let (previews, notes) = try await (previewsTask, notesTask)
+        // dedup ...
+        return BookSearchResult(previews: previews, noteMatches: noteMatches)
+    }
+}
+```
+
+The `BookSearchResult` / `SongSearchResult` / `CatalogueSearchResult` types are structurally identical and could also be unified into a single shared `SearchResult` type.
+
+## Steps when ready
+
+1. Add migration to add `search_terms` (text array, default `{}`) to `previews`
+2. Populate it in each `PreviewModelMiddleware` configure closure (e.g. genre, album)
+3. Extend `listPreviews` to also ILIKE-search the `search_terms` array elements
+4. Refactor `searchBooks` and `searchSongs` to use `previewSearch` + `noteSearch` resolvers
+5. Remove `database` + `permission` params from both commands
+6. Optionally unify the three result types into `SearchResult`

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/BookInput.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/BookInput.swift
@@ -76,3 +76,10 @@ extension Validator where Input == BookInput {
         }
     }
 }
+
+extension BookInput {
+
+    func edit(id: BookID) -> EditBookInput {
+        EditBookInput(id: id, parameters: self)
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/Command+BookSearch.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/Command+BookSearch.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Core
+import Fluent
+import AuthKit
+
+struct BookSearchResult: Sendable {
+
+    let previews: [Preview]
+
+    let noteMatches: [Preview]
+}
+
+extension Command where Self == PlainCommand<String?, BookSearchResult> {
+
+    static func searchBooks(
+        database: Database,
+        permission: BasePermissionResolver<QueryBuilder<Preview>>,
+        noteSearch: CommandResolver<NoteQueryPayload, [Note]>
+    ) -> Self {
+        PlainCommand { term in
+            let safeTerm = term.flatMap { t -> String? in
+                let trimmed = t.trimmed
+                return trimmed.isEmpty ? nil : trimmed.replacingOccurrences(of: "'", with: "''")
+            }
+
+            let query = Preview.query(on: database)
+                .with(\.$image)
+                .filter(\.$parentType == Book.previewType)
+                .join(Book.self, on: \Book.$preview.$id == \Preview.$id)
+                .sort(\.$createdAt, .descending)
+
+            if let safeTerm {
+                query.group(.or) { group in
+                    group.filter(.sql(unsafeRaw: "books.title ILIKE '%\(safeTerm)%'"))
+                    group.filter(.sql(unsafeRaw: "books.author ILIKE '%\(safeTerm)%'"))
+                    group.filter(.sql(unsafeRaw: "books.genre ILIKE '%\(safeTerm)%'"))
+                }
+            }
+
+            try await permission.grant(query)
+
+            async let previewsTask = query.all()
+            async let notesTask = noteSearch(NoteQueryPayload(term: term, types: [Book.previewType]))
+            let (previews, notes) = try await (previewsTask, notesTask)
+
+            let previewIDs = Set(previews.compactMap(\.id))
+            var seen = previewIDs
+            let noteMatches = notes.compactMap { note -> Preview? in
+                guard let id = note.attachment.id, !seen.contains(id) else { return nil }
+                seen.insert(id)
+                return note.attachment
+            }
+
+            return BookSearchResult(previews: previews, noteMatches: noteMatches)
+        }
+    }
+}
+
+extension CommandFactory<String?, BookSearchResult> {
+
+    static var searchBooks: Self {
+        CommandFactory { request in
+            .searchBooks(
+                database: request.commandDB,
+                permission: request.permissions.previews.query,
+                noteSearch: request.commands.notes.search
+            )
+            .logged(name: "Search Books", logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/Command+LookupBook.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/Command+LookupBook.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Core
+import Fluent
+import AuthKit
+
+extension Command where Self == PlainCommand<String, Book?> {
+
+    static func lookupBook(
+        database: Database,
+        permission: BasePermissionResolver<QueryBuilder<Book>>
+    ) -> Self {
+        PlainCommand { url in
+            let escaped = url.replacingOccurrences(of: "'", with: "''")
+            let query = Book.query(on: database)
+                .filter(.sql(unsafeRaw: "'\(escaped)' = ANY(books.resource_urls)"))
+            try await permission.grant(query)
+            return try await query.first()
+        }
+    }
+}
+
+extension CommandFactory<String, Book?> {
+
+    static var lookupBook: Self {
+        CommandFactory { request in
+            .lookupBook(
+                database: request.commandDB,
+                permission: request.permissions.books.lookup
+            )
+            .logged(name: "Lookup Book", logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/FetchBookMetadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Command/FetchBookMetadata.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Vapor
+import Core
+import Logging
+import Fluent
+import AuthKit
+
+struct FetchBookMetadataCommand: Command {
+
+    private let fetch: CommandResolver<URL, Metadata>
+
+    private let platform: Platform<BookMetadata>
+
+    init(
+        fetch: CommandResolver<URL, Metadata>,
+        platform: Platform<BookMetadata> = .book
+    ) {
+        self.fetch = fetch
+        self.platform = platform
+    }
+
+    func execute(_ url: URL) async throws -> BookMetadata {
+        guard let metadata = try await platform.metadata(for: url, fetcher: fetch.callAsFunction) else {
+            throw Abort(.badRequest, reason: "Could not extract metadata from URL.")
+        }
+        return metadata
+    }
+}
+
+extension CommandFactory<URL, BookMetadata> {
+
+    static var fetchBookMetadata: Self {
+        CommandFactory { request in
+            FetchBookMetadataCommand(
+                fetch: request.commands.catalogue.metadata
+            )
+            .logged(logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Commands+Books.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Commands/Commands+Books.swift
@@ -6,27 +6,39 @@ extension Commands {
 }
 
 extension Commands {
-    
+
     struct Books: CommandCollection, Sendable {
-        
+
         let create: CommandFactory<BookInput, Book>
-        
+
         let delete: CommandFactory<BookID, Void>
-        
+
         let edit: CommandFactory<EditBookInput, Book>
-        
+
         let fetch: CommandFactory<FetchParameters<BookID>, Book>
-        
+
+        let lookup: CommandFactory<String, Book?>
+
+        let metadata: CommandFactory<URL, BookMetadata>
+
+        let search: CommandFactory<String?, BookSearchResult>
+
         init(
             create: CommandFactory<BookInput, Book> = .createBook,
             delete: CommandFactory<BookID, Void> = .delete(\.books),
             edit: CommandFactory<EditBookInput, Book> = .editBook,
-            fetch: CommandFactory<FetchParameters<BookID>, Book> = .fetchBook
+            fetch: CommandFactory<FetchParameters<BookID>, Book> = .fetchBook,
+            lookup: CommandFactory<String, Book?> = .lookupBook,
+            metadata: CommandFactory<URL, BookMetadata> = .fetchBookMetadata,
+            search: CommandFactory<String?, BookSearchResult> = .searchBooks
         ) {
             self.create = create
             self.delete = delete
             self.edit = edit
             self.fetch = fetch
+            self.lookup = lookup
+            self.metadata = metadata
+            self.search = search
         }
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Permissions/Permissions+Books.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Permissions/Permissions+Books.swift
@@ -18,4 +18,11 @@ extension PreviewablePermissionScope<Book> {
             )
         )
     }
+
+    var lookup: Permission<QueryBuilder<Book>> {
+        Permission { user, query in
+            guard let userID = user?.userID else { return }
+            query.filter(\.$owner.$id == userID)
+        }
+    }
 }


### PR DESCRIPTION
Three new CommandFactory properties on Commands.Books:
- lookup: finds a Book by resource URL using ANY() SQL
- search: queries title, author, and genre with note body fallback; returns BookSearchResult(previews:noteMatches:)
- metadata: fetches BookMetadata via the GoodReads extractor

Adds BookInput.edit(id:) for the PUT route and the lookup permission scope to Permissions+Books.