### PR TITLE
Podcasts Layer 5: list, detail, editor, and preview view models

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+Podcast.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+Podcast.swift
@@ -4,70 +4,108 @@ import AuthKit
 import Core
 
 struct PodcastViewModel: Encodable, Sendable {
-    
+
     private let id: PodcastID
-    
+
+    private let allowsNewNote: Bool
+
     private let artwork: ImageViewModel?
-    
-    private let episodeNumber: Int?
-    
-    private let episodeTitle: String
-    
-    private let genre: String?
-    
+
+    private let info: String?
+
     private let notes: [NoteViewModel]
-    
+
+    private let notesEndpoint: String
+
+    private let episodeTitle: String
+
     private let post: PostItemViewModel?
-    
-    private let releaseDate: String?
-    
+
     private let resources: [Hyperlink]
-    
-    private let seasonNumber: Int?
-    
+
     private let title: String
-    
+
     init(
         id: PodcastID,
+        allowsNewNote: Bool,
+        artwork: ImageViewModel?,
+        info: String?,
+        notes: [NoteViewModel],
+        notesEndpoint: String,
+        episodeTitle: String,
+        post: PostItemViewModel?,
+        resources: [Hyperlink],
+        title: String
+    ) {
+        self.id = id
+        self.allowsNewNote = allowsNewNote
+        self.artwork = artwork
+        self.info = info
+        self.notes = notes
+        self.notesEndpoint = notesEndpoint
+        self.episodeTitle = episodeTitle
+        self.post = post
+        self.resources = resources
+        self.title = title
+    }
+
+    init(
+        id: PodcastID,
+        allowsNewNote: Bool,
         artwork: ImageViewModel?,
         episodeNumber: Int?,
-        episodeTitle: String,
         genre: String?,
         notes: [NoteViewModel],
+        notesEndpoint: String,
+        episodeTitle: String,
         post: PostItemViewModel?,
         releaseDate: String?,
         resources: [Hyperlink],
         seasonNumber: Int?,
         title: String
     ) {
-        self.id = id
-        self.artwork = artwork
-        self.episodeNumber = episodeNumber
-        self.episodeTitle = episodeTitle
-        self.genre = genre
-        self.notes = notes
-        self.post = post
-        self.releaseDate = releaseDate
-        self.resources = resources
-        self.seasonNumber = seasonNumber
-        self.title = title
+        let seasonEpisode: String? = {
+            if let s = seasonNumber, let e = episodeNumber {
+                return "S\(s):E\(e)"
+            } else if let e = episodeNumber {
+                return "E\(e)"
+            }
+            return nil
+        }()
+        let parts = [seasonEpisode, genre, releaseDate].compactMap(\.self).filter { !$0.isEmpty }
+        self.init(
+            id: id,
+            allowsNewNote: allowsNewNote,
+            artwork: artwork,
+            info: parts.isEmpty ? nil : parts.joined(separator: ", "),
+            notes: notes,
+            notesEndpoint: notesEndpoint,
+            episodeTitle: episodeTitle,
+            post: post,
+            resources: resources,
+            title: title
+        )
     }
-    
+
     init(
         podcast: Podcast,
         notes: [Note],
         baseURL: String,
+        allowsNewNote: Bool,
         platform: Platform<PodcastMetadata> = .podcast
     ) throws {
+        let podcastID = try podcast.requireID()
         self.init(
-            id: try podcast.requireID(),
+            id: podcastID,
+            allowsNewNote: allowsNewNote,
             artwork: podcast.artwork.flatMap {
                 ImageViewModel(image: $0, baseURL: baseURL)
             },
             episodeNumber: podcast.episodeNumber,
-            episodeTitle: podcast.episodeTitle,
             genre: podcast.genre,
-            notes: try notes.map { try NoteViewModel(note: $0) },
+            notes: try notes.map { try NoteViewModel(note: $0, isEditable: allowsNewNote) },
+            notesEndpoint: "/podcasts/\(podcastID)/notes",
+            episodeTitle: podcast.episodeTitle,
             post: try podcast.post.map(PostItemViewModel.init),
             releaseDate: podcast.releaseDate?.formatted(.releaseDate),
             resources: podcast.resourceURLs.compactMap(platform.hyperlink),
@@ -87,16 +125,16 @@ extension Page {
             guard let podcastID = request.parameters.get("podcastID", as: Int.self) else {
                 throw Abort(.badRequest)
             }
-            return try await request.commands.transaction { commands in
-                async let podcast = commands.podcasts.fetch(podcastID, for: .read)
-                async let notes = commands.notes.query(id: podcastID, of: Podcast.previewType)
-                
-                return try PodcastViewModel(
-                    podcast: await podcast,
-                    notes: await notes,
-                    baseURL: request.baseURL
-                )
-            }
+            async let podcastTask = request.commands.podcasts.fetch(podcastID, for: .read)
+            async let notesTask = request.commands.notes.query(id: podcastID, of: Podcast.previewType)
+            let resolvedPodcast = try await podcastTask
+            let allowsNewNote = (try? await request.permissions.podcasts.edit.grant(resolvedPodcast)) != nil
+            return try PodcastViewModel(
+                podcast: resolvedPodcast,
+                notes: await notesTask,
+                baseURL: request.baseURL,
+                allowsNewNote: allowsNewNote
+            )
         }
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+PodcastEditor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+PodcastEditor.swift
@@ -1,0 +1,205 @@
+import Core
+import Foundation
+import Vapor
+import Fluent
+import AuthKit
+
+struct PodcastEditorViewModel: Encodable, Sendable {
+
+    struct NoteViewModel: Encodable, Sendable {
+        let id: String?
+        let body: String
+        let access: Access
+    }
+
+    private let id: Int?
+
+    private let pageTitle: String?
+
+    private let access: Access
+
+    private let artworkId: Int?
+
+    private let artworkSourceURL: String?
+
+    private let artworkThumbnailURL: String?
+
+    private let episodeNumber: String
+
+    private let episodeTitle: String
+
+    private let genre: String
+
+    private let notes: [NoteViewModel]
+
+    private let releaseDate: String
+
+    private let resourceURLs: [String]
+
+    private let seasonNumber: String
+
+    private let submit: Form.Submit
+
+    private let title: String
+
+    let _csrf: String?
+
+    private let error: String?
+
+    init(
+        id: Int? = nil,
+        pageTitle: String? = nil,
+        access: Access = .private,
+        artworkId: Int? = nil,
+        artworkSourceURL: String? = nil,
+        artworkThumbnailURL: String? = nil,
+        episodeNumber: String = "",
+        episodeTitle: String = "",
+        genre: String = "",
+        notes: [NoteViewModel] = [],
+        releaseDate: String = "",
+        resourceURLs: [String] = [],
+        seasonNumber: String = "",
+        submit: Form.Submit,
+        title: String = "",
+        csrf: String? = nil,
+        error: String? = nil
+    ) {
+        self.id = id
+        self.pageTitle = pageTitle
+        self.access = access
+        self.artworkId = artworkId
+        self.artworkSourceURL = artworkSourceURL
+        self.artworkThumbnailURL = artworkThumbnailURL
+        self.episodeNumber = episodeNumber
+        self.episodeTitle = episodeTitle
+        self.genre = genre
+        self.notes = notes
+        self.releaseDate = releaseDate
+        self.resourceURLs = resourceURLs
+        self.seasonNumber = seasonNumber
+        self.submit = submit
+        self.title = title
+        self._csrf = csrf
+        self.error = error
+    }
+
+    init(
+        podcast: Podcast,
+        notes: [Note],
+        baseURL: String,
+        csrf: String?
+    ) throws {
+        let id = try podcast.requireID()
+        let artworkId = podcast.$artwork.id
+        let artworkThumbnailURL: String?
+        if let artwork = podcast.artwork {
+            artworkThumbnailURL = "\(baseURL)/gallery/data/\(artwork.thumbnailKey)"
+        } else {
+            artworkThumbnailURL = nil
+        }
+        self.init(
+            id: id,
+            pageTitle: "Edit '\(podcast.episodeTitle)'",
+            access: podcast.access,
+            artworkId: artworkId,
+            artworkSourceURL: nil,
+            artworkThumbnailURL: artworkThumbnailURL,
+            episodeNumber: podcast.episodeNumber.map(String.init) ?? "",
+            episodeTitle: podcast.episodeTitle,
+            genre: podcast.genre ?? "",
+            notes: notes.map { NoteViewModel(id: $0.id?.uuidString, body: $0.body, access: $0.access) },
+            releaseDate: podcast.releaseDate?.formatted(.releaseDate) ?? "",
+            resourceURLs: podcast.resourceURLs,
+            seasonNumber: podcast.seasonNumber.map(String.init) ?? "",
+            submit: Form.Submit(action: "/podcasts/\(id)", label: "Save"),
+            title: podcast.title,
+            csrf: csrf
+        )
+    }
+}
+
+extension Template where Model == PodcastEditorViewModel {
+    static let podcastEditor = Template(name: "Catalogue/Podcasts/podcast-editor")
+}
+
+extension Page {
+    static var createPodcast: Self {
+        Page(template: .podcastEditor) { req in
+            try await req.permissions.podcasts.create()
+            let submit = Form.Submit(action: "/podcasts/new", label: "Save")
+            let csrf = UUID().uuidString
+            req.session.data["csrf.editor"] = csrf
+            return PodcastEditorViewModel(pageTitle: "New podcast", submit: submit, csrf: csrf)
+        }
+    }
+
+    static var editPodcast: Self {
+        Page(template: .podcastEditor) { request in
+            guard let podcastID = request.parameters.get("podcastID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Podcast ID is incorrect or missing.")
+            }
+            async let podcast = request.commands.podcasts.fetch(podcastID, for: .write)
+            async let notes = request.commands.notes.query(id: podcastID, of: Podcast.previewType)
+            let csrf = UUID().uuidString
+            request.session.data["csrf.editor"] = csrf
+            return try await PodcastEditorViewModel(
+                podcast: podcast,
+                notes: notes,
+                baseURL: request.baseURL,
+                csrf: csrf
+            )
+        }
+    }
+}
+
+private struct PodcastPreviewPayload: Content {
+    let episodeTitle: String
+    let title: String
+    let genre: String?
+    let releaseDate: String?
+    let artworkURL: String?
+    let resourceURLs: String?
+    let notes: String
+    let seasonNumber: Int?
+    let episodeNumber: Int?
+}
+
+extension Page {
+    static var podcastPreview: Self {
+        Page(template: .podcast) { req in
+            try await req.permissions.podcasts.create.grant()
+            let payload = try req.content.decode(PodcastPreviewPayload.self)
+            let formatter = MarkdownFormatter.html
+            let notes: [NoteViewModel] = payload.notes.isEmpty ? [] : [
+                NoteViewModel(
+                    id: UUID(),
+                    body: formatter.format(payload.notes),
+                    created: Date.now.formatted(.publishDate)
+                )
+            ]
+            let platform = Platform<PodcastMetadata>.podcast
+            let resources = (payload.resourceURLs ?? "")
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map(String.init)
+                .compactMap(platform.hyperlink)
+            return PodcastViewModel(
+                id: 0,
+                allowsNewNote: false,
+                artwork: payload.artworkURL.flatMap { url in
+                    url.isEmpty ? nil : ImageViewModel(previewURL: url)
+                },
+                episodeNumber: payload.episodeNumber,
+                genre: payload.genre,
+                notes: notes,
+                notesEndpoint: "",
+                episodeTitle: "Preview: \(payload.episodeTitle)",
+                post: nil,
+                releaseDate: payload.releaseDate,
+                resources: resources,
+                seasonNumber: payload.seasonNumber,
+                title: payload.title
+            )
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+Podcasts.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+Podcasts.swift
@@ -1,0 +1,31 @@
+import Vapor
+import Core
+import Foundation
+
+struct PodcastsViewModel: Encodable, Sendable {
+    let compose: String?
+    let term: String?
+    let previews: [PreviewViewModel]
+}
+
+extension Template where Model == PodcastsViewModel {
+    static let podcasts = Template(name: "Catalogue/Podcasts/podcasts")
+}
+
+extension Page {
+    static var podcasts: Self {
+        Page(template: .podcasts) { req in
+            let term = try? req.query.get(String.self, at: "term")
+            async let composeURL: String? = (try? await req.permissions.podcasts.create()) != nil ? "/podcasts/new" : nil
+            async let result = req.commands.podcasts.search(term)
+            let baseURL = req.baseURL
+            let resolved = try await result
+            return PodcastsViewModel(
+                compose: await composeURL,
+                term: term,
+                previews: resolved.previews.map { PreviewViewModel(preview: $0, baseURL: baseURL) }
+                    + resolved.noteMatches.map { PreviewViewModel(preview: $0, baseURL: baseURL, isNoteMatch: true) }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PodcastsViewModel` (list page) — searches podcasts, builds preview cards with note matches
- Refactor `PodcastViewModel` (detail page) — add `allowsNewNote`, `notesEndpoint`, `info`; compute `info` from S/E, genre, releaseDate joined with `, ` (removes separate fields the template was computing with hardcoded separators)
- Add `PodcastEditorViewModel` — pre-populated form for create/edit, season/episode as strings for form compatibility
- Add `Page.createPodcast`, `Page.editPodcast`, `Page.podcastPreview` statics

## Test plan
- [ ] `swift build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)