### PR TITLE
Podcasts Layer 1: platform metadata struct + Apple Podcasts extractor

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+ApplePodcasts.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+ApplePodcasts.swift
@@ -4,45 +4,33 @@ extension MetadataExtractor where M == PodcastMetadata {
 
     static let applePodcasts = MetadataExtractor { url, fetcher in
         let episode = try await fetcher(url)
-        guard episode.type == "music.episode" else {
-            throw MetadataExtractionError.invalidType(expected: "music.episode", actual: episode.type)
+
+        // Apple Podcasts sets og:type = "website" for all pages, so we validate
+        // via JSON-LD @type to confirm this is an episode (not a show page).
+        guard (episode.json["@type"] as? String) == "PodcastEpisode" else {
+            throw MetadataExtractionError.invalidType(
+                expected: "PodcastEpisode",
+                actual: episode.json["@type"] as? String
+            )
         }
 
-        // Try fetching the show page to extract its title — same pattern as album fetch in appleMusicSong.
-        // Strip the ?i= episode param so we hit the show URL.
-        var showComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        showComponents?.queryItems = nil
-        let showTitle = try? await MetadataExtractor.extract(
-            key: "og:title",
-            from: showComponents?.string,
-            of: "music.album",
-            with: fetcher
-        )
+        // Show title is in JSON-LD partOfSeries.name — no secondary fetch needed.
+        let showTitle = (episode.json["partOfSeries"] as? [String: Any])?["name"] as? String
 
-        // Episode/season numbers from JSON-LD if the page exposes them.
+        // Episode and season numbers from JSON-LD.
         let episodeNumber = (episode.json["episodeNumber"] as? Int)
             ?? (episode.json["episodeNumber"] as? String).flatMap(Int.init)
         let seasonNumber = (episode.json["partOfSeason"] as? [String: Any])
             .flatMap { $0["seasonNumber"] as? Int }
 
-        // Release date prefers the structured tag; falls back to JSON-LD datePublished.
-        let releaseDate = episode.tags["music:release_date"]
-            ?? episode.json["datePublished"] as? String
-
-        // ExternalID: episode ID from the URL query parameter `i`.
-        let externalID = URLComponents(url: url, resolvingAgainstBaseURL: false)?
-            .queryItems?
-            .first(where: { $0.name == "i" })?
-            .value
-
         return PodcastMetadata(
-            episodeTitle: episode.tags["og:title"] ?? episode.tags["apple:title"],
+            episodeTitle: episode.tags["apple:title"] ?? episode.tags["og:title"],
             showTitle: showTitle,
             artwork: episode.tags["og:image"],
-            releaseDate: releaseDate,
+            releaseDate: episode.json["datePublished"] as? String,
             episodeNumber: episodeNumber,
             seasonNumber: seasonNumber,
-            externalID: externalID
+            externalID: episode.tags["apple:content_id"]
         )
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+ApplePodcasts.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+ApplePodcasts.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+extension MetadataExtractor where M == PodcastMetadata {
+
+    static let applePodcasts = MetadataExtractor { url, fetcher in
+        let episode = try await fetcher(url)
+        guard episode.type == "music.episode" else {
+            throw MetadataExtractionError.invalidType(expected: "music.episode", actual: episode.type)
+        }
+
+        // Try fetching the show page to extract its title — same pattern as album fetch in appleMusicSong.
+        // Strip the ?i= episode param so we hit the show URL.
+        var showComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        showComponents?.queryItems = nil
+        let showTitle = try? await MetadataExtractor.extract(
+            key: "og:title",
+            from: showComponents?.string,
+            of: "music.album",
+            with: fetcher
+        )
+
+        // Episode/season numbers from JSON-LD if the page exposes them.
+        let episodeNumber = (episode.json["episodeNumber"] as? Int)
+            ?? (episode.json["episodeNumber"] as? String).flatMap(Int.init)
+        let seasonNumber = (episode.json["partOfSeason"] as? [String: Any])
+            .flatMap { $0["seasonNumber"] as? Int }
+
+        // Release date prefers the structured tag; falls back to JSON-LD datePublished.
+        let releaseDate = episode.tags["music:release_date"]
+            ?? episode.json["datePublished"] as? String
+
+        // ExternalID: episode ID from the URL query parameter `i`.
+        let externalID = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == "i" })?
+            .value
+
+        return PodcastMetadata(
+            episodeTitle: episode.tags["og:title"] ?? episode.tags["apple:title"],
+            showTitle: showTitle,
+            artwork: episode.tags["og:image"],
+            releaseDate: releaseDate,
+            episodeNumber: episodeNumber,
+            seasonNumber: seasonNumber,
+            externalID: externalID
+        )
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/PodcastMetadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/PodcastMetadata.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Vapor
+
+struct PodcastMetadata: Encodable, AsyncResponseEncodable, Sendable {
+
+    let episodeTitle: String?
+
+    let showTitle: String?
+
+    let artwork: String?
+
+    let releaseDate: String?
+
+    let episodeNumber: Int?
+
+    let seasonNumber: Int?
+
+    let externalID: String?
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/MetadataExtractor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/MetadataExtractor.swift
@@ -35,7 +35,7 @@ struct MetadataExtractor<M>: Sendable {
         of type: String,
         with fetcher: Fetcher
     ) async throws -> String? {
-        guard let url = urlString.flatMap({ URL(string: $0) }) else { return nil }
+        guard let url = urlString.flatMap(URL.init) else { return nil }
         return try await extract(key: key, from: url, of: type, with: fetcher)
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/MetadataExtractor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/MetadataExtractor.swift
@@ -35,7 +35,7 @@ struct MetadataExtractor<M>: Sendable {
         of type: String,
         with fetcher: Fetcher
     ) async throws -> String? {
-        guard let url = urlString.flatMap(URL.init) else { return nil }
+        guard let url = urlString.flatMap({ URL(string: $0) }) else { return nil }
         return try await extract(key: key, from: url, of: type, with: fetcher)
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Podcast.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Podcast.swift
@@ -1,9 +1,9 @@
-extension Platform where M == Void {
+extension Platform where M == PodcastMetadata {
 
-    static var podcast: Platform<Void> {
+    static var podcast: Platform<PodcastMetadata> {
         Platform(platforms: [
             Platform(name: "Spotify", checker: .spotify),
-            Platform(name: "Podcasts", checker: .applePodcasts)
+            Platform(name: "Podcasts", checker: .applePodcasts, extractor: .applePodcasts)
         ])
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/API/Responses/PodcastResponse.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/API/Responses/PodcastResponse.swift
@@ -69,7 +69,7 @@ struct PodcastResponse: Encodable, Sendable {
         podcast: Podcast,
         baseURL: String,
         notes: [Note],
-        platform: Platform<Void> = .podcast
+        platform: Platform<PodcastMetadata> = .podcast
     ) {
         self.init(
             id: podcast.id!,

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+Podcast.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/Pages/Page+Podcast.swift
@@ -57,7 +57,7 @@ struct PodcastViewModel: Encodable, Sendable {
         podcast: Podcast,
         notes: [Note],
         baseURL: String,
-        platform: Platform<Void> = .podcast
+        platform: Platform<PodcastMetadata> = .podcast
     ) throws {
         self.init(
             id: try podcast.requireID(),


### PR DESCRIPTION
## Summary

- Add `PodcastMetadata` struct (encodable response DTO for Apple Podcasts API responses)
- Add `MetadataExtractor+ApplePodcasts` — validates via JSON-LD `@type = "PodcastEpisode"` (not `og:type`, which is always `"website"`), extracts episode title, show title, artwork, release date, episode/season numbers, and `apple:content_id` as external ID
- Upgrade `Platform+Podcast.swift` from `Platform<Void>` to `Platform<PodcastMetadata>`, wiring in the Apple Podcasts extractor alongside the existing Spotify URL checker
- Fix `URL.init` ambiguity in the shared `MetadataExtractor` helper caused by the Configuration module introducing `URL.init(configString:)`

## Test plan

- [ ] `GET /podcasts/metadata?url=<apple-podcasts-episode-url>` returns a populated `PodcastMetadata` JSON response
- [ ] A show page URL (not an episode) returns a 422/extraction error
- [ ] Spotify URLs still pass the checker (no extractor, no metadata response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)