### PR TITLE
Movies Layer 4: MoviesAPIController with full CRUD and notes endpoint

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/MovieInput.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Commands/Command/MovieInput.swift
@@ -66,13 +66,19 @@ extension ModelConfiguration where Model == Movie, Parameters == MovieInput {
 }
 
 extension Validator where Input == MovieInput {
-    
+
     static var movie: Self {
         Validator { movie in
             guard !movie.title.trimmed.isEmpty else {
-                throw Abort(.badRequest, reason: "The movie author or title is missing")
+                throw Abort(.badRequest, reason: "Title is required.")
             }
-
         }
+    }
+}
+
+extension MovieInput {
+
+    func edit(id: MovieID) -> EditMovieInput {
+        EditMovieInput(id: id, parameters: self)
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/API/MoviesAPIController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/API/MoviesAPIController.swift
@@ -1,0 +1,115 @@
+import Vapor
+import AuthKit
+import Fluent
+import Core
+
+private struct MovieLookupResponse: Content, Sendable {
+    let id: Int
+    let title: String
+    let director: String?
+    let detailURL: String
+}
+
+struct MoviesAPIController: RouteCollection {
+
+    func boot(routes: RoutesBuilder) throws {
+
+        let moviesRoute = routes.grouped("api", "movies")
+
+        // GET /api/movies/lookup?url=
+        moviesRoute.get("lookup") { request async throws -> MovieLookupResponse in
+            let url = try request.query.get(String.self, at: "url")
+            guard let movie = try await request.commands.movies.lookup(url),
+                  let movieID = movie.id
+            else {
+                throw Abort(.notFound)
+            }
+            return MovieLookupResponse(id: movieID, title: movie.title, director: movie.director, detailURL: "/movies/\(movieID)")
+        }
+
+        // GET /api/movies/:movieID
+        moviesRoute.get(":movieID") { request async throws -> MovieResponse in
+            guard let movieID = request.parameters.get("movieID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Movie ID")
+            }
+            async let movie = request.commands.movies.fetch(movieID, for: .read)
+            async let notes = request.commands.notes.query(id: movieID, of: Movie.previewType)
+            return MovieResponse(
+                movie: try await movie,
+                baseURL: request.baseURL,
+                notes: try await notes
+            )
+        }
+
+        // POST /api/movies
+        moviesRoute.post(use: { request async throws -> MovieResponse in
+            let payload = try request.content.decode(MoviePayload.self)
+            return try await request.commands.transaction { commands in
+                let movieInput = MovieInput(payload: payload)
+                let movie = try await commands.movies.create(movieInput)
+                let notesInput = payload.notes.map { entries in
+                    BatchCreateNoteInput(
+                        attachment: movie.preview,
+                        notes: entries.map(NoteInput.init)
+                    )
+                }
+                let notes = try await notesInput.map(commands.notes.batchCreate)
+                return MovieResponse(
+                    movie: movie,
+                    baseURL: request.baseURL,
+                    notes: notes ?? []
+                )
+            }
+        })
+
+        // PUT /api/movies/:movieID
+        moviesRoute.put(":movieID") { request async throws -> MovieResponse in
+            guard let movieID = request.parameters.get("movieID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Movie ID")
+            }
+            let payload = try request.content.decode(MoviePayload.self)
+            let input = MovieInput(payload: payload)
+            return try await request.commands.transaction { commands in
+                let movie = try await commands.movies.edit(input.edit(id: movieID))
+                if let entries = payload.notes {
+                    let preview = try await commands.previews.fetch(movie.$preview.id, for: .write)
+                    let syncEntries = entries.map { entry in
+                        SyncNoteEntry(id: entry.noteID, body: entry.body, access: entry.access, deleted: entry.deleted ?? false)
+                    }
+                    _ = try await commands.notes.sync(
+                        SyncNotesInput(attachment: preview, parentAccess: payload.access, entries: syncEntries)
+                    )
+                }
+                let notes = try await commands.notes.query(id: movieID, of: Movie.previewType)
+                return MovieResponse(movie: movie, baseURL: request.baseURL, notes: notes)
+            }
+        }
+
+        // DELETE /api/movies/:movieID
+        moviesRoute.delete(":movieID") { req async throws -> HTTPStatus in
+            guard let movieID = req.parameters.get("movieID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Movie ID")
+            }
+            try await req.commands.movies.delete(movieID)
+            return .noContent
+        }
+
+        // POST /api/movies/:movieID/notes
+        moviesRoute.post(":movieID", "notes") { request async throws -> NoteResponse in
+            guard let movieID = request.parameters.get("movieID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Movie ID")
+            }
+            let payload = try request.content.decode(NotePayload.self)
+            let movie = try await request.commands.movies.fetch(movieID, for: .write)
+            let input = CreateNoteInput(
+                body: payload.body,
+                access: payload.access,
+                attachmentID: movie.$preview.id
+            )
+            let note = try await request.commands.notes.create(input)
+            try await note.$attachment.load(on: request.commandDB)
+            try await note.$author.load(on: request.commandDB)
+            return NoteResponse(note: note, baseURL: request.baseURL)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/API/Responses/MovieResponse.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/API/Responses/MovieResponse.swift
@@ -3,7 +3,7 @@ import Foundation
 import AuthKit
 import Core
 
-struct MovieResponse: Encodable, Sendable {
+struct MovieResponse: Encodable, Sendable, AsyncResponseEncodable {
     
     private let id: Int
     


### PR DESCRIPTION
## Summary

- Add `MoviesAPIController` mirroring `BooksAPIController`:
  - `GET /api/movies/lookup?url=` → `MovieLookupResponse`
  - `GET /api/movies/:movieID` → `MovieResponse`
  - `POST /api/movies` → `MovieResponse`
  - `PUT /api/movies/:movieID` → `MovieResponse`
  - `DELETE /api/movies/:movieID` → 204
  - `POST /api/movies/:movieID/notes` → `NoteResponse`
- Add `MovieInput.edit(id:)` extension (was missing from the model layer)

## Test plan
- [ ] `swift build` passes
- [ ] `POST /api/movies` creates a movie and returns the response
- [ ] `DELETE /api/movies/:id` returns 204

🤖 Generated with [Claude Code](https://claude.com/claude-code)