### PR TITLE
Podcasts Layer 2: lookup, search, and metadata commands

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/Command+LookupPodcast.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/Command+LookupPodcast.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Core
+import Fluent
+import AuthKit
+
+extension Command where Self == PlainCommand<String, Podcast?> {
+
+    static func lookupPodcast(
+        database: Database,
+        permission: BasePermissionResolver<QueryBuilder<Podcast>>
+    ) -> Self {
+        PlainCommand { url in
+            let escaped = url.replacingOccurrences(of: "'", with: "''")
+            let query = Podcast.query(on: database)
+                .filter(.sql(unsafeRaw: "'\(escaped)' = ANY(podcasts.resource_urls)"))
+            try await permission.grant(query)
+            return try await query.first()
+        }
+    }
+}
+
+extension CommandFactory<String, Podcast?> {
+
+    static var lookupPodcast: Self {
+        CommandFactory { request in
+            .lookupPodcast(
+                database: request.commandDB,
+                permission: request.permissions.podcasts.lookup
+            )
+            .logged(name: "Lookup Podcast", logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/Command+PodcastSearch.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/Command+PodcastSearch.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Core
+import Fluent
+import AuthKit
+
+struct PodcastSearchResult: Sendable {
+
+    let previews: [Preview]
+
+    let noteMatches: [Preview]
+}
+
+extension Command where Self == PlainCommand<String?, PodcastSearchResult> {
+
+    static func searchPodcasts(
+        database: Database,
+        permission: BasePermissionResolver<QueryBuilder<Preview>>,
+        noteSearch: CommandResolver<NoteQueryPayload, [Note]>
+    ) -> Self {
+        PlainCommand { term in
+            let safeTerm = term.flatMap { t -> String? in
+                let trimmed = t.trimmed
+                return trimmed.isEmpty ? nil : trimmed.replacingOccurrences(of: "'", with: "''")
+            }
+
+            let query = Preview.query(on: database)
+                .with(\.$image)
+                .filter(\.$parentType == Podcast.previewType)
+                .join(Podcast.self, on: \Podcast.$preview.$id == \Preview.$id)
+                .sort(\.$createdAt, .descending)
+
+            if let safeTerm {
+                query.group(.or) { group in
+                    group.filter(.sql(unsafeRaw: "podcasts.episode_title ILIKE '%\(safeTerm)%'"))
+                    group.filter(.sql(unsafeRaw: "podcasts.title ILIKE '%\(safeTerm)%'"))
+                    group.filter(.sql(unsafeRaw: "podcasts.genre ILIKE '%\(safeTerm)%'"))
+                }
+            }
+
+            try await permission.grant(query)
+
+            async let previewsTask = query.all()
+            async let notesTask = noteSearch(NoteQueryPayload(term: term, types: [Podcast.previewType]))
+            let (previews, notes) = try await (previewsTask, notesTask)
+
+            let previewIDs = Set(previews.compactMap(\.id))
+            var seen = previewIDs
+            let noteMatches = notes.compactMap { note -> Preview? in
+                guard let id = note.attachment.id, !seen.contains(id) else { return nil }
+                seen.insert(id)
+                return note.attachment
+            }
+
+            return PodcastSearchResult(previews: previews, noteMatches: noteMatches)
+        }
+    }
+}
+
+extension CommandFactory<String?, PodcastSearchResult> {
+
+    static var searchPodcasts: Self {
+        CommandFactory { request in
+            .searchPodcasts(
+                database: request.commandDB,
+                permission: request.permissions.previews.query,
+                noteSearch: request.commands.notes.search
+            )
+            .logged(name: "Search Podcasts", logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/FetchPodcastMetadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/FetchPodcastMetadata.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Vapor
+import Core
+import Logging
+import Fluent
+import AuthKit
+
+struct FetchPodcastMetadataCommand: Command {
+
+    private let fetch: CommandResolver<URL, Metadata>
+
+    private let platform: Platform<PodcastMetadata>
+
+    init(
+        fetch: CommandResolver<URL, Metadata>,
+        platform: Platform<PodcastMetadata> = .podcast
+    ) {
+        self.fetch = fetch
+        self.platform = platform
+    }
+
+    func execute(_ url: URL) async throws -> PodcastMetadata {
+        guard let metadata = try await platform.metadata(for: url, fetcher: fetch.callAsFunction) else {
+            throw Abort(.badRequest, reason: "Could not extract metadata from URL.")
+        }
+        return metadata
+    }
+}
+
+extension CommandFactory<URL, PodcastMetadata> {
+
+    static var fetchPodcastMetadata: Self {
+        CommandFactory { request in
+            FetchPodcastMetadataCommand(
+                fetch: request.commands.catalogue.metadata
+            )
+            .logged(logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Commands+Podcasts.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Commands/Commands+Podcasts.swift
@@ -8,25 +8,37 @@ extension Commands {
 extension Commands {
     
     struct Podcasts: CommandCollection, Sendable {
-        
+
         let create: CommandFactory<PodcastInput, Podcast>
-        
+
         let delete: CommandFactory<PodcastID, Void>
-        
+
         let edit: CommandFactory<EditPodcastInput, Podcast>
-        
+
         let fetch: CommandFactory<FetchParameters<PodcastID>, Podcast>
-        
+
+        let lookup: CommandFactory<String, Podcast?>
+
+        let metadata: CommandFactory<URL, PodcastMetadata>
+
+        let search: CommandFactory<String?, PodcastSearchResult>
+
         init(
             create: CommandFactory<PodcastInput, Podcast> = .createPodcast,
             delete: CommandFactory<PodcastID, Void> = .delete(\.podcasts),
             edit: CommandFactory<EditPodcastInput, Podcast> = .editPodcast,
-            fetch: CommandFactory<FetchParameters<PodcastID>, Podcast> = .fetchPodcast
+            fetch: CommandFactory<FetchParameters<PodcastID>, Podcast> = .fetchPodcast,
+            lookup: CommandFactory<String, Podcast?> = .lookupPodcast,
+            metadata: CommandFactory<URL, PodcastMetadata> = .fetchPodcastMetadata,
+            search: CommandFactory<String?, PodcastSearchResult> = .searchPodcasts
         ) {
             self.create = create
             self.delete = delete
             self.edit = edit
             self.fetch = fetch
+            self.lookup = lookup
+            self.metadata = metadata
+            self.search = search
         }
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Permissions/Permissions+Podcasts.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Permissions/Permissions+Podcasts.swift
@@ -18,4 +18,11 @@ extension PreviewablePermissionScope<Podcast> {
             )
         )
     }
+
+    var lookup: Permission<QueryBuilder<Podcast>> {
+        Permission { user, query in
+            guard let userID = user?.userID else { return }
+            query.filter(\.$owner.$id == userID)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `Command+LookupPodcast` — finds existing podcast by resource URL (filter on `podcasts.resource_urls` array)
- Add `Command+PodcastSearch` — ILIKE across `episode_title`, `title` (show), `genre`; deduplicates against note matches
- Add `FetchPodcastMetadata` — delegates to `Platform<PodcastMetadata>.podcast` extractor
- Extend `Commands.Podcasts` with `lookup`, `metadata`, `search` factories
- Add `lookup` permission scope to `Permissions+Podcasts` (filters to owner's podcasts only)

## Test plan
- [ ] `swift build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)