### PR TITLE
Podcasts Layer 4: REST API controller

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/API/PodcastsAPIController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/API/PodcastsAPIController.swift
@@ -1,0 +1,120 @@
+import Vapor
+import AuthKit
+import Fluent
+import Core
+
+private struct PodcastLookupResponse: Content, Sendable {
+    let id: Int
+    let episodeTitle: String
+    let title: String
+    let detailURL: String
+}
+
+struct PodcastsAPIController: RouteCollection {
+
+    func boot(routes: RoutesBuilder) throws {
+
+        let podcastsRoute = routes.grouped("api", "podcasts")
+
+        // GET /api/podcasts/lookup?url=
+        podcastsRoute.get("lookup") { request async throws -> PodcastLookupResponse in
+            let url = try request.query.get(String.self, at: "url")
+            guard let podcast = try await request.commands.podcasts.lookup(url),
+                  let podcastID = podcast.id
+            else {
+                throw Abort(.notFound)
+            }
+            return PodcastLookupResponse(
+                id: podcastID,
+                episodeTitle: podcast.episodeTitle,
+                title: podcast.title,
+                detailURL: "/podcasts/\(podcastID)"
+            )
+        }
+
+        // GET /api/podcasts/:podcastID
+        podcastsRoute.get(":podcastID") { request async throws -> PodcastResponse in
+            guard let podcastID = request.parameters.get("podcastID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Podcast ID")
+            }
+            async let podcast = request.commands.podcasts.fetch(podcastID, for: .read)
+            async let notes = request.commands.notes.query(id: podcastID, of: Podcast.previewType)
+            return PodcastResponse(
+                podcast: try await podcast,
+                baseURL: request.baseURL,
+                notes: try await notes
+            )
+        }
+
+        // POST /api/podcasts
+        podcastsRoute.post(use: { request async throws -> PodcastResponse in
+            let payload = try request.content.decode(PodcastPayload.self)
+            return try await request.commands.transaction { commands in
+                let podcastInput = PodcastInput(payload: payload)
+                let podcast = try await commands.podcasts.create(podcastInput)
+                let notesInput = payload.notes.map { entries in
+                    BatchCreateNoteInput(
+                        attachment: podcast.preview,
+                        notes: entries.map(NoteInput.init)
+                    )
+                }
+                let notes = try await notesInput.map(commands.notes.batchCreate)
+                return PodcastResponse(
+                    podcast: podcast,
+                    baseURL: request.baseURL,
+                    notes: notes ?? []
+                )
+            }
+        })
+
+        // PUT /api/podcasts/:podcastID
+        podcastsRoute.put(":podcastID") { request async throws -> PodcastResponse in
+            guard let podcastID = request.parameters.get("podcastID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Podcast ID")
+            }
+            let payload = try request.content.decode(PodcastPayload.self)
+            let input = PodcastInput(payload: payload)
+            return try await request.commands.transaction { commands in
+                let podcast = try await commands.podcasts.edit(input.edit(id: podcastID))
+                if let entries = payload.notes {
+                    let preview = try await commands.previews.fetch(podcast.$preview.id, for: .write)
+                    let syncEntries = entries.map { entry in
+                        SyncNoteEntry(id: entry.noteID, body: entry.body, access: entry.access, deleted: entry.deleted ?? false)
+                    }
+                    _ = try await commands.notes.sync(
+                        SyncNotesInput(attachment: preview, parentAccess: payload.access, entries: syncEntries)
+                    )
+                }
+                let notes = try await commands.notes.query(id: podcastID, of: Podcast.previewType)
+                return PodcastResponse(podcast: podcast, baseURL: request.baseURL, notes: notes)
+            }
+        }
+
+        // DELETE /api/podcasts/:podcastID
+        podcastsRoute.delete(":podcastID") { req async throws -> HTTPStatus in
+            guard let podcastID = req.parameters.get("podcastID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Podcast ID")
+            }
+            try await req.commands.podcasts.delete(podcastID)
+            return .noContent
+        }
+
+        // POST /api/podcasts/:podcastID/notes
+        podcastsRoute.post(":podcastID", "notes") { request async throws -> NoteResponse in
+            guard let podcastID = request.parameters.get("podcastID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Podcast ID")
+            }
+            let payload = try request.content.decode(NotePayload.self)
+            let podcast = try await request.commands.podcasts.fetch(podcastID, for: .write)
+            let input = CreateNoteInput(
+                body: payload.body,
+                access: payload.access,
+                attachmentID: podcast.$preview.id
+            )
+            let note = try await request.commands.notes.create(input)
+            try await note.$attachment.load(on: request.commandDB)
+            try await note.$author.load(on: request.commandDB)
+            return NoteResponse(note: note, baseURL: request.baseURL)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/API/Responses/PodcastResponse.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/API/Responses/PodcastResponse.swift
@@ -3,7 +3,7 @@ import Foundation
 import AuthKit
 import Core
 
-struct PodcastResponse: Encodable, Sendable {
+struct PodcastResponse: Encodable, Sendable, AsyncResponseEncodable {
     
     private let id: PodcastID
     


### PR DESCRIPTION
## Summary
- Add `PodcastsAPIController` with lookup, CRUD, and per-podcast note creation endpoints
- Fix `PodcastResponse` missing `AsyncResponseEncodable` conformance (blocked route registration)

Endpoints: `GET /api/podcasts/lookup`, `GET/POST /api/podcasts`, `GET/PUT/DELETE /api/podcasts/:id`, `POST /api/podcasts/:id/notes`

## Test plan
- [ ] `swift build` passes
- [ ] `GET /api/podcasts/:id` returns JSON with notes and resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)