### PR TITLE
Fix podcast editor bugs and harden catalogue routing

### DIFF
--- a/tmbr/Public/Styles/Shared/editor.css
+++ b/tmbr/Public/Styles/Shared/editor.css
@@ -454,7 +454,7 @@ form label.access {
  ------------------------------------------------
  */
 
-main > form > input[name=title] {
+main > form > input.title {
     font-size: 3.2rem;
     font-weight: 700;
     margin: 3.2rem -8px;

--- a/tmbr/Resources/Views/Catalogue/Books/book-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Books/book-editor.leaf
@@ -15,7 +15,7 @@
 
         <input
             id="editor-book-title"
-            class="text-input"
+            class="text-input title"
             name="title"
             type="text"
             value="#(title)"

--- a/tmbr/Resources/Views/Catalogue/Movies/movie-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Movies/movie-editor.leaf
@@ -15,7 +15,7 @@
 
         <input
             id="editor-movie-title"
-            class="text-input"
+            class="text-input title"
             name="title"
             type="text"
             value="#(title)"

--- a/tmbr/Resources/Views/Catalogue/Podcasts/podcast-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Podcasts/podcast-editor.leaf
@@ -15,7 +15,7 @@
 
         <input
             id="editor-podcast-episode-title"
-            class="text-input"
+            class="text-input title"
             name="episodeTitle"
             type="text"
             value="#(episodeTitle)"

--- a/tmbr/Resources/Views/Catalogue/Songs/song-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Songs/song-editor.leaf
@@ -15,7 +15,7 @@
 
         <input
             id="editor-song-title"
-            class="text-input"
+            class="text-input title"
             name="title"
             type="text"
             value="#(title)"

--- a/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/BooksWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Books/Routes/Web/BooksWebController.swift
@@ -12,21 +12,23 @@ struct BooksWebController: RouteCollection {
 
     func boot(routes: RoutesBuilder) throws {
         let booksRoute = routes.grouped("books")
+        let recoveringRoute = routes.grouped("books")
+            .grouped(RecoverMiddleware())
 
-        booksRoute.get(page: .books)
+        recoveringRoute.get(page: .books)
 
-        booksRoute.get(":bookID", page: .book)
+        recoveringRoute.get(":bookID", page: .book)
 
-        booksRoute.get("new", page: .createBook)
-        booksRoute.post("new", use: createBook)
+        recoveringRoute.get("new", page: .createBook)
+        recoveringRoute.post("new", use: createBook)
 
         booksRoute.get("metadata", use: metadata)
         booksRoute.get("lookup", use: lookupDialog)
 
-        booksRoute.get(":bookID", "edit", page: .editBook)
-        booksRoute.post(":bookID", use: updateBook)
+        recoveringRoute.get(":bookID", "edit", page: .editBook)
+        recoveringRoute.post(":bookID", use: updateBook)
 
-        booksRoute.post("preview", page: .bookPreview)
+        recoveringRoute.post("preview", page: .bookPreview)
 
         booksRoute.post(":bookID", "notes", use: createNote)
     }

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Commands/Command+Metadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Commands/Command+Metadata.swift
@@ -39,7 +39,7 @@ struct FetchMetadataCommand: Command {
         
         let response = try await client.get(URI(string: url.absoluteString))
         
-        guard response.status == .ok else {
+        guard (200..<300).contains(response.status.code) else {
             throw Abort(.badGateway, reason: "Metadata fetch failed. Upstream returned \(response.status.code)")
         }
         guard let body = response.body,

--- a/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/Web/MoviesWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Movies/Routes/Web/MoviesWebController.swift
@@ -12,21 +12,23 @@ struct MoviesWebController: RouteCollection {
 
     func boot(routes: RoutesBuilder) throws {
         let moviesRoute = routes.grouped("movies")
+        let recoveringRoute = routes.grouped("movies")
+            .grouped(RecoverMiddleware())
 
-        moviesRoute.get(page: .movies)
+        recoveringRoute.get(page: .movies)
 
-        moviesRoute.get(":movieID", page: .movie)
+        recoveringRoute.get(":movieID", page: .movie)
 
-        moviesRoute.get("new", page: .createMovie)
-        moviesRoute.post("new", use: createMovie)
+        recoveringRoute.get("new", page: .createMovie)
+        recoveringRoute.post("new", use: createMovie)
 
         moviesRoute.get("metadata", use: metadata)
         moviesRoute.get("lookup", use: lookupDialog)
 
-        moviesRoute.get(":movieID", "edit", page: .editMovie)
-        moviesRoute.post(":movieID", use: updateMovie)
+        recoveringRoute.get(":movieID", "edit", page: .editMovie)
+        recoveringRoute.post(":movieID", use: updateMovie)
 
-        moviesRoute.post("preview", page: .moviePreview)
+        recoveringRoute.post("preview", page: .moviePreview)
 
         moviesRoute.post(":movieID", "notes", use: createNote)
     }

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Models/Migrations/AddMissingFieldsToPodcast.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Models/Migrations/AddMissingFieldsToPodcast.swift
@@ -1,0 +1,21 @@
+import Fluent
+
+struct AddMissingFieldsToPodcast: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(Podcast.schema)
+            .field("episode_number", .int)
+            .field("episode_title", .string, .required, .sql(.default("")))
+            .field("genre", .string)
+            .field("season", .int)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Podcast.schema)
+            .deleteField("episode_number")
+            .deleteField("episode_title")
+            .deleteField("genre")
+            .deleteField("season")
+            .update()
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Podcasts.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Podcasts.swift
@@ -19,6 +19,7 @@ struct Podcasts: Module {
 
     func configure(_ app: Vapor.Application) async throws {
         app.migrations.add(CreatePodcast())
+        app.migrations.add(AddMissingFieldsToPodcast())
         app.databases.middleware.use(PreviewModelMiddleware.podcast, on: .psql)
         
         try await app.permissions.add(scope: permissions)

--- a/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/PodcastEditorPayload.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/PodcastEditorPayload.swift
@@ -14,7 +14,7 @@ struct PodcastEditorPayload: Decodable, Sendable {
 
     private let artworkSourceURLRaw: String?
 
-    let episodeNumber: Int?
+    private let episodeNumberRaw: String?
 
     let genre: String?
 
@@ -24,7 +24,11 @@ struct PodcastEditorPayload: Decodable, Sendable {
 
     let resourceURLs: [String]
 
-    let seasonNumber: Int?
+    private let seasonNumberRaw: String?
+
+    var episodeNumber: Int? { episodeNumberRaw.flatMap(Int.init) }
+
+    var seasonNumber: Int? { seasonNumberRaw.flatMap(Int.init) }
 
     let title: String
 
@@ -47,13 +51,13 @@ struct PodcastEditorPayload: Decodable, Sendable {
         case access
         case artworkIdRaw = "artwork-id"
         case artworkSourceURLRaw = "artwork-source-url"
-        case episodeNumber = "episode-number"
+        case episodeNumberRaw = "episode-number"
         case episodeTitle
         case genre
         case notes
         case releaseDate = "release-date"
         case resourceURLs
-        case seasonNumber = "season-number"
+        case seasonNumberRaw = "season-number"
         case title
     }
 
@@ -75,13 +79,13 @@ struct PodcastEditorPayload: Decodable, Sendable {
         self.access = access
         self.artworkIdRaw = artworkIdRaw
         self.artworkSourceURLRaw = artworkSourceURLRaw
-        self.episodeNumber = episodeNumber
+        self.episodeNumberRaw = episodeNumber.map(String.init)
         self.episodeTitle = episodeTitle
         self.genre = genre
         self.notes = notes
         self.releaseDate = releaseDate
         self.resourceURLs = resourceURLs
-        self.seasonNumber = seasonNumber
+        self.seasonNumberRaw = seasonNumber.map(String.init)
         self.title = title
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
@@ -12,21 +12,23 @@ struct SongsWebController: RouteCollection {
 
     func boot(routes: RoutesBuilder) throws {
         let songsRoute = routes.grouped("songs")
-        
-        songsRoute.get (page: . songs)
+        let recoveringRoute = routes.grouped("songs")
+            .grouped(RecoverMiddleware())
 
-        songsRoute.get(":songID", page: .song)
+        recoveringRoute.get(page: .songs)
 
-        songsRoute.get("new", page: .createSong)
-        songsRoute.post("new", use: createSong)
+        recoveringRoute.get(":songID", page: .song)
+
+        recoveringRoute.get("new", page: .createSong)
+        recoveringRoute.post("new", use: createSong)
 
         songsRoute.get("metadata", use: metadata)
         songsRoute.get("lookup", use: lookupDialog)
 
-        songsRoute.get(":songID", "edit", page: .editSong)
-        songsRoute.post(":songID", use: updateSong)
+        recoveringRoute.get(":songID", "edit", page: .editSong)
+        recoveringRoute.post(":songID", use: updateSong)
 
-        songsRoute.post("preview", page: .songPreview)
+        recoveringRoute.post("preview", page: .songPreview)
 
         songsRoute.post(":songID", "notes", use: createNote)
     }

--- a/tmbr/Sources/Core/Commands/Commands/LoggedCommand.swift
+++ b/tmbr/Sources/Core/Commands/Commands/LoggedCommand.swift
@@ -37,7 +37,7 @@ where Input: Sendable, Output: Sendable {
             logger.trace("\(name) produced output: \(String(describing: output))")
             return output
         } catch {
-            logger.error("\(name) produced error: \(error)")
+            logger.error("\(name) produced error: \(String(reflecting: error))")
             throw error
         }
     }


### PR DESCRIPTION
Podcast fixes:
- Add migration for missing columns (episode_number, episode_title, genre, season) that were defined in the Podcast model but never created in the DB
- Fix podcast editor form being blank after a save error: season-number and episode-number were typed as Int? in PodcastEditorPayload, causing URL- encoded empty strings to fail decoding; now stored as String? with computed Int? accessors so the catch-block re-decode always succeeds
- Fix podcast editor title input missing the large bold heading style

Catalogue-wide fixes:
- Replace input[name=title] CSS selector with a .title class applied to the primary title input in all four editors (book, movie, song, podcast)
- Accept any 2xx status from upstream in FetchMetadataCommand instead of requiring exactly 200 OK (fixes 502 on IMDb 202 responses)
- Add RecoverMiddleware to page/form/preview routes in MoviesWebController, SongsWebController, and BooksWebController so errors render a proper recovery page instead of a raw Vapor error response; metadata, lookup, and notes routes remain outside the middleware to keep their error responses as clean HTTP errors for JS callers