### PR TITLE
Books: add BookEditorPayload for web form submissions

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/BookEditorPayload.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/BookEditorPayload.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Vapor
+import AuthKit
+
+struct BookEditorPayload: Decodable, Sendable {
+
+    struct NoteEntry: Decodable, Sendable {
+        let id: String?
+        let body: String
+        let access: Access
+        let deleted: Bool?
+
+        init(body: String, access: Access = .private) {
+            self.id = nil
+            self.body = body
+            self.access = access
+            self.deleted = nil
+        }
+
+        var noteID: NoteID? {
+            guard let raw = id, !raw.isEmpty else { return nil }
+            return UUID(uuidString: raw)
+        }
+    }
+
+    let _csrf: String?
+
+    let access: Access
+
+    let author: String
+
+    private let coverIdRaw: String?
+
+    private let coverSourceURLRaw: String?
+
+    let genre: String?
+
+    let notes: [NoteEntry]
+
+    let releaseDate: Date?
+
+    let resourceURLs: [String]
+
+    let title: String
+
+    var coverId: ImageID? {
+        guard let raw = coverIdRaw, !raw.isEmpty else { return nil }
+        return Int(raw)
+    }
+
+    var coverSourceURL: String? {
+        guard let raw = coverSourceURLRaw, !raw.isEmpty else { return nil }
+        return raw
+    }
+
+    var filteredResourceURLs: [String] {
+        resourceURLs.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case _csrf
+        case access
+        case author
+        case coverIdRaw = "cover-id"
+        case coverSourceURLRaw = "cover-source-url"
+        case genre
+        case notes
+        case releaseDate = "release-date"
+        case resourceURLs
+        case title
+    }
+
+    init(
+        _csrf: String? = nil,
+        access: Access = .private,
+        author: String = "",
+        coverIdRaw: String? = nil,
+        coverSourceURLRaw: String? = nil,
+        genre: String? = nil,
+        notes: [NoteEntry] = [],
+        releaseDate: Date? = nil,
+        resourceURLs: [String] = [],
+        title: String = ""
+    ) {
+        self._csrf = _csrf
+        self.access = access
+        self.author = author
+        self.coverIdRaw = coverIdRaw
+        self.coverSourceURLRaw = coverSourceURLRaw
+        self.genre = genre
+        self.notes = notes
+        self.releaseDate = releaseDate
+        self.resourceURLs = resourceURLs
+        self.title = title
+    }
+}
+
+extension BookInput {
+
+    init(payload: BookEditorPayload, coverId: ImageID? = nil) {
+        self.init(
+            access: payload.access,
+            author: payload.author,
+            cover: coverId ?? payload.coverId,
+            genre: payload.genre,
+            releaseDate: payload.releaseDate,
+            resourceURLs: payload.filteredResourceURLs,
+            title: payload.title
+        )
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/BookEditorPayload.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/BookEditorPayload.swift
@@ -4,25 +4,6 @@ import AuthKit
 
 struct BookEditorPayload: Decodable, Sendable {
 
-    struct NoteEntry: Decodable, Sendable {
-        let id: String?
-        let body: String
-        let access: Access
-        let deleted: Bool?
-
-        init(body: String, access: Access = .private) {
-            self.id = nil
-            self.body = body
-            self.access = access
-            self.deleted = nil
-        }
-
-        var noteID: NoteID? {
-            guard let raw = id, !raw.isEmpty else { return nil }
-            return UUID(uuidString: raw)
-        }
-    }
-
     let _csrf: String?
 
     let access: Access
@@ -35,7 +16,7 @@ struct BookEditorPayload: Decodable, Sendable {
 
     let genre: String?
 
-    let notes: [NoteEntry]
+    let notes: [NotePayload]
 
     let releaseDate: Date?
 
@@ -77,7 +58,7 @@ struct BookEditorPayload: Decodable, Sendable {
         coverIdRaw: String? = nil,
         coverSourceURLRaw: String? = nil,
         genre: String? = nil,
-        notes: [NoteEntry] = [],
+        notes: [NotePayload] = [],
         releaseDate: Date? = nil,
         resourceURLs: [String] = [],
         title: String = ""

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongEditorPayload.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongEditorPayload.swift
@@ -4,25 +4,6 @@ import AuthKit
 
 struct SongEditorPayload: Decodable, Sendable {
 
-    struct NoteEntry: Decodable, Sendable {
-        let id: String?
-        let body: String
-        let access: Access
-        let deleted: Bool?
-
-        init(body: String, access: Access = .private) {
-            self.id = nil
-            self.body = body
-            self.access = access
-            self.deleted = nil
-        }
-
-        var noteID: NoteID? {
-            guard let raw = id, !raw.isEmpty else { return nil }
-            return UUID(uuidString: raw)
-        }
-    }
-
     let _csrf: String?
     
     let access: Access
@@ -37,7 +18,7 @@ struct SongEditorPayload: Decodable, Sendable {
     
     let genre: String?
     
-    let notes: [NoteEntry]
+    let notes: [NotePayload]
     
     let releaseDate: Date?
     
@@ -81,7 +62,7 @@ struct SongEditorPayload: Decodable, Sendable {
         artworkIdRaw: String? = nil,
         artworkSourceURLRaw: String? = nil,
         genre: String? = nil,
-        notes: [NoteEntry] = [],
+        notes: [NotePayload] = [],
         releaseDate: Date? = nil,
         resourceURLs: [String] = [],
         title: String = ""

--- a/tmbr/Sources/App/Modules/Notes/Payloads/NotePayload.swift
+++ b/tmbr/Sources/App/Modules/Notes/Payloads/NotePayload.swift
@@ -1,10 +1,25 @@
 import Foundation
 import AuthKit
-import Vapor
 
-struct NotePayload: Decodable {
-    
+struct NotePayload: Decodable, Sendable {
+
+    let id: String?
+
     let body: String
-    
+
     let access: Access
+
+    let deleted: Bool?
+
+    init(body: String, access: Access = .private) {
+        self.id = nil
+        self.body = body
+        self.access = access
+        self.deleted = nil
+    }
+
+    var noteID: NoteID? {
+        guard let raw = id, !raw.isEmpty else { return nil }
+        return UUID(uuidString: raw)
+    }
 }

--- a/tmbr/Sources/App/Modules/Notes/Routes/Web/NotesWebController.swift
+++ b/tmbr/Sources/App/Modules/Notes/Routes/Web/NotesWebController.swift
@@ -36,7 +36,7 @@ struct NotesWebController: RouteCollection {
                 error: errorMessage
             )
             let view = try await Template.noteItem.render(NoteItemContext(note: model), with: request.view)
-            var response = try await view.encodeResponse(for: request)
+            let response = try await view.encodeResponse(for: request)
             response.status = .unprocessableEntity
             return response
         }


### PR DESCRIPTION
Decodes the multipart form POST from the book editor. Includes CSRF,
access, cover image inputs (cover-id / cover-source-url), resource URLs,
and notes with NoteEntry nested struct. Maps to BookInput via a
convenience init on BookInput.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>