### PR TITLE
Books: add list and editor Leaf templates; fix detail template and CSS

### DIFF
--- a/tmbr/Public/Styles/Shared/editor.css
+++ b/tmbr/Public/Styles/Shared/editor.css
@@ -213,6 +213,11 @@ form section > header {
     flex-shrink: 0;
 }
 
+.image-picker.book-cover {
+    aspect-ratio: 2 / 3;
+    width: 90px;
+}
+
 .image-picker > img {
     width: 100%;
     height: 100%;

--- a/tmbr/Public/Styles/Shared/editor.css
+++ b/tmbr/Public/Styles/Shared/editor.css
@@ -213,7 +213,7 @@ form section > header {
     flex-shrink: 0;
 }
 
-.image-picker.book-cover {
+.image-picker.portrait {
     aspect-ratio: 2 / 3;
     width: 90px;
 }

--- a/tmbr/Public/Styles/Shared/main.css
+++ b/tmbr/Public/Styles/Shared/main.css
@@ -617,7 +617,8 @@ main > section > nav > form input[type="search"]::-webkit-search-cancel-button {
 }
 
 main > section > nav > form input[type="search"]:hover,
-main > section > nav > form input[type="search"]:focus {
+main > section > nav > form input[type="search"]:focus,
+main > section > nav > form input[type="search"]:not(:placeholder-shown) {
     background: var(--input-background-hover);
 }
 

--- a/tmbr/Resources/Views/Catalogue/Books/book-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Books/book-editor.leaf
@@ -69,7 +69,7 @@
                     />
                 </div>
 
-                <figure id="artwork-placeholder" class="image-picker book-cover #if(!coverThumbnailURL):empty#endif">
+                <figure id="artwork-placeholder" class="image-picker portrait #if(!coverThumbnailURL):empty#endif">
                     <img id="artwork-image" src="#(coverThumbnailURL)" alt="Book cover" />
                     <span>#extend("Icons/gallery")</span>
                     <button id="artwork-clear" type="button" class="icon">#extend("Icons/trash")</button>

--- a/tmbr/Resources/Views/Catalogue/Books/book-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Books/book-editor.leaf
@@ -1,0 +1,128 @@
+#extend("Shared/page"):
+
+    #export("styles"):
+    <link rel="stylesheet" href="/Styles/Shared/editor.css">
+    #endexport
+
+    #export("main"):
+    <form id="book-form" method="#(submit.method)" action="#(submit.action)">
+        <input id="editor-book-id" type="hidden" name="id" value="#(id)" />
+        <input id="editor-cover-id" type="hidden" name="cover-id" value="#(coverId)" />
+        <input id="editor-cover-source-url" type="hidden" name="cover-source-url" value="#(coverSourceURL)" />
+        #if(_csrf):
+            <input type="hidden" name="_csrf" value="#(_csrf)" />
+        #endif
+
+        <input
+            id="editor-book-title"
+            class="text-input"
+            name="title"
+            type="text"
+            value="#(title)"
+            placeholder="Title"
+            autocomplete="off"
+            spellcheck="true"
+        />
+
+        #extend("Catalogue/resources-editor")
+
+        <section id="details-section">
+            <h3>Details</h3>
+
+            <div class="details-content">
+                <div class="details-inputs">
+                    <input
+                        id="editor-book-author"
+                        class="text-input"
+                        name="author"
+                        type="text"
+                        value="#(author)"
+                        placeholder="Author"
+                        autocomplete="off"
+                        spellcheck="true"
+                    />
+
+                    <input
+                        id="editor-book-release-date"
+                        class="text-input"
+                        type="text"
+                        value="#(releaseDate)"
+                        placeholder="Publication date, e.g. 2024 or 2025-06-15"
+                        autocomplete="off"
+                    />
+                    <input
+                        id="editor-book-release-date-iso"
+                        name="release-date"
+                        type="hidden"
+                        value=""
+                    />
+
+                    <input
+                        id="editor-book-genre"
+                        class="text-input"
+                        name="genre"
+                        type="text"
+                        value="#(genre)"
+                        placeholder="Genre"
+                        autocomplete="off"
+                        spellcheck="true"
+                    />
+                </div>
+
+                <figure id="artwork-placeholder" class="image-picker book-cover #if(!coverThumbnailURL):empty#endif">
+                    <img id="artwork-image" src="#(coverThumbnailURL)" alt="Book cover" />
+                    <span>#extend("Icons/gallery")</span>
+                    <button id="artwork-clear" type="button" class="icon">#extend("Icons/trash")</button>
+                </figure>
+            </div>
+        </section>
+
+        #if(error):
+            <p class="editor-error">#unsafeHTML(error)</p>
+        #endif
+
+        #extend("Notes/notes-editor")
+
+        <p id="autofill-status" class="system-info" hidden></p>
+
+        <div class="editor-actions">
+            <button id="editor-book-preview" class="link" type="button">Preview</button>
+            <div>
+                <input type="hidden" name="access" value="public" />
+                <button id="editor-post-save" class="primary" type="submit">#(submit.label)</button>
+            </div>
+        </div>
+    </form>
+
+    <form id="preview-form" method="post" action="/books/preview" target="_blank" hidden>
+        <input type="hidden" name="title" id="preview-title" />
+        <input type="hidden" name="author" id="preview-author" />
+        <input type="hidden" name="genre" id="preview-genre" />
+        <input type="hidden" name="releaseDate" id="preview-release-date" />
+        <input type="hidden" name="coverURL" id="preview-cover-url" />
+        <input type="hidden" name="resourceURLs" id="preview-resource-urls" />
+        <input type="hidden" name="notes" id="preview-notes" />
+    </form>
+
+    <div id="duplicate-container"></div>
+
+    <aside id="gallery" hidden>
+        <div id="gallery-header">
+            <button class="icon small" type="button" id="gallery-close" aria-label="Close">
+                #extend("Icons/close")
+            </button>
+            <h4 id="gallery-title">Gallery</h4>
+            <span id="gallery-status" class="system-info"></span>
+        </div>
+        <section id="gallery-section"></section>
+    </aside>
+    #endexport
+
+    #export("scripts"):
+        <script src="/Scripts/Shared/persistence.js"></script>
+        <script src="/Scripts/Gallery/gallery.js"></script>
+        <script src="/Scripts/Catalogue/resources-editor.js"></script>
+        <script src="/Scripts/Notes/notes-editor.js"></script>
+        <script src="/Scripts/Catalogue/Books/book-editor.js"></script>
+    #endexport
+#endextend

--- a/tmbr/Resources/Views/Catalogue/Books/book.leaf
+++ b/tmbr/Resources/Views/Catalogue/Books/book.leaf
@@ -1,28 +1,42 @@
 #extend("Catalogue/details"):
-    
+
     #export("details-header"):
     <div class="details">
         <h1>#(title)</h1>
         <h3>by #(author)</h3>
-        
-        <p>
-            #if(genre) #(genre),
-            #if(releaseDate) #(releaseDate)
-        </p>
-        
+
+        #if(info):
+        <p>#(info)</p>
+        #endif
+
         #extend("Catalogue/resources")
     </div>
-    
+
     #if(cover):
     <div class="artwork">
         <img src="#(cover.url)" alt="Cover image of #(title)">
     </div>
     #endif
-    
+
+    #endexport
+
+    #export("styles"):
+    <link rel="stylesheet" href="/Styles/Shared/editor.css">
     #endexport
 
     #export("scripts"):
-    <script>document.addEventListener('DOMContentLoaded', () => new ShortcutsController([ShortcutsController.login, ShortcutsController.edit]).init());</script>
+    <script src="/Scripts/Shared/persistence.js"></script>
+    <script src="/Scripts/Notes/note-detail.js"></script>
+    <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        new ShortcutsController([ShortcutsController.login, ShortcutsController.edit]).init();
+        const notesSection = document.getElementById('notes-section');
+        if (notesSection) {
+            const persistence = new PersistenceController();
+            new NoteDetailController({ section: notesSection }, { persistence }).init();
+        }
+    });
+    </script>
     #endexport
 
 #endextend

--- a/tmbr/Resources/Views/Catalogue/Books/books.leaf
+++ b/tmbr/Resources/Views/Catalogue/Books/books.leaf
@@ -1,0 +1,28 @@
+#extend("Shared/page"):
+
+    #export("toolbar"):
+        #if(compose):
+            <a id="compose" class="icon" href="#(compose)" aria-label="Compose">
+                #extend("Icons/pencil")
+            </a>
+        #endif
+    #endexport
+
+    #export("main"):
+        #extend("Shared/signature")
+
+        <section>
+            <nav>
+                #extend("Shared/search")
+            </nav>
+
+            #extend("Previews/previews")
+        </section>
+    #endexport
+
+    #export("scripts"):
+        <script src="/Scripts/Shared/search.js"></script>
+        <script>document.addEventListener('DOMContentLoaded', () => new ShortcutsController([ShortcutsController.login]).init());</script>
+    #endexport
+
+#endextend

--- a/tmbr/Resources/Views/Catalogue/details.leaf
+++ b/tmbr/Resources/Views/Catalogue/details.leaf
@@ -17,7 +17,7 @@
             </section>
             #endif
                     
-            <section id="notes-section" data-song-id="#(id)">
+            <section id="notes-section" data-notes-endpoint="#(notesEndpoint)">
                 <h3>Notes</h3>
                 #if(allowsNewNote):
                 <div class="note-new">


### PR DESCRIPTION
books.leaf mirrors songs.leaf. book-editor.leaf adapts song-editor.leaf with cover-id / cover-source-url inputs and a book-cover image picker (2/3 aspect ratio defined in editor.css).

book.leaf loads editor.css (access checkbox positioning) and persistence.js + note-detail.js (note edit button). Uses #if(info) to suppress the paragraph when empty instead of hardcoding separators.

details.leaf uses data-notes-endpoint instead of data-song-id so NoteDetailController works on any catalogue detail page.

main.css shows the search input background when the field has a value.