### PR TITLE
Movies Layer 7: register API and web routes in boot()

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Movies.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Movies.swift
@@ -27,6 +27,10 @@ struct Movies: Module {
     }
     
     func boot(_ routes: any Vapor.RoutesBuilder) async throws {
+        try routes.register(collection: MoviesAPIController())
+        try routes
+            .grouped(RecoverMiddleware())
+            .register(collection: MoviesWebController())
     }
 }
 


### PR DESCRIPTION
## Summary

- Wire `MoviesAPIController` and `MoviesWebController` into `Movies.boot()`, using the same `RecoverMiddleware` pattern as the Books module

## Test plan
- [ ] `swift build` passes
- [ ] `swift run App serve` starts without route conflicts
- [ ] `GET /movies` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)