### PR TITLE
Books: add list, editor, and preview page view models

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/Pages/Page+Book.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/Pages/Page+Book.swift
@@ -4,63 +4,103 @@ import AuthKit
 import Core
 
 struct BookViewModel: Encodable, Sendable {
-    
+
     private let id: BookID
-    
+
     private let author: String?
-    
+
+    private let allowsNewNote: Bool
+
     private let cover: ImageViewModel?
-    
-    private let genre: String?
-    
+
+    private let info: String?
+
     private let notes: [NoteViewModel]
-    
+
+    private let notesEndpoint: String
+
     private let post: PostItemViewModel?
-    
-    private let releaseDate: String?
-    
+
     private let resources: [Hyperlink]
-    
+
     private let title: String
-    
+
     init(
         id: BookID,
         author: String?,
+        allowsNewNote: Bool,
         cover: ImageViewModel?,
-        genre: String?,
+        info: String?,
         notes: [NoteViewModel],
+        notesEndpoint: String,
         post: PostItemViewModel?,
-        releaseDate: String?,
         resources: [Hyperlink],
         title: String
     ) {
         self.id = id
         self.author = author
+        self.allowsNewNote = allowsNewNote
         self.cover = cover
-        self.genre = genre
+        self.info = info
         self.notes = notes
+        self.notesEndpoint = notesEndpoint
         self.post = post
-        self.releaseDate = releaseDate
         self.resources = resources
         self.title = title
     }
-    
+
+    init(
+        id: BookID,
+        author: String?,
+        allowsNewNote: Bool,
+        cover: ImageViewModel?,
+        genre: String?,
+        notes: [NoteViewModel],
+        notesEndpoint: String,
+        post: PostItemViewModel?,
+        releaseDate: String?,
+        resources: [Hyperlink],
+        title: String
+    ) {
+        self.init(
+            id: id,
+            author: author,
+            allowsNewNote: allowsNewNote,
+            cover: cover,
+            info: {
+                let parts = [genre, releaseDate].compactMap(\.self).filter { !$0.isEmpty }
+                return parts.isEmpty ? nil : parts.joined(separator: ", ")
+            }(),
+            notes: notes,
+            notesEndpoint: notesEndpoint,
+            post: post,
+            resources: resources,
+            title: title
+        )
+    }
+
     init(
         book: Book,
         notes: [Note],
         baseURL: String,
+        allowsNewNote: Bool,
         platform: Platform<BookMetadata> = .book
     ) throws {
+        let bookID = try book.requireID()
         self.init(
-            id: try book.requireID(),
+            id: bookID,
             author: book.author,
+            allowsNewNote: allowsNewNote,
             cover: book.cover.flatMap {
                 ImageViewModel(image: $0, baseURL: baseURL)
             },
-            genre: book.genre,
-            notes: try notes.map { try NoteViewModel(note: $0) },
+            info: {
+                let parts = [book.genre, book.releaseDate?.formatted(.releaseDate)].compactMap(\.self).filter { !$0.isEmpty }
+                return parts.isEmpty ? nil : parts.joined(separator: ", ")
+            }(),
+            notes: try notes.map { try NoteViewModel(note: $0, isEditable: allowsNewNote) },
+            notesEndpoint: "/books/\(bookID)/notes",
             post: try book.post.map(PostItemViewModel.init),
-            releaseDate: book.releaseDate?.formatted(.releaseDate),
             resources: book.resourceURLs.compactMap(platform.hyperlink),
             title: book.title
         )
@@ -77,16 +117,16 @@ extension Page {
             guard let bookID = request.parameters.get("bookID", as: Int.self) else {
                 throw Abort(.badRequest)
             }
-            return try await request.commands.transaction { commands in
-                async let book = commands.books.fetch(bookID, for: .read)
-                async let notes = commands.notes.query(id: bookID, of: Book.previewType)
-                
-                return try BookViewModel(
-                    book: await book,
-                    notes: await notes,
-                    baseURL: request.baseURL
-                )
-            }
+            async let bookTask = request.commands.books.fetch(bookID, for: .read)
+            async let notesTask = request.commands.notes.query(id: bookID, of: Book.previewType)
+            let resolvedBook = try await bookTask
+            let allowsNewNote = (try? await request.permissions.books.edit.grant(resolvedBook)) != nil
+            return try BookViewModel(
+                book: resolvedBook,
+                notes: await notesTask,
+                baseURL: request.baseURL,
+                allowsNewNote: allowsNewNote
+            )
         }
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/Pages/Page+BookEditor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/Pages/Page+BookEditor.swift
@@ -1,0 +1,197 @@
+import Core
+import Foundation
+import Vapor
+import Fluent
+import AuthKit
+
+struct BookEditorViewModel: Encodable, Sendable {
+
+    struct NoteViewModel: Encodable, Sendable {
+        let id: String?
+        let body: String
+        let access: Access
+    }
+
+    private let id: Int?
+
+    private let pageTitle: String?
+
+    private let access: Access
+
+    private let author: String
+
+    private let coverId: Int?
+
+    private let coverSourceURL: String?
+
+    private let coverThumbnailURL: String?
+
+    private let genre: String
+
+    private let notes: [NoteViewModel]
+
+    private let releaseDate: String
+
+    private let resourceURLs: [String]
+
+    private let submit: Form.Submit
+
+    private let title: String
+
+    let _csrf: String?
+
+    private let error: String?
+
+    init(
+        id: Int? = nil,
+        pageTitle: String? = nil,
+        access: Access = .private,
+        author: String = "",
+        coverId: Int? = nil,
+        coverSourceURL: String? = nil,
+        coverThumbnailURL: String? = nil,
+        genre: String = "",
+        notes: [NoteViewModel] = [],
+        releaseDate: String = "",
+        resourceURLs: [String] = [],
+        submit: Form.Submit,
+        title: String = "",
+        csrf: String? = nil,
+        error: String? = nil
+    ) {
+        self.id = id
+        self.pageTitle = pageTitle
+        self.access = access
+        self.author = author
+        self.coverId = coverId
+        self.coverSourceURL = coverSourceURL
+        self.coverThumbnailURL = coverThumbnailURL
+        self.genre = genre
+        self.notes = notes
+        self.releaseDate = releaseDate
+        self.resourceURLs = resourceURLs
+        self.submit = submit
+        self.title = title
+        self._csrf = csrf
+        self.error = error
+    }
+
+    init(
+        book: Book,
+        notes: [Note],
+        baseURL: String,
+        csrf: String?
+    ) throws {
+        let id = try book.requireID()
+        let coverId = book.$cover.id
+        let coverThumbnailURL: String?
+        if let cover = book.cover {
+            coverThumbnailURL = "\(baseURL)/gallery/data/\(cover.thumbnailKey)"
+        } else {
+            coverThumbnailURL = nil
+        }
+        self.init(
+            id: id,
+            pageTitle: "Edit '\(book.title)'",
+            access: book.access,
+            author: book.author,
+            coverId: coverId,
+            coverSourceURL: nil,
+            coverThumbnailURL: coverThumbnailURL,
+            genre: book.genre ?? "",
+            notes: notes.map { NoteViewModel(id: $0.id?.uuidString, body: $0.body, access: $0.access) },
+            releaseDate: book.releaseDate?.formatted(.releaseDate) ?? "",
+            resourceURLs: book.resourceURLs,
+            submit: Form.Submit(
+                action: "/books/\(id)",
+                label: "Save"
+            ),
+            title: book.title,
+            csrf: csrf
+        )
+    }
+}
+
+extension Template where Model == BookEditorViewModel {
+    static let bookEditor = Template(name: "Catalogue/Books/book-editor")
+}
+
+extension Page {
+    static var createBook: Self {
+        Page(template: .bookEditor) { req in
+            try await req.permissions.books.create()
+            let submit = Form.Submit(
+                action: "/books/new",
+                label: "Save"
+            )
+            let csrf = UUID().uuidString
+            req.session.data["csrf.editor"] = csrf
+            return BookEditorViewModel(pageTitle: "New book", submit: submit, csrf: csrf)
+        }
+    }
+
+    static var editBook: Self {
+        Page(template: .bookEditor) { request in
+            guard let bookID = request.parameters.get("bookID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Book ID is incorrect or missing.")
+            }
+            async let book = request.commands.books.fetch(bookID, for: .write)
+            async let notes = request.commands.notes.query(id: bookID, of: Book.previewType)
+            let csrf = UUID().uuidString
+            request.session.data["csrf.editor"] = csrf
+            return try await BookEditorViewModel(
+                book: book,
+                notes: notes,
+                baseURL: request.baseURL,
+                csrf: csrf
+            )
+        }
+    }
+}
+
+private struct BookPreviewPayload: Content {
+    let title: String
+    let author: String
+    let genre: String?
+    let releaseDate: String?
+    let coverURL: String?
+    let resourceURLs: String?
+    let notes: String
+}
+
+extension Page {
+    static var bookPreview: Self {
+        Page(template: .book) { req in
+            try await req.permissions.books.create.grant()
+            let payload = try req.content.decode(BookPreviewPayload.self)
+            let formatter = MarkdownFormatter.html
+            let notes: [NoteViewModel] = payload.notes.isEmpty ? [] : [
+                NoteViewModel(
+                    id: UUID(),
+                    body: formatter.format(payload.notes),
+                    created: Date.now.formatted(.publishDate)
+                )
+            ]
+            let platform = Platform<BookMetadata>.book
+            let resources = (payload.resourceURLs ?? "")
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map(String.init)
+                .compactMap(platform.hyperlink)
+            return BookViewModel(
+                id: 0,
+                author: payload.author,
+                allowsNewNote: false,
+                cover: payload.coverURL.flatMap { url in
+                    url.isEmpty ? nil : ImageViewModel(previewURL: url)
+                },
+                genre: payload.genre,
+                notes: notes,
+                notesEndpoint: "",
+                post: nil,
+                releaseDate: payload.releaseDate,
+                resources: resources,
+                title: "Preview: \(payload.title)"
+            )
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/Pages/Page+Books.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/Pages/Page+Books.swift
@@ -1,0 +1,31 @@
+import Vapor
+import Core
+import Foundation
+
+struct BooksViewModel: Encodable, Sendable {
+    let compose: String?
+    let term: String?
+    let previews: [PreviewViewModel]
+}
+
+extension Template where Model == BooksViewModel {
+    static let books = Template(name: "Catalogue/Books/books")
+}
+
+extension Page {
+    static var books: Self {
+        Page(template: .books) { req in
+            let term = try? req.query.get(String.self, at: "term")
+            async let composeURL: String? = (try? await req.permissions.books.create()) != nil ? "/books/new" : nil
+            async let result = req.commands.books.search(term)
+            let baseURL = req.baseURL
+            let resolved = try await result
+            return BooksViewModel(
+                compose: await composeURL,
+                term: term,
+                previews: resolved.previews.map { PreviewViewModel(preview: $0, baseURL: baseURL) }
+                    + resolved.noteMatches.map { PreviewViewModel(preview: $0, baseURL: baseURL, isNoteMatch: true) }
+            )
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/Pages/Page+Song.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/Pages/Page+Song.swift
@@ -17,6 +17,8 @@ struct SongViewModel: Encodable, Sendable {
 
     private let notes: [NoteViewModel]
 
+    private let notesEndpoint: String
+
     private let post: PostItemViewModel?
 
     private let resources: [Hyperlink]
@@ -30,6 +32,7 @@ struct SongViewModel: Encodable, Sendable {
         allowsNewNote: Bool,
         info: String?,
         notes: [NoteViewModel],
+        notesEndpoint: String,
         post: PostItemViewModel?,
         resources: [Hyperlink],
         title: String
@@ -40,6 +43,7 @@ struct SongViewModel: Encodable, Sendable {
         self.allowsNewNote = allowsNewNote
         self.info = info
         self.notes = notes
+        self.notesEndpoint = notesEndpoint
         self.post = post
         self.resources = resources
         self.title = title
@@ -53,6 +57,7 @@ struct SongViewModel: Encodable, Sendable {
         allowsNewNote: Bool,
         genre: String?,
         notes: [NoteViewModel],
+        notesEndpoint: String,
         post: PostItemViewModel?,
         releaseDate: String?,
         resources: [Hyperlink],
@@ -68,6 +73,7 @@ struct SongViewModel: Encodable, Sendable {
                 return parts.isEmpty ? nil : parts.joined(separator: ", ")
             }(),
             notes: notes,
+            notesEndpoint: notesEndpoint,
             post: post,
             resources: resources,
             title: title
@@ -81,8 +87,9 @@ struct SongViewModel: Encodable, Sendable {
         allowsNewNote: Bool,
         platform: Platform<SongMetadata> = .song
     ) throws {
+        let songID = try song.requireID()
         self.init(
-            id: try song.requireID(),
+            id: songID,
             album: song.album,
             artist: song.artist,
             artwork: song.artwork.flatMap {
@@ -91,6 +98,7 @@ struct SongViewModel: Encodable, Sendable {
             allowsNewNote: allowsNewNote,
             genre: song.genre,
             notes: try notes.map { try NoteViewModel(note: $0, isEditable: allowsNewNote) },
+            notesEndpoint: "/songs/\(songID)/notes",
             post: try song.post.map(PostItemViewModel.init),
             releaseDate: song.releaseDate?.formatted(.releaseDate),
             resources: song.resourceURLs.compactMap(platform.hyperlink),

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/Pages/Page+SongPreview.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/Pages/Page+SongPreview.swift
@@ -42,6 +42,7 @@ extension Page {
                 allowsNewNote: false,
                 genre: payload.genre,
                 notes: notes,
+                notesEndpoint: "",
                 post: nil,
                 releaseDate: payload.releaseDate,
                 resources: resources,


### PR DESCRIPTION
BooksViewModel drives the /books list page. BookEditorViewModel covers create, edit, and preview with CSRF token generation.

BookViewModel replaces separate genre/releaseDate fields with a computed info: String? (joined with ", ", nil when empty) and adds notesEndpoint required by NoteDetailController on the detail page.

SongViewModel gains the same notesEndpoint field so details.leaf works generically for both types.