### PR TITLE
Podcasts Layer 1: platform metadata struct + Apple Podcasts extractor

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+ApplePodcasts.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+ApplePodcasts.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+extension MetadataExtractor where M == PodcastMetadata {
+
+    static let applePodcasts = MetadataExtractor { url, fetcher in
+        let episode = try await fetcher(url)
+        guard episode.type == "music.episode" else {
+            throw MetadataExtractionError.invalidType(expected: "music.episode", actual: episode.type)
+        }
+
+        // Try fetching the show page to extract its title — same pattern as album fetch in appleMusicSong.
+        // Strip the ?i= episode param so we hit the show URL.
+        var showComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        showComponents?.queryItems = nil
+        let showTitle = try? await MetadataExtractor.extract(
+            key: "og:title",
+            from: showComponents?.string,
+            of: "music.album",
+            with: fetcher
+        )
+
+        // Episode/season numbers from JSON-LD if the page exposes them.
+        let episodeNumber = (episode.json["episodeNumber"] as? Int)
+            ?? (episode.json["episodeNumber"] as? String).flatMap(Int.init)
+        let seasonNumber = (episode.json["partOfSeason"] as? [String: Any])
+            .flatMap { $0["seasonNumber"] as? Int }
+
+        // Release date prefers the structured tag; falls back to JSON-LD datePublished.
+        let releaseDate = episode.tags["music:release_date"]
+            ?? episode.json["datePublished"] as? String
+
+        // ExternalID: episode ID from the URL query parameter `i`.
+        let externalID = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == "i" })?
+            .value
+
+        return PodcastMetadata(
+            episodeTitle: episode.tags["og:title"] ?? episode.tags["apple:title"],
+            showTitle: showTitle,
+            artwork: episode.tags["og:image"],
+            releaseDate: releaseDate,
+            episodeNumber: episodeNumber,
+            seasonNumber: seasonNumber,
+            externalID: externalID
+        )
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/PodcastMetadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/PodcastMetadata.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Vapor
+
+struct PodcastMetadata: Encodable, AsyncResponseEncodable, Sendable {
+
+    let episodeTitle: String?
+
+    let showTitle: String?
+
+    let artwork: String?
+
+    let releaseDate: String?
+
+    let episodeNumber: Int?
+
+    let seasonNumber: Int?
+
+    let externalID: String?
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/MetadataExtractor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/MetadataExtractor.swift
@@ -35,7 +35,7 @@ struct MetadataExtractor<M>: Sendable {
         of type: String,
         with fetcher: Fetcher
     ) async throws -> String? {
-        guard let url = urlString.flatMap(URL.init) else { return nil }
+        guard let url = urlString.flatMap({ URL(string: $0) }) else { return nil }
         return try await extract(key: key, from: url, of: type, with: fetcher)
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Podcast.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Podcast.swift
@@ -1,9 +1,9 @@
-extension Platform where M == Void {
+extension Platform where M == PodcastMetadata {
 
-    static var podcast: Platform<Void> {
+    static var podcast: Platform<PodcastMetadata> {
         Platform(platforms: [
             Platform(name: "Spotify", checker: .spotify),
-            Platform(name: "Podcasts", checker: .applePodcasts)
+            Platform(name: "Podcasts", checker: .applePodcasts, extractor: .applePodcasts)
         ])
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/API/Responses/PodcastResponse.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/API/Responses/PodcastResponse.swift
@@ -69,7 +69,7 @@ struct PodcastResponse: Encodable, Sendable {
         podcast: Podcast,
         baseURL: String,
         notes: [Note],
-        platform: Platform<Void> = .podcast
+        platform: Platform<PodcastMetadata> = .podcast
     ) {
         self.init(
             id: podcast.id!,

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+Podcast.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+Podcast.swift
@@ -57,7 +57,7 @@ struct PodcastViewModel: Encodable, Sendable {
         podcast: Podcast,
         notes: [Note],
         baseURL: String,
-        platform: Platform<Void> = .podcast
+        platform: Platform<PodcastMetadata> = .podcast
     ) throws {
         self.init(
             id: try podcast.requireID(),


### PR DESCRIPTION
## Summary
- Add `PodcastMetadata` struct (`episodeTitle`, `showTitle`, `artwork`, `releaseDate`, `episodeNumber`, `seasonNumber`, `externalID`)
- Add `MetadataExtractor+ApplePodcasts` — fetches episode OG tags + JSON-LD; secondary fetch to show page URL for show title; `externalID` from `?i=` query param
- Upgrade `Platform+Podcast.swift` from `Platform<Void>` to `Platform<PodcastMetadata>`, keeping Spotify as checker-only
- Fix `URL.init` ambiguity in shared `MetadataExtractor.swift` helper (conflicting `URL.init(configString:)` from Configuration module)

## Test plan
- [ ] `swift build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)