### PR TITLE
Movies Layer 5: list, editor, and preview page view models

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/Web/Pages/Page+Movie.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/Web/Pages/Page+Movie.swift
@@ -4,63 +4,94 @@ import AuthKit
 import Core
 
 struct MovieViewModel: Encodable, Sendable {
-    
+
     private let id: MovieID
-    
+
     private let cover: ImageViewModel?
-    
-    private let director: String?
-    
-    private let genre: String?
-    
+
+    private let allowsNewNote: Bool
+
+    private let info: String?
+
     private let notes: [NoteViewModel]
-    
+
+    private let notesEndpoint: String
+
     private let post: PostItemViewModel?
-    
-    private let releaseYear: String
-    
+
     private let resources: [Hyperlink]
-    
+
     private let title: String
-    
+
     init(
         id: MovieID,
         cover: ImageViewModel?,
-        director: String?,
-        genre: String?,
+        allowsNewNote: Bool,
+        info: String?,
         notes: [NoteViewModel],
+        notesEndpoint: String,
         post: PostItemViewModel?,
-        releaseYear: String,
         resources: [Hyperlink],
         title: String
     ) {
         self.id = id
         self.cover = cover
-        self.director = director
-        self.genre = genre
+        self.allowsNewNote = allowsNewNote
+        self.info = info
         self.notes = notes
+        self.notesEndpoint = notesEndpoint
         self.post = post
-        self.releaseYear = releaseYear
         self.resources = resources
         self.title = title
     }
-    
+
+    init(
+        id: MovieID,
+        allowsNewNote: Bool,
+        cover: ImageViewModel?,
+        director: String?,
+        genre: String?,
+        notes: [NoteViewModel],
+        notesEndpoint: String,
+        post: PostItemViewModel?,
+        releaseDate: String?,
+        resources: [Hyperlink],
+        title: String
+    ) {
+        self.init(
+            id: id,
+            cover: cover,
+            allowsNewNote: allowsNewNote,
+            info: {
+                let parts = [director, genre, releaseDate].compactMap { $0 }.filter { !$0.isEmpty }
+                return parts.isEmpty ? nil : parts.joined(separator: ", ")
+            }(),
+            notes: notes,
+            notesEndpoint: notesEndpoint,
+            post: post,
+            resources: resources,
+            title: title
+        )
+    }
+
     init(
         movie: Movie,
         notes: [Note],
         baseURL: String,
+        allowsNewNote: Bool,
         platform: Platform<MovieMetadata> = .movie
     ) throws {
+        let movieID = try movie.requireID()
         self.init(
-            id: try movie.requireID(),
-            cover: movie.cover.flatMap {
-                ImageViewModel(image: $0, baseURL: baseURL)
-            },
+            id: movieID,
+            allowsNewNote: allowsNewNote,
+            cover: movie.cover.flatMap { ImageViewModel(image: $0, baseURL: baseURL) },
             director: movie.director,
             genre: movie.genre,
-            notes: try notes.map { try NoteViewModel(note: $0) },
+            notes: try notes.map { try NoteViewModel(note: $0, isEditable: allowsNewNote) },
+            notesEndpoint: "/movies/\(movieID)/notes",
             post: try movie.post.map(PostItemViewModel.init),
-            releaseYear: movie.releaseDate?.formatted(.year) ?? "",
+            releaseDate: movie.releaseDate?.formatted(.releaseDate),
             resources: movie.resourceURLs.compactMap(platform.hyperlink),
             title: movie.title
         )
@@ -77,16 +108,16 @@ extension Page {
             guard let movieID = request.parameters.get("movieID", as: Int.self) else {
                 throw Abort(.badRequest)
             }
-            return try await request.commands.transaction { commands in
-                async let movie = commands.movies.fetch(movieID, for: .read)
-                async let notes = commands.notes.query(id: movieID, of: Movie.previewType)
-                
-                return try MovieViewModel(
-                    movie: await movie,
-                    notes: await notes,
-                    baseURL: request.baseURL
-                )
-            }
+            async let movieTask = request.commands.movies.fetch(movieID, for: .read)
+            async let notesTask = request.commands.notes.query(id: movieID, of: Movie.previewType)
+            let resolvedMovie = try await movieTask
+            let allowsNewNote = (try? await request.permissions.movies.edit.grant(resolvedMovie)) != nil
+            return try MovieViewModel(
+                movie: resolvedMovie,
+                notes: await notesTask,
+                baseURL: request.baseURL,
+                allowsNewNote: allowsNewNote
+            )
         }
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/Web/Pages/Page+MovieEditor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/Web/Pages/Page+MovieEditor.swift
@@ -1,0 +1,197 @@
+import Core
+import Foundation
+import Vapor
+import Fluent
+import AuthKit
+
+struct MovieEditorViewModel: Encodable, Sendable {
+
+    struct NoteViewModel: Encodable, Sendable {
+        let id: String?
+        let body: String
+        let access: Access
+    }
+
+    private let id: Int?
+
+    private let pageTitle: String?
+
+    private let access: Access
+
+    private let director: String
+
+    private let coverId: Int?
+
+    private let coverSourceURL: String?
+
+    private let coverThumbnailURL: String?
+
+    private let genre: String
+
+    private let notes: [NoteViewModel]
+
+    private let releaseDate: String
+
+    private let resourceURLs: [String]
+
+    private let submit: Form.Submit
+
+    private let title: String
+
+    let _csrf: String?
+
+    private let error: String?
+
+    init(
+        id: Int? = nil,
+        pageTitle: String? = nil,
+        access: Access = .private,
+        director: String = "",
+        coverId: Int? = nil,
+        coverSourceURL: String? = nil,
+        coverThumbnailURL: String? = nil,
+        genre: String = "",
+        notes: [NoteViewModel] = [],
+        releaseDate: String = "",
+        resourceURLs: [String] = [],
+        submit: Form.Submit,
+        title: String = "",
+        csrf: String? = nil,
+        error: String? = nil
+    ) {
+        self.id = id
+        self.pageTitle = pageTitle
+        self.access = access
+        self.director = director
+        self.coverId = coverId
+        self.coverSourceURL = coverSourceURL
+        self.coverThumbnailURL = coverThumbnailURL
+        self.genre = genre
+        self.notes = notes
+        self.releaseDate = releaseDate
+        self.resourceURLs = resourceURLs
+        self.submit = submit
+        self.title = title
+        self._csrf = csrf
+        self.error = error
+    }
+
+    init(
+        movie: Movie,
+        notes: [Note],
+        baseURL: String,
+        csrf: String?
+    ) throws {
+        let id = try movie.requireID()
+        let coverId = movie.$cover.id
+        let coverThumbnailURL: String?
+        if let cover = movie.cover {
+            coverThumbnailURL = "\(baseURL)/gallery/data/\(cover.thumbnailKey)"
+        } else {
+            coverThumbnailURL = nil
+        }
+        self.init(
+            id: id,
+            pageTitle: "Edit '\(movie.title)'",
+            access: movie.access,
+            director: movie.director ?? "",
+            coverId: coverId,
+            coverSourceURL: nil,
+            coverThumbnailURL: coverThumbnailURL,
+            genre: movie.genre ?? "",
+            notes: notes.map { NoteViewModel(id: $0.id?.uuidString, body: $0.body, access: $0.access) },
+            releaseDate: movie.releaseDate?.formatted(.releaseDate) ?? "",
+            resourceURLs: movie.resourceURLs,
+            submit: Form.Submit(
+                action: "/movies/\(id)",
+                label: "Save"
+            ),
+            title: movie.title,
+            csrf: csrf
+        )
+    }
+}
+
+extension Template where Model == MovieEditorViewModel {
+    static let movieEditor = Template(name: "Catalogue/Movies/movie-editor")
+}
+
+extension Page {
+    static var createMovie: Self {
+        Page(template: .movieEditor) { req in
+            try await req.permissions.movies.create()
+            let submit = Form.Submit(
+                action: "/movies/new",
+                label: "Save"
+            )
+            let csrf = UUID().uuidString
+            req.session.data["csrf.editor"] = csrf
+            return MovieEditorViewModel(pageTitle: "New movie", submit: submit, csrf: csrf)
+        }
+    }
+
+    static var editMovie: Self {
+        Page(template: .movieEditor) { request in
+            guard let movieID = request.parameters.get("movieID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Movie ID is incorrect or missing.")
+            }
+            async let movie = request.commands.movies.fetch(movieID, for: .write)
+            async let notes = request.commands.notes.query(id: movieID, of: Movie.previewType)
+            let csrf = UUID().uuidString
+            request.session.data["csrf.editor"] = csrf
+            return try await MovieEditorViewModel(
+                movie: movie,
+                notes: notes,
+                baseURL: request.baseURL,
+                csrf: csrf
+            )
+        }
+    }
+}
+
+private struct MoviePreviewPayload: Content {
+    let title: String
+    let director: String?
+    let genre: String?
+    let releaseDate: String?
+    let coverURL: String?
+    let resourceURLs: String?
+    let notes: String
+}
+
+extension Page {
+    static var moviePreview: Self {
+        Page(template: .movie) { req in
+            try await req.permissions.movies.create.grant()
+            let payload = try req.content.decode(MoviePreviewPayload.self)
+            let formatter = MarkdownFormatter.html
+            let notes: [NoteViewModel] = payload.notes.isEmpty ? [] : [
+                NoteViewModel(
+                    id: UUID(),
+                    body: formatter.format(payload.notes),
+                    created: Date.now.formatted(.publishDate)
+                )
+            ]
+            let platform = Platform<MovieMetadata>.movie
+            let resources = (payload.resourceURLs ?? "")
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map(String.init)
+                .compactMap(platform.hyperlink)
+            return MovieViewModel(
+                id: 0,
+                allowsNewNote: false,
+                cover: payload.coverURL.flatMap { url in
+                    url.isEmpty ? nil : ImageViewModel(previewURL: url)
+                },
+                director: payload.director,
+                genre: payload.genre,
+                notes: notes,
+                notesEndpoint: "",
+                post: nil,
+                releaseDate: payload.releaseDate,
+                resources: resources,
+                title: "Preview: \(payload.title)"
+            )
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/Web/Pages/Page+Movies.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/Web/Pages/Page+Movies.swift
@@ -1,0 +1,31 @@
+import Vapor
+import Core
+import Foundation
+
+struct MoviesViewModel: Encodable, Sendable {
+    let compose: String?
+    let term: String?
+    let previews: [PreviewViewModel]
+}
+
+extension Template where Model == MoviesViewModel {
+    static let movies = Template(name: "Catalogue/Movies/movies")
+}
+
+extension Page {
+    static var movies: Self {
+        Page(template: .movies) { req in
+            let term = try? req.query.get(String.self, at: "term")
+            async let composeURL: String? = (try? await req.permissions.movies.create()) != nil ? "/movies/new" : nil
+            async let result = req.commands.movies.search(term)
+            let baseURL = req.baseURL
+            let resolved = try await result
+            return MoviesViewModel(
+                compose: await composeURL,
+                term: term,
+                previews: resolved.previews.map { PreviewViewModel(preview: $0, baseURL: baseURL) }
+                    + resolved.noteMatches.map { PreviewViewModel(preview: $0, baseURL: baseURL, isNoteMatch: true) }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Refactor `MovieViewModel`: replaces separate `releaseYear`/`director`/`genre` fields with a computed `info` string (joined with ", "), adds `allowsNewNote` and `notesEndpoint` to match the Book pattern
- Add `Page+Movies.swift`: `MoviesViewModel` for the `/movies` list page (search + previews)
- Add `Page+MovieEditor.swift`:
  - `MovieEditorViewModel` with `director` field instead of `author`
  - `Page.createMovie` and `Page.editMovie` statics with CSRF generation
  - `Page.moviePreview` renders a read-only preview card without saving

## Test plan
- [ ] `swift build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)