### PR TITLE
Podcasts Layer 8: Leaf templates (list, editor, detail)

### DIFF
--- a/tmbr/Resources/Views/Catalogue/Podcasts/podcast-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Podcasts/podcast-editor.leaf
@@ -1,0 +1,153 @@
+#extend("Shared/page"):
+
+    #export("styles"):
+    <link rel="stylesheet" href="/Styles/Shared/editor.css">
+    #endexport
+
+    #export("main"):
+    <form id="podcast-form" method="#(submit.method)" action="#(submit.action)">
+        <input id="editor-podcast-id" type="hidden" name="id" value="#(id)" />
+        <input id="editor-artwork-id" type="hidden" name="artwork-id" value="#(artworkId)" />
+        <input id="editor-artwork-source-url" type="hidden" name="artwork-source-url" value="#(artworkSourceURL)" />
+        #if(_csrf):
+            <input type="hidden" name="_csrf" value="#(_csrf)" />
+        #endif
+
+        <input
+            id="editor-podcast-episode-title"
+            class="text-input"
+            name="episodeTitle"
+            type="text"
+            value="#(episodeTitle)"
+            placeholder="Episode title"
+            autocomplete="off"
+            spellcheck="true"
+        />
+
+        #extend("Catalogue/resources-editor")
+
+        <section id="details-section">
+            <h3>Details</h3>
+
+            <div class="details-content">
+                <div class="details-inputs">
+                    <input
+                        id="editor-podcast-title"
+                        class="text-input"
+                        name="title"
+                        type="text"
+                        value="#(title)"
+                        placeholder="Show title"
+                        autocomplete="off"
+                        spellcheck="true"
+                    />
+
+                    <input
+                        id="editor-podcast-release-date"
+                        class="text-input"
+                        type="text"
+                        value="#(releaseDate)"
+                        placeholder="Release date, e.g. 2024 or 2025-06-15"
+                        autocomplete="off"
+                    />
+                    <input
+                        id="editor-podcast-release-date-iso"
+                        name="release-date"
+                        type="hidden"
+                        value=""
+                    />
+
+                    <input
+                        id="editor-podcast-genre"
+                        class="text-input"
+                        name="genre"
+                        type="text"
+                        value="#(genre)"
+                        placeholder="Genre"
+                        autocomplete="off"
+                        spellcheck="true"
+                    />
+
+                    <input
+                        id="editor-podcast-season-number"
+                        class="text-input"
+                        name="season-number"
+                        type="number"
+                        min="1"
+                        value="#(seasonNumber)"
+                        placeholder="Season"
+                        autocomplete="off"
+                    />
+
+                    <input
+                        id="editor-podcast-episode-number"
+                        class="text-input"
+                        name="episode-number"
+                        type="number"
+                        min="1"
+                        value="#(episodeNumber)"
+                        placeholder="Episode"
+                        autocomplete="off"
+                    />
+                </div>
+
+                <figure id="artwork-placeholder" class="image-picker #if(!artworkThumbnailURL):empty#endif">
+                    <img id="artwork-image" src="#(artworkThumbnailURL)" alt="Podcast artwork" />
+                    <span>#extend("Icons/gallery")</span>
+                    <button id="artwork-clear" type="button" class="icon">#extend("Icons/trash")</button>
+                </figure>
+            </div>
+        </section>
+
+        #if(error):
+            <p class="editor-error">#unsafeHTML(error)</p>
+        #endif
+
+        #extend("Notes/notes-editor")
+
+        <p id="autofill-status" class="system-info" hidden></p>
+
+        <div class="editor-actions">
+            <button id="editor-podcast-preview" class="link" type="button">Preview</button>
+            <div>
+                <input type="hidden" name="access" value="public" />
+                <button id="editor-post-save" class="primary" type="submit">#(submit.label)</button>
+            </div>
+        </div>
+    </form>
+
+    <form id="preview-form" method="post" action="/podcasts/preview" target="_blank" hidden>
+        <input type="hidden" name="episodeTitle" id="preview-episode-title" />
+        <input type="hidden" name="title" id="preview-title" />
+        <input type="hidden" name="genre" id="preview-genre" />
+        <input type="hidden" name="releaseDate" id="preview-release-date" />
+        <input type="hidden" name="artworkURL" id="preview-artwork-url" />
+        <input type="hidden" name="resourceURLs" id="preview-resource-urls" />
+        <input type="hidden" name="notes" id="preview-notes" />
+        <input type="hidden" name="seasonNumber" id="preview-season-number" />
+        <input type="hidden" name="episodeNumber" id="preview-episode-number" />
+    </form>
+
+    <div id="duplicate-container"></div>
+
+    <aside id="gallery" hidden>
+        <div id="gallery-header">
+            <button class="icon small" type="button" id="gallery-close" aria-label="Close">
+                #extend("Icons/close")
+            </button>
+            <h4 id="gallery-title">Gallery</h4>
+            <span id="gallery-status" class="system-info"></span>
+        </div>
+        <section id="gallery-section"></section>
+    </aside>
+    #endexport
+
+    #export("scripts"):
+        <script src="/Scripts/Shared/persistence.js"></script>
+        <script src="/Scripts/Shared/date-parser.js"></script>
+        <script src="/Scripts/Media/media.js"></script>
+        <script src="/Scripts/Notes/notes-editor.js"></script>
+        <script src="/Scripts/Catalogue/catalogue-editor.js"></script>
+        <script src="/Scripts/Catalogue/Podcasts/podcast-editor.js"></script>
+    #endexport
+#endextend

--- a/tmbr/Resources/Views/Catalogue/Podcasts/podcast.leaf
+++ b/tmbr/Resources/Views/Catalogue/Podcasts/podcast.leaf
@@ -1,32 +1,41 @@
 #extend("Catalogue/details"):
-    
+
     #export("details-header"):
     <div class="details">
         <h1>#(episodeTitle)</h1>
         <h3>from #(title)</h3>
-        
-        <p>
-            #if(seasonNumber):
-                #if(episodeNumber):
-                    S#(seasonNumber):E#(episodeNumber),
-                #endif
-            #endif
-            #if(releaseDate) #(releaseDate),
-            #if(genre) #(genre)
-        </p>
-        
+
+        #if(info):
+        <p>#(info)</p>
+        #endif
+
         #extend("Catalogue/resources")
     </div>
     #if(artwork):
     <div class="artwork">
-        <img src="#(artwork.url)" alt="Artwork image of #(title)">
+        <img src="#(artwork.url)" alt="Artwork image of #(episodeTitle)">
     </div>
     #endif
-    
+
+    #endexport
+
+    #export("styles"):
+    <link rel="stylesheet" href="/Styles/Shared/editor.css">
     #endexport
 
     #export("scripts"):
-    <script>document.addEventListener('DOMContentLoaded', () => new ShortcutsController([ShortcutsController.login, ShortcutsController.edit]).init());</script>
+    <script src="/Scripts/Shared/persistence.js"></script>
+    <script src="/Scripts/Notes/note-detail.js"></script>
+    <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        new ShortcutsController([ShortcutsController.login, ShortcutsController.edit]).init();
+        const notesSection = document.getElementById('notes-section');
+        if (notesSection) {
+            const persistence = new PersistenceController();
+            new NoteDetailController({ section: notesSection }, { persistence }).init();
+        }
+    });
+    </script>
     #endexport
 
 #endextend

--- a/tmbr/Resources/Views/Catalogue/Podcasts/podcasts.leaf
+++ b/tmbr/Resources/Views/Catalogue/Podcasts/podcasts.leaf
@@ -1,0 +1,28 @@
+#extend("Shared/page"):
+
+    #export("toolbar"):
+        #if(compose):
+            <a id="compose" class="icon" href="#(compose)" aria-label="Compose">
+                #extend("Icons/pencil")
+            </a>
+        #endif
+    #endexport
+
+    #export("main"):
+        #extend("Shared/signature")
+
+        <section>
+            <nav>
+                #extend("Shared/search")
+            </nav>
+
+            #extend("Previews/previews")
+        </section>
+    #endexport
+
+    #export("scripts"):
+        <script src="/Scripts/Shared/search.js"></script>
+        <script>document.addEventListener('DOMContentLoaded', () => new ShortcutsController([ShortcutsController.login]).init());</script>
+    #endexport
+
+#endextend


### PR DESCRIPTION
## Summary
- Add `podcasts.leaf` — list page with toolbar compose link, search nav, preview grid
- Add `podcast-editor.leaf` — editor with episode title (primary), show title, season/episode number inputs, square artwork picker, resources, notes; scripts block includes `persistence.js`, `date-parser.js`, `podcast-editor.js`
- Update `podcast.leaf` — add `editor.css` + `persistence.js`/`note-detail.js` scripts + `NoteDetailController` init; replace hardcoded-separator `<p>` block with `#if(info): <p>#(info)</p> #endif`

## Test plan
- [ ] `GET /podcasts` renders list page
- [ ] `GET /podcasts/new` renders editor form
- [ ] `GET /podcasts/:id` renders detail with working notes section (edit button, access toggle positioned correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)