### PR TITLE
Movies Layer 2: lookup, search, and metadata commands

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/Command+LookupMovie.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/Command+LookupMovie.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Core
+import Fluent
+import AuthKit
+
+extension Command where Self == PlainCommand<String, Movie?> {
+
+    static func lookupMovie(
+        database: Database,
+        permission: BasePermissionResolver<QueryBuilder<Movie>>
+    ) -> Self {
+        PlainCommand { url in
+            let escaped = url.replacingOccurrences(of: "'", with: "''")
+            let query = Movie.query(on: database)
+                .filter(.sql(unsafeRaw: "'\(escaped)' = ANY(movies.resource_urls)"))
+            try await permission.grant(query)
+            return try await query.first()
+        }
+    }
+}
+
+extension CommandFactory<String, Movie?> {
+
+    static var lookupMovie: Self {
+        CommandFactory { request in
+            .lookupMovie(
+                database: request.commandDB,
+                permission: request.permissions.movies.lookup
+            )
+            .logged(name: "Lookup Movie", logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/Command+MovieSearch.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/Command+MovieSearch.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Core
+import Fluent
+import AuthKit
+
+struct MovieSearchResult: Sendable {
+
+    let previews: [Preview]
+
+    let noteMatches: [Preview]
+}
+
+extension Command where Self == PlainCommand<String?, MovieSearchResult> {
+
+    static func searchMovies(
+        database: Database,
+        permission: BasePermissionResolver<QueryBuilder<Preview>>,
+        noteSearch: CommandResolver<NoteQueryPayload, [Note]>
+    ) -> Self {
+        PlainCommand { term in
+            let safeTerm = term.flatMap { t -> String? in
+                let trimmed = t.trimmed
+                return trimmed.isEmpty ? nil : trimmed.replacingOccurrences(of: "'", with: "''")
+            }
+
+            let query = Preview.query(on: database)
+                .with(\.$image)
+                .filter(\.$parentType == Movie.previewType)
+                .join(Movie.self, on: \Movie.$preview.$id == \Preview.$id)
+                .sort(\.$createdAt, .descending)
+
+            if let safeTerm {
+                query.group(.or) { group in
+                    group.filter(.sql(unsafeRaw: "movies.title ILIKE '%\(safeTerm)%'"))
+                    group.filter(.sql(unsafeRaw: "movies.director ILIKE '%\(safeTerm)%'"))
+                    group.filter(.sql(unsafeRaw: "movies.genre ILIKE '%\(safeTerm)%'"))
+                }
+            }
+
+            try await permission.grant(query)
+
+            async let previewsTask = query.all()
+            async let notesTask = noteSearch(NoteQueryPayload(term: term, types: [Movie.previewType]))
+            let (previews, notes) = try await (previewsTask, notesTask)
+
+            let previewIDs = Set(previews.compactMap(\.id))
+            var seen = previewIDs
+            let noteMatches = notes.compactMap { note -> Preview? in
+                guard let id = note.attachment.id, !seen.contains(id) else { return nil }
+                seen.insert(id)
+                return note.attachment
+            }
+
+            return MovieSearchResult(previews: previews, noteMatches: noteMatches)
+        }
+    }
+}
+
+extension CommandFactory<String?, MovieSearchResult> {
+
+    static var searchMovies: Self {
+        CommandFactory { request in
+            .searchMovies(
+                database: request.commandDB,
+                permission: request.permissions.previews.query,
+                noteSearch: request.commands.notes.search
+            )
+            .logged(name: "Search Movies", logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/FetchMovieMetadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/FetchMovieMetadata.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Vapor
+import Core
+import Logging
+import Fluent
+import AuthKit
+
+struct FetchMovieMetadataCommand: Command {
+
+    private let fetch: CommandResolver<URL, Metadata>
+
+    private let platform: Platform<MovieMetadata>
+
+    init(
+        fetch: CommandResolver<URL, Metadata>,
+        platform: Platform<MovieMetadata> = .movie
+    ) {
+        self.fetch = fetch
+        self.platform = platform
+    }
+
+    func execute(_ url: URL) async throws -> MovieMetadata {
+        guard let metadata = try await platform.metadata(for: url, fetcher: fetch.callAsFunction) else {
+            throw Abort(.badRequest, reason: "Could not extract metadata from URL.")
+        }
+        return metadata
+    }
+}
+
+extension CommandFactory<URL, MovieMetadata> {
+
+    static var fetchMovieMetadata: Self {
+        CommandFactory { request in
+            FetchMovieMetadataCommand(
+                fetch: request.commands.catalogue.metadata
+            )
+            .logged(logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Commands+Movies.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Commands+Movies.swift
@@ -6,27 +6,39 @@ extension Commands {
 }
 
 extension Commands {
-    
+
     struct Movies: CommandCollection, Sendable {
-        
+
         let create: CommandFactory<MovieInput, Movie>
-        
+
         let delete: CommandFactory<MovieID, Void>
-        
+
         let edit: CommandFactory<EditMovieInput, Movie>
-        
+
         let fetch: CommandFactory<FetchParameters<MovieID>, Movie>
-        
+
+        let lookup: CommandFactory<String, Movie?>
+
+        let metadata: CommandFactory<URL, MovieMetadata>
+
+        let search: CommandFactory<String?, MovieSearchResult>
+
         init(
             create: CommandFactory<MovieInput, Movie> = .createMovie,
             delete: CommandFactory<MovieID, Void> = .delete(\.movies),
             edit: CommandFactory<EditMovieInput, Movie> = .editMovie,
-            fetch: CommandFactory<FetchParameters<MovieID>, Movie> = .fetchMovie
+            fetch: CommandFactory<FetchParameters<MovieID>, Movie> = .fetchMovie,
+            lookup: CommandFactory<String, Movie?> = .lookupMovie,
+            metadata: CommandFactory<URL, MovieMetadata> = .fetchMovieMetadata,
+            search: CommandFactory<String?, MovieSearchResult> = .searchMovies
         ) {
             self.create = create
             self.delete = delete
             self.edit = edit
             self.fetch = fetch
+            self.lookup = lookup
+            self.metadata = metadata
+            self.search = search
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `Command+LookupMovie`: finds movie by resource URL using `ANY()` filter on `movies.resource_urls`
- Add `Command+MovieSearch`: searches `title`, `director`, `genre` columns plus note body matches; returns `MovieSearchResult`
- Add `FetchMovieMetadata`: delegates to `Platform<MovieMetadata>.movie` (IMDb extractor)
- Extend `Commands.Movies` with `lookup`, `metadata`, and `search` factories

## Test plan
- [ ] `swift build` passes
- [ ] `GET /api/movies/lookup?url=<imdb-url>` returns the movie if owned

🤖 Generated with [Claude Code](https://claude.com/claude-code)