### PR TITLE
Stage 2: shallow preview architecture — ContainerEntry, nullable parentID, album tracklist

### DIFF
--- a/tmbr/Resources/Views/Catalogue/details.leaf
+++ b/tmbr/Resources/Views/Catalogue/details.leaf
@@ -19,7 +19,6 @@
 
             #import("detail-body")
 
-
             <section id="notes-section" data-notes-endpoint="#(notesEndpoint)">
                 <h3>Notes</h3>
                 #if(allowsNewNote):

--- a/tmbr/Sources/App/Modules/Catalogue/Albums/Routes/Web/Pages/Page+Album.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Albums/Routes/Web/Pages/Page+Album.swift
@@ -3,6 +3,22 @@ import Foundation
 import AuthKit
 import Core
 
+struct TrackViewModel: Encodable, Sendable {
+    let position: Int
+    let title: String
+    let href: String?
+
+    init(entry: ContainerEntry) {
+        position = entry.position
+        title = entry.preview.primaryInfo
+        if let parentID = entry.preview.parentID {
+            href = "/\(entry.preview.parentType)s/\(parentID)"
+        } else {
+            href = nil
+        }
+    }
+}
+
 struct AlbumViewModel: Encodable, Sendable {
 
     private let id: AlbumID
@@ -25,6 +41,8 @@ struct AlbumViewModel: Encodable, Sendable {
 
     private let title: String
 
+    private let tracks: [TrackViewModel]
+
     init(
         id: AlbumID,
         artist: String,
@@ -35,7 +53,8 @@ struct AlbumViewModel: Encodable, Sendable {
         notesEndpoint: String,
         post: PostItemViewModel?,
         resources: [Hyperlink],
-        title: String
+        title: String,
+        tracks: [TrackViewModel] = []
     ) {
         self.id = id
         self.artist = artist
@@ -47,6 +66,7 @@ struct AlbumViewModel: Encodable, Sendable {
         self.post = post
         self.resources = resources
         self.title = title
+        self.tracks = tracks
     }
 
     init(
@@ -60,7 +80,8 @@ struct AlbumViewModel: Encodable, Sendable {
         post: PostItemViewModel?,
         releaseDate: String?,
         resources: [Hyperlink],
-        title: String
+        title: String,
+        tracks: [TrackViewModel] = []
     ) {
         self.init(
             id: id,
@@ -75,13 +96,15 @@ struct AlbumViewModel: Encodable, Sendable {
             notesEndpoint: notesEndpoint,
             post: post,
             resources: resources,
-            title: title
+            title: title,
+            tracks: tracks
         )
     }
 
     init(
         album: Album,
         notes: [Note],
+        tracks: [TrackViewModel],
         baseURL: String,
         allowsNewNote: Bool,
         platform: Platform<AlbumMetadata> = .album
@@ -100,7 +123,8 @@ struct AlbumViewModel: Encodable, Sendable {
             post: try album.post.map(PostItemViewModel.init),
             releaseDate: album.releaseDate?.formatted(.releaseDate),
             resources: album.resourceURLs.compactMap(platform.hyperlink),
-            title: album.title
+            title: album.title,
+            tracks: tracks
         )
     }
 }
@@ -117,11 +141,16 @@ extension Page {
             }
             async let album = request.commands.albums.fetch(albumID, for: .read)
             async let notes = request.commands.notes.query(id: albumID, of: Album.previewType)
+            async let entries = request.commands.previews.listEntries(
+                ContainerEntriesInput(containerType: "album", containerID: albumID)
+            )
             let resolvedAlbum = try await album
             let allowsNewNote = (try? await request.permissions.albums.edit.grant(resolvedAlbum)) != nil
+            let tracks = try await entries.map(TrackViewModel.init)
             return try AlbumViewModel(
                 album: resolvedAlbum,
                 notes: await notes,
+                tracks: tracks,
                 baseURL: request.baseURL,
                 allowsNewNote: allowsNewNote
             )

--- a/tmbr/Sources/App/Modules/Catalogue/Albums/Routes/Web/Pages/Page+Album.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Albums/Routes/Web/Pages/Page+Album.swift
@@ -141,7 +141,7 @@ extension Page {
             }
             async let album = request.commands.albums.fetch(albumID, for: .read)
             async let notes = request.commands.notes.query(id: albumID, of: Album.previewType)
-            async let entries = request.commands.previews.listEntries(
+            async let entries = request.commands.previews.listContainerEntries(
                 ContainerEntriesInput(containerType: "album", containerID: albumID)
             )
             let resolvedAlbum = try await album

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/PromoteSongCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/PromoteSongCommand.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Vapor
+import Core
+import AuthKit
+
+struct PromoteSongCommand: Command {
+
+    private let fetchPreview: CommandResolver<FetchParameters<PreviewID>, Preview>
+
+    private let fetchContainerEntry: CommandResolver<ContainerEntryInput, ContainerEntry>
+
+    private let fetchAlbum: CommandResolver<FetchParameters<AlbumID>, Album>
+
+    private let create: CommandResolver<SongInput, Song>
+
+    init(
+        fetchPreview: CommandResolver<FetchParameters<PreviewID>, Preview>,
+        fetchContainerEntry: CommandResolver<ContainerEntryInput, ContainerEntry>,
+        fetchAlbum: CommandResolver<FetchParameters<AlbumID>, Album>,
+        create: CommandResolver<SongInput, Song>
+    ) {
+        self.fetchPreview = fetchPreview
+        self.fetchContainerEntry = fetchContainerEntry
+        self.fetchAlbum = fetchAlbum
+        self.create = create
+    }
+
+    func execute(_ previewID: UUID) async throws -> Song {
+        let preview = try await fetchPreview(previewID, for: .read)
+        let entry = try await fetchContainerEntry(ContainerEntryInput(previewID: previewID, containerType: "album"))
+        let album = try await fetchAlbum(entry.containerID, for: .read)
+        return try await create(SongInput(
+            previewID: previewID,
+            access: preview.parentAccess,
+            album: album.title,
+            artist: album.artist,
+            artwork: album.$artwork.id,
+            genre: album.genre,
+            releaseDate: nil,
+            resourceURLs: preview.externalLinks,
+            title: preview.primaryInfo
+        ))
+    }
+}
+
+extension CommandFactory<UUID, Song> {
+    static var promoteSong: Self {
+        CommandFactory { request in
+            PromoteSongCommand(
+                fetchPreview: request.commands.previews.fetch,
+                fetchContainerEntry: request.commands.previews.fetchContainerEntry,
+                fetchAlbum: request.commands.albums.fetch,
+                create: request.commands.songs.create
+            )
+            .logged(name: "Promote Song", logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/SongInput.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/SongInput.swift
@@ -4,24 +4,27 @@ import AuthKit
 import Core
 
 struct SongInput {
-    
+
     fileprivate let access: Access
-    
+
+    fileprivate let adoptingPreviewID: UUID?
+
     fileprivate let album: String?
-    
+
     fileprivate let artist: String
-        
+
     fileprivate let artwork: ImageID?
-    
+
     fileprivate let genre: String?
-        
+
     fileprivate let releaseDate: Date?
-    
+
     fileprivate let resourceURLs: [String]
-    
+
     fileprivate let title: String
-    
+
     init(
+        adoptingPreviewID: UUID? = nil,
         access: Access,
         album: String?,
         artist: String,
@@ -31,6 +34,7 @@ struct SongInput {
         resourceURLs: [String],
         title: String
     ) {
+        self.adoptingPreviewID = adoptingPreviewID
         self.access = access
         self.album = album
         self.artist = artist
@@ -40,7 +44,7 @@ struct SongInput {
         self.resourceURLs = resourceURLs
         self.title = title
     }
-    
+
     init(payload: SongPayload) {
         self.init(
             access: payload.access,
@@ -56,9 +60,10 @@ struct SongInput {
 }
 
 extension ModelConfiguration where Model == Song, Parameters == SongInput {
-    
+
     static var song: Self {
         ModelConfiguration { song, input in
+            song.adoptingPreviewID = input.adoptingPreviewID
             song.access = input.access
             song.album = input.album
             song.artist = input.artist

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/SongInput.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/SongInput.swift
@@ -7,7 +7,7 @@ struct SongInput {
 
     fileprivate let access: Access
 
-    fileprivate let adoptingPreviewID: UUID?
+    fileprivate let previewID: UUID?
 
     fileprivate let album: String?
 
@@ -24,7 +24,7 @@ struct SongInput {
     fileprivate let title: String
 
     init(
-        adoptingPreviewID: UUID? = nil,
+        previewID: UUID? = nil,
         access: Access,
         album: String?,
         artist: String,
@@ -34,7 +34,7 @@ struct SongInput {
         resourceURLs: [String],
         title: String
     ) {
-        self.adoptingPreviewID = adoptingPreviewID
+        self.previewID = previewID
         self.access = access
         self.album = album
         self.artist = artist
@@ -63,7 +63,7 @@ extension ModelConfiguration where Model == Song, Parameters == SongInput {
 
     static var song: Self {
         ModelConfiguration { song, input in
-            song.adoptingPreviewID = input.adoptingPreviewID
+            song.adoptingPreviewID = input.previewID
             song.access = input.access
             song.album = input.album
             song.artist = input.artist

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Commands+Songs.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Commands+Songs.swift
@@ -21,6 +21,8 @@ extension Commands {
 
         let metadata: CommandFactory<URL, SongMetadata>
 
+        let promote: CommandFactory<UUID, Song>
+
         let search: CommandFactory<String?, SongSearchResult>
 
         init(
@@ -30,6 +32,7 @@ extension Commands {
             fetch: CommandFactory<FetchParameters<SongID>, Song> = .fetchSong,
             lookup: CommandFactory<String, Song?> = .lookupSong,
             metadata: CommandFactory<URL, SongMetadata> = .fetchMetadata,
+            promote: CommandFactory<UUID, Song> = .promoteSong,
             search: CommandFactory<String?, SongSearchResult> = .searchSongs
         ) {
             self.create = create
@@ -38,6 +41,7 @@ extension Commands {
             self.fetch = fetch
             self.lookup = lookup
             self.metadata = metadata
+            self.promote = promote
             self.search = search
         }
     }

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Models/Song.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Models/Song.swift
@@ -85,7 +85,6 @@ extension PreviewModelMiddleware where M == Song {
 
     static var song: Self {
         Self(
-            readPreviewID: { $0.adoptingPreviewID },
             attach: { previewID, song in
                 song.$preview.id = previewID
             },
@@ -98,7 +97,8 @@ extension PreviewModelMiddleware where M == Song {
             fetch: { song, database in
                 try await song.$preview.load(on: database)
                 return song.preview
-            }
+            },
+            previewID: { $0.adoptingPreviewID }
         )
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Models/Song.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Models/Song.swift
@@ -48,7 +48,9 @@ final class Song: Model, Previewable, @unchecked Sendable {
     var title: String
     
     var ownerID: UserID { $owner.id }
-    
+
+    var adoptingPreviewID: UUID?
+
     init() {}
     
     init(owner: UserID) {

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Models/Song.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Models/Song.swift
@@ -82,9 +82,10 @@ final class Song: Model, Previewable, @unchecked Sendable {
 }
 
 extension PreviewModelMiddleware where M == Song {
-    
+
     static var song: Self {
         Self(
+            readPreviewID: { $0.adoptingPreviewID },
             attach: { previewID, song in
                 song.$preview.id = previewID
             },

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/API/SongsAPIController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/API/SongsAPIController.swift
@@ -94,6 +94,17 @@ struct SongsAPIController: RouteCollection {
             return .noContent
         }
 
+        // POST /api/songs/promote
+        songsRoute.post("promote") { request async throws -> SongResponse in
+            struct PromotePayload: Content {
+                let previewID: UUID
+            }
+            let payload = try request.content.decode(PromotePayload.self)
+            let song = try await request.commands.songs.promote(payload.previewID)
+            let notes = try await request.commands.notes.query(id: song.id!, of: Song.previewType)
+            return SongResponse(song: song, notes: notes, baseURL: request.baseURL)
+        }
+
         // POST /api/songs/:songID/notes
         songsRoute.post(":songID", "notes") { request async throws -> NoteResponse in
             guard let songID = request.parameters.get("songID", as: Int.self) else {

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
@@ -29,6 +29,7 @@ struct SongsWebController: RouteCollection {
         recoveringRoute.post(":songID", use: updateSong)
 
         recoveringRoute.post("preview", page: .songPreview)
+        recoveringRoute.post("promote", use: promote)
 
         songsRoute.post(":songID", "notes", use: createNote)
     }
@@ -218,6 +219,38 @@ struct SongsWebController: RouteCollection {
         } catch {
             return Response(status: .unprocessableEntity)
         }
+    }
+
+    @Sendable
+    private func promote(_ request: Request) async throws -> Response {
+        struct PromotePayload: Content {
+            let previewID: UUID
+        }
+        let payload = try request.content.decode(PromotePayload.self)
+        let preview = try await request.commands.previews.fetch(payload.previewID, for: .read)
+
+        guard let entry = try await ContainerEntry.query(on: request.commandDB)
+            .filter(\.$preview.$id == payload.previewID)
+            .filter(\.$containerType == "album")
+            .first()
+        else {
+            throw Abort(.notFound, reason: "No album container entry found for this track")
+        }
+
+        let album = try await request.commands.albums.fetch(entry.containerID, for: .read)
+        let input = SongInput(
+            adoptingPreviewID: payload.previewID,
+            access: preview.parentAccess,
+            album: album.title,
+            artist: album.artist,
+            artwork: album.$artwork.id,
+            genre: album.genre,
+            releaseDate: nil,
+            resourceURLs: preview.externalLinks,
+            title: preview.primaryInfo
+        )
+        let song = try await request.commands.songs.create(input)
+        return request.redirect(to: "/songs/\(song.id!)")
     }
 
     private func editorErrorHTML(for error: Error, on req: Request) -> String {

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
@@ -227,29 +227,7 @@ struct SongsWebController: RouteCollection {
             let previewID: UUID
         }
         let payload = try request.content.decode(PromotePayload.self)
-        let preview = try await request.commands.previews.fetch(payload.previewID, for: .read)
-
-        guard let entry = try await ContainerEntry.query(on: request.commandDB)
-            .filter(\.$preview.$id == payload.previewID)
-            .filter(\.$containerType == "album")
-            .first()
-        else {
-            throw Abort(.notFound, reason: "No album container entry found for this track")
-        }
-
-        let album = try await request.commands.albums.fetch(entry.containerID, for: .read)
-        let input = SongInput(
-            adoptingPreviewID: payload.previewID,
-            access: preview.parentAccess,
-            album: album.title,
-            artist: album.artist,
-            artwork: album.$artwork.id,
-            genre: album.genre,
-            releaseDate: nil,
-            resourceURLs: preview.externalLinks,
-            title: preview.primaryInfo
-        )
-        let song = try await request.commands.songs.create(input)
+        let song = try await request.commands.songs.promote(payload.previewID)
         return request.redirect(to: "/songs/\(song.id!)")
     }
 

--- a/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+FetchContainerEntry.swift
+++ b/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+FetchContainerEntry.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Vapor
+import Core
+import Fluent
+
+struct ContainerEntryInput: Sendable {
+    let previewID: UUID
+    let containerType: String
+}
+
+extension Command where Self == PlainCommand<ContainerEntryInput, ContainerEntry> {
+    static func fetchContainerEntry(database: Database) -> Self {
+        PlainCommand { input in
+            guard let entry = try await ContainerEntry.query(on: database)
+                .filter(\.$preview.$id == input.previewID)
+                .filter(\.$containerType == input.containerType)
+                .first()
+            else {
+                throw Abort(.notFound, reason: "No \(input.containerType) container entry found for this preview")
+            }
+            return entry
+        }
+    }
+}
+
+extension CommandFactory<ContainerEntryInput, ContainerEntry> {
+    static var fetchContainerEntry: Self {
+        CommandFactory { request in
+            .fetchContainerEntry(database: request.commandDB)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+ListContainerEntries.swift
+++ b/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+ListContainerEntries.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Vapor
+import Core
+import Fluent
+
+struct ContainerEntriesInput: Sendable {
+    let containerType: String
+    let containerID: Int
+}
+
+extension Command where Self == PlainCommand<ContainerEntriesInput, [ContainerEntry]> {
+    static func listContainerEntries(database: Database) -> Self {
+        PlainCommand { input in
+            try await ContainerEntry.query(on: database)
+                .filter(\.$containerType == input.containerType)
+                .filter(\.$containerID == input.containerID)
+                .sort(\.$position)
+                .with(\.$preview)
+                .all()
+        }
+    }
+}
+
+extension CommandFactory<ContainerEntriesInput, [ContainerEntry]> {
+    static var listContainerEntries: Self {
+        CommandFactory { request in
+            .listContainerEntries(database: request.commandDB)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Previews/Commands/Commands+Previews.swift
+++ b/tmbr/Sources/App/Modules/Previews/Commands/Commands+Previews.swift
@@ -10,18 +10,22 @@ extension Commands {
 
         let fetch: CommandFactory<FetchParameters<PreviewID>, Preview>
 
+        let fetchContainerEntry: CommandFactory<ContainerEntryInput, ContainerEntry>
+
         let list: CommandFactory<PreviewQueryInput, [Preview]>
 
-        let listEntries: CommandFactory<ContainerEntriesInput, [ContainerEntry]>
+        let listContainerEntries: CommandFactory<ContainerEntriesInput, [ContainerEntry]>
 
         init(
             fetch: CommandFactory<FetchParameters<PreviewID>, Preview> = .fetchPreview,
+            fetchContainerEntry: CommandFactory<ContainerEntryInput, ContainerEntry> = .fetchContainerEntry,
             list: CommandFactory<PreviewQueryInput, [Preview]> = .listPreviews,
-            listEntries: CommandFactory<ContainerEntriesInput, [ContainerEntry]> = .listContainerEntries
+            listContainerEntries: CommandFactory<ContainerEntriesInput, [ContainerEntry]> = .listContainerEntries
         ) {
             self.fetch = fetch
+            self.fetchContainerEntry = fetchContainerEntry
             self.list = list
-            self.listEntries = listEntries
+            self.listContainerEntries = listContainerEntries
         }
     }
 }

--- a/tmbr/Sources/App/Modules/Previews/Commands/Commands+Previews.swift
+++ b/tmbr/Sources/App/Modules/Previews/Commands/Commands+Previews.swift
@@ -7,17 +7,21 @@ extension Commands {
 
 extension Commands {
     struct Previews: CommandCollection, Sendable {
-        
+
         let fetch: CommandFactory<FetchParameters<PreviewID>, Preview>
-        
+
         let list: CommandFactory<PreviewQueryInput, [Preview]>
-                
+
+        let listEntries: CommandFactory<ContainerEntriesInput, [ContainerEntry]>
+
         init(
             fetch: CommandFactory<FetchParameters<PreviewID>, Preview> = .fetchPreview,
-            list: CommandFactory<PreviewQueryInput, [Preview]> = .listPreviews
+            list: CommandFactory<PreviewQueryInput, [Preview]> = .listPreviews,
+            listEntries: CommandFactory<ContainerEntriesInput, [ContainerEntry]> = .listContainerEntries
         ) {
             self.fetch = fetch
             self.list = list
+            self.listEntries = listEntries
         }
     }
 }

--- a/tmbr/Sources/App/Modules/Previews/Models/ContainerEntry.swift
+++ b/tmbr/Sources/App/Modules/Previews/Models/ContainerEntry.swift
@@ -1,0 +1,30 @@
+import Fluent
+import Foundation
+
+final class ContainerEntry: Model, @unchecked Sendable {
+    static let schema = "container_entries"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "container_type")
+    var containerType: String
+
+    @Field(key: "container_id")
+    var containerID: Int
+
+    @Parent(key: "preview_id")
+    var preview: Preview
+
+    @Field(key: "position")
+    var position: Int
+
+    init() {}
+
+    init(containerType: String, containerID: Int, previewID: UUID, position: Int) {
+        self.containerType = containerType
+        self.containerID = containerID
+        self.$preview.id = previewID
+        self.position = position
+    }
+}

--- a/tmbr/Sources/App/Modules/Previews/Models/Middlewares/PreviewModelMiddleware.swift
+++ b/tmbr/Sources/App/Modules/Previews/Models/Middlewares/PreviewModelMiddleware.swift
@@ -4,12 +4,18 @@ import Foundation
 import AuthKit
 
 protocol Previewable: Model where IDValue == Int {
-    
+
     static var previewType: String { get }
-    
+
     var access: Access { get }
-    
+
     var ownerID: UserID { get }
+
+    var adoptingPreviewID: UUID? { get }
+}
+
+extension Previewable {
+    var adoptingPreviewID: UUID? { nil }
 }
 
 final class PreviewModelMiddleware<M: Previewable>: AsyncModelMiddleware {
@@ -35,19 +41,34 @@ final class PreviewModelMiddleware<M: Previewable>: AsyncModelMiddleware {
         on db: any Database,
         next: any AnyAsyncModelResponder
     ) async throws {
-        let previewID = UUID()
-        try attach(previewID, model)
-        try await next.create(model, on: db)
-
-        var preview = Preview(
-            id: previewID,
-            parentID: try model.requireID(),
-            parentAccess: model.access,
-            parentOwner: model.ownerID,
-            parentType: M.previewType
-        )
-        try configure(&preview, model)
-        try await preview.save(on: db)
+        if let adoptingID = model.adoptingPreviewID {
+            try attach(adoptingID, model)
+            try await next.create(model, on: db)
+            guard var preview = try await Preview.find(adoptingID, on: db) else {
+                throw Abort(.notFound, reason: "Orphan preview not found for adoption")
+            }
+            preview.adopt(
+                parentID: try model.requireID(),
+                parentType: M.previewType,
+                parentAccess: model.access,
+                parentOwner: model.ownerID
+            )
+            try configure(&preview, model)
+            try await preview.save(on: db)
+        } else {
+            let previewID = UUID()
+            try attach(previewID, model)
+            try await next.create(model, on: db)
+            var preview = Preview(
+                id: previewID,
+                parentID: try model.requireID(),
+                parentAccess: model.access,
+                parentOwner: model.ownerID,
+                parentType: M.previewType
+            )
+            try configure(&preview, model)
+            try await preview.save(on: db)
+        }
     }
 
     func update(

--- a/tmbr/Sources/App/Modules/Previews/Models/Middlewares/PreviewModelMiddleware.swift
+++ b/tmbr/Sources/App/Modules/Previews/Models/Middlewares/PreviewModelMiddleware.swift
@@ -14,24 +14,24 @@ protocol Previewable: Model where IDValue == Int {
 
 final class PreviewModelMiddleware<M: Previewable>: AsyncModelMiddleware {
 
-    private let readPreviewID: @Sendable (M) -> PreviewID?
-
     private let attach: @Sendable (PreviewID, M) throws -> Void
 
     private let configure: @Sendable (inout Preview, M) throws -> Void
 
     private let fetch: @Sendable (M, Database) async throws -> Preview
 
+    private let previewID: @Sendable (M) -> PreviewID?
+
     init(
-        readPreviewID: @escaping @Sendable (M) -> PreviewID? = { _ in nil },
         attach: @escaping @Sendable (PreviewID, M) throws -> Void,
         configure: @escaping @Sendable (inout Preview, M) throws -> Void,
-        fetch: @escaping @Sendable (M, Database) async throws -> Preview
+        fetch: @escaping @Sendable (M, Database) async throws -> Preview,
+        previewID: @escaping @Sendable (M) -> PreviewID? = { _ in nil }
     ) {
-        self.readPreviewID = readPreviewID
         self.attach = attach
         self.configure = configure
         self.fetch = fetch
+        self.previewID = previewID
     }
 
     func create(
@@ -39,7 +39,8 @@ final class PreviewModelMiddleware<M: Previewable>: AsyncModelMiddleware {
         on db: any Database,
         next: any AnyAsyncModelResponder
     ) async throws {
-        if let adoptingID = readPreviewID(model) {
+        if let adoptingID = previewID(model) {
+            try attach(adoptingID, model)
             try await next.create(model, on: db)
             guard var preview = try await Preview.find(adoptingID, on: db) else {
                 throw Abort(.notFound, reason: "Orphan preview not found for adoption")
@@ -53,11 +54,11 @@ final class PreviewModelMiddleware<M: Previewable>: AsyncModelMiddleware {
             try configure(&preview, model)
             try await preview.save(on: db)
         } else {
-            let previewID = UUID()
-            try attach(previewID, model)
+            let newID = UUID()
+            try attach(newID, model)
             try await next.create(model, on: db)
             var preview = Preview(
-                id: previewID,
+                id: newID,
                 parentID: try model.requireID(),
                 parentAccess: model.access,
                 parentOwner: model.ownerID,

--- a/tmbr/Sources/App/Modules/Previews/Models/Middlewares/PreviewModelMiddleware.swift
+++ b/tmbr/Sources/App/Modules/Previews/Models/Middlewares/PreviewModelMiddleware.swift
@@ -10,39 +10,36 @@ protocol Previewable: Model where IDValue == Int {
     var access: Access { get }
 
     var ownerID: UserID { get }
-
-    var adoptingPreviewID: UUID? { get }
-}
-
-extension Previewable {
-    var adoptingPreviewID: UUID? { nil }
 }
 
 final class PreviewModelMiddleware<M: Previewable>: AsyncModelMiddleware {
-    
+
+    private let readPreviewID: @Sendable (M) -> PreviewID?
+
     private let attach: @Sendable (PreviewID, M) throws -> Void
-    
+
     private let configure: @Sendable (inout Preview, M) throws -> Void
-    
+
     private let fetch: @Sendable (M, Database) async throws -> Preview
-    
+
     init(
+        readPreviewID: @escaping @Sendable (M) -> PreviewID? = { _ in nil },
         attach: @escaping @Sendable (PreviewID, M) throws -> Void,
         configure: @escaping @Sendable (inout Preview, M) throws -> Void,
         fetch: @escaping @Sendable (M, Database) async throws -> Preview
     ) {
+        self.readPreviewID = readPreviewID
         self.attach = attach
         self.configure = configure
         self.fetch = fetch
     }
-    
+
     func create(
         model: M,
         on db: any Database,
         next: any AnyAsyncModelResponder
     ) async throws {
-        if let adoptingID = model.adoptingPreviewID {
-            try attach(adoptingID, model)
+        if let adoptingID = readPreviewID(model) {
             try await next.create(model, on: db)
             guard var preview = try await Preview.find(adoptingID, on: db) else {
                 throw Abort(.notFound, reason: "Orphan preview not found for adoption")

--- a/tmbr/Sources/App/Modules/Previews/Models/Migrations/CreateContainerEntries.swift
+++ b/tmbr/Sources/App/Modules/Previews/Models/Migrations/CreateContainerEntries.swift
@@ -1,0 +1,33 @@
+import Fluent
+import Foundation
+import SQLKit
+
+struct CreateContainerEntries: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(ContainerEntry.schema)
+            .id()
+            .field("container_type", .string, .required)
+            .field("container_id", .int, .required)
+            .field("preview_id", .uuid, .required, .references(Preview.schema, "id", onDelete: .cascade))
+            .field("position", .int, .required)
+            .unique(on: "container_type", "container_id", "preview_id")
+            .create()
+
+        if let sqlDB = database as? SQLDatabase {
+            try await sqlDB
+                .create(index: "idx_container_entries")
+                .on(ContainerEntry.schema)
+                .column("container_type")
+                .column("container_id")
+                .column("position")
+                .run()
+        }
+    }
+
+    func revert(on database: Database) async throws {
+        if let sqlDB = database as? SQLDatabase {
+            try await sqlDB.drop(index: "idx_container_entries").run()
+        }
+        try await database.schema(ContainerEntry.schema).delete()
+    }
+}

--- a/tmbr/Sources/App/Modules/Previews/Models/Migrations/ExtendPreview.swift
+++ b/tmbr/Sources/App/Modules/Previews/Models/Migrations/ExtendPreview.swift
@@ -1,0 +1,23 @@
+import Fluent
+import Foundation
+import SQLKit
+
+struct ExtendPreview: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        guard let sqlDB = database as? SQLDatabase else { return }
+        try await sqlDB.raw(#"ALTER TABLE previews DROP CONSTRAINT IF EXISTS "uq:previews.parent_type+parent_id""#).run()
+        try await sqlDB.raw("ALTER TABLE previews ALTER COLUMN parent_id DROP NOT NULL").run()
+        try await sqlDB.raw("""
+            CREATE UNIQUE INDEX uq_previews_parent_type_parent_id
+            ON previews (parent_type, parent_id)
+            WHERE parent_id IS NOT NULL
+            """).run()
+    }
+
+    func revert(on database: Database) async throws {
+        guard let sqlDB = database as? SQLDatabase else { return }
+        try await sqlDB.raw("DROP INDEX IF EXISTS uq_previews_parent_type_parent_id").run()
+        try await sqlDB.raw("ALTER TABLE previews ALTER COLUMN parent_id SET NOT NULL").run()
+        try await sqlDB.raw(#"ALTER TABLE previews ADD CONSTRAINT "uq:previews.parent_type+parent_id" UNIQUE (parent_type, parent_id)"#).run()
+    }
+}

--- a/tmbr/Sources/App/Modules/Previews/Models/Preview.swift
+++ b/tmbr/Sources/App/Modules/Previews/Models/Preview.swift
@@ -11,8 +11,8 @@ final class Preview: Model, @unchecked Sendable {
     @ID(custom: "id", generatedBy: .user)
     var id: UUID?
     
-    @Field(key: "parent_id")
-    private(set) var parentID: Int
+    @OptionalField(key: "parent_id")
+    private(set) var parentID: Int?
     
     @Enum(key: "parent_access")
     private(set) var parentAccess: Access
@@ -43,9 +43,16 @@ final class Preview: Model, @unchecked Sendable {
 
     init() {}
 
+    func adopt(parentID: Int, parentType: String, parentAccess: Access, parentOwner: UserID) {
+        self.parentID = parentID
+        self.parentType = parentType
+        self.parentAccess = parentAccess
+        self.$parentOwner.id = parentOwner
+    }
+
     init(
         id: UUID,
-        parentID: Int,
+        parentID: Int?,
         parentAccess: Access,
         parentOwner: UserID,
         parentType: String

--- a/tmbr/Sources/App/Modules/Previews/Previews.swift
+++ b/tmbr/Sources/App/Modules/Previews/Previews.swift
@@ -20,12 +20,16 @@ struct Previews: Module {
     func configure(_ app: Application) async throws {
         app.migrations.add(CreatePreview())
         app.migrations.add(AddPreviewParentAccessAndOwner())
+        app.migrations.add(ExtendPreview())
+        app.migrations.add(CreateContainerEntries())
 
         try await app.permissions.add(scope: permissions)
         try await app.commands.add(collection: commands)
     }
-    
-    func boot(_ routes: any Vapor.RoutesBuilder) async throws {}
+
+    func boot(_ routes: any Vapor.RoutesBuilder) async throws {
+        try routes.register(collection: PreviewsWebController())
+    }
 }
 
 extension Module where Self == Previews {

--- a/tmbr/Sources/App/Modules/Previews/Routes/API/Responses/PreviewResponse.swift
+++ b/tmbr/Sources/App/Modules/Previews/Routes/API/Responses/PreviewResponse.swift
@@ -5,11 +5,11 @@ import Foundation
 struct PreviewResponse: Content, Sendable {
 
     struct Source: Content, Sendable {
-        private let id: Int
+        private let id: Int?
 
         private let type: String
-        
-        init(id: Int, type: String) {
+
+        init(id: Int?, type: String) {
             self.id = id
             self.type = type
         }

--- a/tmbr/Sources/App/Modules/Previews/Routes/Web/Pages/Page+CatalogueItem.swift
+++ b/tmbr/Sources/App/Modules/Previews/Routes/Web/Pages/Page+CatalogueItem.swift
@@ -1,0 +1,56 @@
+import Vapor
+import Foundation
+import AuthKit
+import Core
+
+struct CatalogueItemViewModel: Encodable, Sendable {
+
+    private let title: String
+
+    private let subtitle: String?
+
+    private let artwork: ImageViewModel?
+
+    private let info: String?
+
+    private let notes: [NoteViewModel]
+
+    private let notesEndpoint: String
+
+    private let resources: [Hyperlink]
+
+    private let allowsNewNote: Bool
+
+    private let post: PostItemViewModel?
+
+    init(preview: Preview, baseURL: String) {
+        title = preview.primaryInfo
+        subtitle = preview.secondaryInfo
+        artwork = preview.image.flatMap { ImageViewModel(image: $0, baseURL: baseURL) }
+        info = nil
+        notes = []
+        notesEndpoint = "/catalogue/item/\(preview.id!)/notes"
+        resources = preview.externalLinks.compactMap { urlString in
+            guard let url = URL(string: urlString) else { return nil }
+            return Hyperlink(label: url.host ?? urlString, url: url)
+        }
+        allowsNewNote = false
+        post = nil
+    }
+}
+
+extension Template where Model == CatalogueItemViewModel {
+    static let catalogueItem = Template(name: "Catalogue/details")
+}
+
+extension Page {
+    static var catalogueItem: Self {
+        Page(template: .catalogueItem) { request in
+            guard let previewID = request.parameters.get("previewID", as: UUID.self) else {
+                throw Abort(.badRequest)
+            }
+            let preview = try await request.commands.previews.fetch(previewID, for: .read)
+            return CatalogueItemViewModel(preview: preview, baseURL: request.baseURL)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Previews/Routes/Web/PreviewViewModel.swift
+++ b/tmbr/Sources/App/Modules/Previews/Routes/Web/PreviewViewModel.swift
@@ -18,7 +18,11 @@ struct PreviewViewModel: Encodable, Sendable {
         primaryInfo = preview.primaryInfo
         secondaryInfo = preview.secondaryInfo
         thumbnailURL = preview.image.map { "\(baseURL)/gallery/data/\($0.thumbnailKey)" }
-        href = "/\(preview.parentType)s/\(preview.parentID)"
+        if let parentID = preview.parentID {
+            href = "/\(preview.parentType)s/\(parentID)"
+        } else {
+            href = "/catalogue/item/\(preview.id!)"
+        }
         created = (preview.createdAt ?? .now).formatted(.publishDate)
         self.isNoteMatch = isNoteMatch
     }

--- a/tmbr/Sources/App/Modules/Previews/Routes/Web/PreviewsWebController.swift
+++ b/tmbr/Sources/App/Modules/Previews/Routes/Web/PreviewsWebController.swift
@@ -1,0 +1,10 @@
+import Vapor
+import Core
+
+struct PreviewsWebController: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes
+            .grouped(RecoverMiddleware())
+            .get("catalogue", "item", ":previewID", page: .catalogueItem)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ContainerEntry` join table expressing "Preview X is in container Y at position N"; reused by playlists later with no new model
- Makes `parentID` on `Preview` nullable — orphan tracks have `parentType = "track"`, `parentID = nil`, and never surface in catalogue feed
- Album detail page fetches and renders its tracklist via `ContainerEntry`; unpromoted tracks show title only, promoted tracks link to `/songs/:id`
- `POST /songs/promote` auto-promotes an orphan track Preview into a full Song, adopting its existing Preview UUID so the ContainerEntry row is untouched
- `GET /catalogue/item/:id` renders a shallow detail page for orphan Previews that have no backing model
- Adoption path in `PreviewModelMiddleware.create` detects a pre-set `previewID` closure and reuses an existing orphan Preview instead of creating a new one

## Test plan
- [ ] Existing songs, albums, books, movies, podcasts create and update without regression
- [ ] Album detail page shows tracklist (empty for albums without imported tracks)
- [ ] Orphan track Preview renders at `/catalogue/item/:uuid`
- [ ] `POST /songs/promote` promotes a track and redirects to the new song's detail page; ContainerEntry row survives unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)