### PR TITLE
Stage 4: Apple Music JSON-LD tracklist import on album create

### DIFF
--- a/tmbr/Public/Styles/Shared/main.css
+++ b/tmbr/Public/Styles/Shared/main.css
@@ -236,7 +236,7 @@ main article > header {
     align-items: start;
     gap: 16px;
     width: 100%;
-    margin: 1em 0 2em 0;
+    margin: 1em 0 1em 0;
 }
 
 main article > header .details {
@@ -277,6 +277,24 @@ main article > header ul > li + li::before {
 
 main article > header ul > li > a:hover {
     color: LinkText !important;
+}
+
+main article > header #tracks-section {
+    margin-top: 1em;
+}
+
+main article > header #tracks-section h4 {
+    margin: 0 0 0.3em 0;
+}
+
+main article > header .tracklist {
+    margin: 0;
+    font-size: 1.5rem;
+    line-height: 1.6;
+}
+
+main article > header .tracklist li {
+    padding: 0;
 }
 
 main article > header .artwork {

--- a/tmbr/Resources/Views/Catalogue/Albums/album-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Albums/album-editor.leaf
@@ -52,6 +52,7 @@
         autocomplete="off"
         spellcheck="true"
     />
+    <input id="editor-tracklist-json" type="hidden" name="tracklist-json" value="" />
     #endexport
 
     #export("editor-image-picker"):

--- a/tmbr/Resources/Views/Catalogue/Albums/album.leaf
+++ b/tmbr/Resources/Views/Catalogue/Albums/album.leaf
@@ -8,6 +8,22 @@
         <p>#(info)</p>
         #endif
         #extend("Catalogue/resources")
+        #if(tracks):
+        <section id="tracks-section">
+            <h4>Tracklist</h4>
+            <ol class="tracklist">
+                #for(track in tracks):
+                <li>
+                    #if(track.href):
+                    <a href="#(track.href)">#(track.title)</a>
+                    #else:
+                    <span>#(track.title)</span>
+                    #endif
+                </li>
+                #endfor
+            </ol>
+        </section>
+        #endif
     </div>
     #if(artwork):
     <div class="artwork">
@@ -17,22 +33,6 @@
     #endexport
 
     #export("detail-body"):
-    #if(tracks):
-    <section id="tracks-section">
-        <h3>Tracklist</h3>
-        <ol class="tracklist">
-            #for(track in tracks):
-            <li>
-                #if(track.href):
-                <a href="#(track.href)">#(track.title)</a>
-                #else:
-                <span>#(track.title)</span>
-                #endif
-            </li>
-            #endfor
-        </ol>
-    </section>
-    #endif
     #endexport
 
 #endextend

--- a/tmbr/Sources/App/Modules/Catalogue/Albums/Commands/Command/AlbumInput.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Albums/Commands/Command/AlbumInput.swift
@@ -19,6 +19,8 @@ struct AlbumInput {
 
     fileprivate let title: String
 
+    let tracks: [TrackMetadata]?
+
     init(
         access: Access,
         artist: String,
@@ -26,7 +28,8 @@ struct AlbumInput {
         genre: String?,
         releaseDate: Date?,
         resourceURLs: [String],
-        title: String
+        title: String,
+        tracks: [TrackMetadata]? = nil
     ) {
         self.access = access
         self.artist = artist
@@ -35,6 +38,7 @@ struct AlbumInput {
         self.releaseDate = releaseDate
         self.resourceURLs = resourceURLs
         self.title = title
+        self.tracks = tracks
     }
 
     init(payload: AlbumPayload) {

--- a/tmbr/Sources/App/Modules/Catalogue/Albums/Routes/Web/AlbumEditorPayload.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Albums/Routes/Web/AlbumEditorPayload.swift
@@ -20,6 +20,8 @@ struct AlbumEditorPayload: Decodable, Sendable {
 
     let releaseDate: Date?
 
+    private let tracklistJSONRaw: String?
+
     let resourceURLs: [String]
 
     let title: String
@@ -38,6 +40,12 @@ struct AlbumEditorPayload: Decodable, Sendable {
         resourceURLs.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
     }
 
+    var tracks: [TrackMetadata]? {
+        guard let raw = tracklistJSONRaw, !raw.isEmpty,
+              let data = raw.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode([TrackMetadata].self, from: data)
+    }
+
     enum CodingKeys: String, CodingKey {
         case _csrf
         case access
@@ -49,6 +57,7 @@ struct AlbumEditorPayload: Decodable, Sendable {
         case releaseDate = "release-date"
         case resourceURLs
         case title
+        case tracklistJSONRaw = "tracklist-json"
     }
 
     init(
@@ -61,7 +70,8 @@ struct AlbumEditorPayload: Decodable, Sendable {
         notes: [NotePayload] = [],
         releaseDate: Date? = nil,
         resourceURLs: [String] = [],
-        title: String = ""
+        title: String = "",
+        tracklistJSONRaw: String? = nil
     ) {
         self._csrf = _csrf
         self.access = access
@@ -73,6 +83,7 @@ struct AlbumEditorPayload: Decodable, Sendable {
         self.releaseDate = releaseDate
         self.resourceURLs = resourceURLs
         self.title = title
+        self.tracklistJSONRaw = tracklistJSONRaw
     }
 }
 
@@ -86,7 +97,8 @@ extension AlbumInput {
             genre: payload.genre,
             releaseDate: payload.releaseDate,
             resourceURLs: payload.filteredResourceURLs,
-            title: payload.title
+            title: payload.title,
+            tracks: payload.tracks
         )
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Albums/Routes/Web/AlbumsWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Albums/Routes/Web/AlbumsWebController.swift
@@ -93,6 +93,17 @@ struct AlbumsWebController: RouteCollection {
                         NoteInput(body: entry.body, access: entry.access && payload.access)
                     }
                     _ = try await commands.notes.batchCreate(noteInputs, for: preview)
+                    if let tracks = albumInput.tracks, !tracks.isEmpty {
+                        try await commands.previews.importTracks(
+                            ImportAlbumTracksInput(
+                                albumID: try album.requireID(),
+                                access: payload.access,
+                                artist: payload.artist,
+                                ownerID: preview.$parentOwner.id,
+                                tracks: tracks
+                            )
+                        )
+                    }
                 case .update(let albumID):
                     album = try await commands.albums.edit(albumInput.edit(id: albumID))
                     let preview = try await commands.previews.fetch(album.$preview.id, for: .write)

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Commands/Command+Metadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Commands/Command+Metadata.swift
@@ -17,13 +17,13 @@ struct Metadata: @unchecked Sendable {
 }
 
 struct FetchMetadataCommand: Command {
-    
+
     private let client: Client
-    
+
     private let parser: HTMLMetadataParser
-    
+
     private let permission: AuthPermissionResolver<Void>
-    
+
     init(
         client: Client,
         parser: HTMLMetadataParser = .init(),
@@ -33,26 +33,31 @@ struct FetchMetadataCommand: Command {
         self.parser = parser
         self.permission = permission
     }
-    
+
     func execute(_ url: URL) async throws -> Metadata {
         try await permission.grant()
 
         var headers = HTTPHeaders()
         headers.add(name: .userAgent, value: "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)")
         headers.add(name: .accept, value: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+        headers.add(name: .acceptEncoding, value: "identity")
         headers.add(name: .acceptLanguage, value: "en-US,en;q=0.9")
 
         let response = try await client.get(URI(string: url.absoluteString), headers: headers)
-        
+
         guard (200..<300).contains(response.status.code) else {
             throw Abort(.badGateway, reason: "Metadata fetch failed. Upstream returned \(response.status.code)")
         }
-        guard let body = response.body,
-              let data = body.getData(at: 0, length: body.readableBytes),
-              let html = String(data: data, encoding: .utf8) else {
+        guard let body = response.body else {
             throw Abort(.badGateway, reason: "Metadata fetch failed. Response HTML is invalid or missing")
         }
-        
+        guard let data = body.getData(at: 0, length: body.readableBytes) else {
+            throw Abort(.badGateway, reason: "Metadata fetch failed. Response HTML is invalid or missing")
+        }
+        guard let html = String(data: data, encoding: .utf8) else {
+            throw Abort(.badGateway, reason: "Metadata fetch failed. Response HTML is invalid or missing")
+        }
+
         let (tags, json) = parser.parse(html: html)
 
         guard let type = tags["og:type"] else {
@@ -69,7 +74,7 @@ struct FetchMetadataCommand: Command {
 }
 
 extension CommandFactory<URL, Metadata> {
-    
+
     static var fetchMetadata: Self {
         CommandFactory { request in
             FetchMetadataCommand(

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Commands/Command+Metadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Commands/Command+Metadata.swift
@@ -36,8 +36,13 @@ struct FetchMetadataCommand: Command {
     
     func execute(_ url: URL) async throws -> Metadata {
         try await permission.grant()
-        
-        let response = try await client.get(URI(string: url.absoluteString))
+
+        var headers = HTTPHeaders()
+        headers.add(name: .userAgent, value: "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)")
+        headers.add(name: .accept, value: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+        headers.add(name: .acceptLanguage, value: "en-US,en;q=0.9")
+
+        let response = try await client.get(URI(string: url.absoluteString), headers: headers)
         
         guard (200..<300).contains(response.status.code) else {
             throw Abort(.badGateway, reason: "Metadata fetch failed. Upstream returned \(response.status.code)")

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Metadata/HTMLMetadataParser.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Metadata/HTMLMetadataParser.swift
@@ -113,8 +113,8 @@ struct HTMLMetadataParser {
     // Named scripts (with an `id` attribute) are keyed by their id in the result dict.
     // The first unnamed script's top-level keys are merged into the root for backward compat.
     private func parseJSONLD(from html: String) -> [String: Any] {
-        let scriptPattern = #"<script\b([^>]*)\btype=["']application/ld\+json["']([^>]*)>([\s\S]*?)</script>"#
-        let idPattern = #"\bid=["']([^"']+)["']"#
+        let scriptPattern = #"<script\b([^>]*)\btype=["']?application/ld\+json["']?([^>]*)>([\s\S]*?)</script>"#
+        let idPattern = #"\bid=["']?([^"'\s>]+)["']?"#
         guard let scriptRE = try? NSRegularExpression(pattern: scriptPattern, options: [.caseInsensitive]),
               let idRE = try? NSRegularExpression(pattern: idPattern, options: [.caseInsensitive]) else { return [:] }
 

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Metadata/HTMLMetadataParser.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Metadata/HTMLMetadataParser.swift
@@ -109,18 +109,40 @@ struct HTMLMetadataParser {
         return String(text[r])
     }
 
-    // Extracts fields from the first <script type="application/ld+json"> block in the full HTML.
-    // Top-level string values are stored as "ld:<key>"; nested author objects are flattened to "ld:author".
+    // Extracts all <script type="application/ld+json"> blocks from the HTML.
+    // Named scripts (with an `id` attribute) are keyed by their id in the result dict.
+    // The first unnamed script's top-level keys are merged into the root for backward compat.
     private func parseJSONLD(from html: String) -> [String: Any] {
-        let pattern = #"<script[^>]+type=["']application/ld\+json["'][^>]*>([\s\S]*?)</script>"#
-        guard let re = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
-              let m = re.firstMatch(in: html, range: NSRange(html.startIndex..., in: html)),
-              let range = Range(m.range(at: 1), in: html),
-              let data = html[range].data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return [:]
+        let scriptPattern = #"<script\b([^>]*)\btype=["']application/ld\+json["']([^>]*)>([\s\S]*?)</script>"#
+        let idPattern = #"\bid=["']([^"']+)["']"#
+        guard let scriptRE = try? NSRegularExpression(pattern: scriptPattern, options: [.caseInsensitive]),
+              let idRE = try? NSRegularExpression(pattern: idPattern, options: [.caseInsensitive]) else { return [:] }
+
+        var result: [String: Any] = [:]
+        var foundDefault = false
+        let nsRange = NSRange(html.startIndex..., in: html)
+
+        scriptRE.enumerateMatches(in: html, range: nsRange) { match, _, _ in
+            guard let match,
+                  let contentRange = Range(match.range(at: 3), in: html),
+                  let data = html[contentRange].data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+
+            let attrsBefore = Range(match.range(at: 1), in: html).map { String(html[$0]) } ?? ""
+            let attrsAfter = Range(match.range(at: 2), in: html).map { String(html[$0]) } ?? ""
+            let attrs = attrsBefore + attrsAfter
+            let nsAttrs = NSRange(attrs.startIndex..., in: attrs)
+
+            if let idMatch = idRE.firstMatch(in: attrs, range: nsAttrs),
+               let idRange = Range(idMatch.range(at: 1), in: attrs) {
+                result[String(attrs[idRange])] = json
+            } else if !foundDefault {
+                json.forEach { result[$0] = $1 }
+                foundDefault = true
+            }
         }
-        return json
+
+        return result
     }
 
     // Minimal HTML entity decoding for common cases

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Metadata/HTMLMetadataParser.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Metadata/HTMLMetadataParser.swift
@@ -116,7 +116,9 @@ struct HTMLMetadataParser {
         let scriptPattern = #"<script\b([^>]*)\btype=["']?application/ld\+json["']?([^>]*)>([\s\S]*?)</script>"#
         let idPattern = #"\bid=["']?([^"'\s>]+)["']?"#
         guard let scriptRE = try? NSRegularExpression(pattern: scriptPattern, options: [.caseInsensitive]),
-              let idRE = try? NSRegularExpression(pattern: idPattern, options: [.caseInsensitive]) else { return [:] }
+              let idRE = try? NSRegularExpression(pattern: idPattern, options: [.caseInsensitive]) else {
+            return [:]
+        }
 
         var result: [String: Any] = [:]
         var foundDefault = false
@@ -124,8 +126,9 @@ struct HTMLMetadataParser {
 
         scriptRE.enumerateMatches(in: html, range: nsRange) { match, _, _ in
             guard let match,
-                  let contentRange = Range(match.range(at: 3), in: html),
-                  let data = html[contentRange].data(using: .utf8),
+                  let contentRange = Range(match.range(at: 3), in: html) else { return }
+            let content = html[contentRange]
+            guard let data = content.data(using: .utf8),
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
 
             let attrsBefore = Range(match.range(at: 1), in: html).map { String(html[$0]) } ?? ""

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicAlbum.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicAlbum.swift
@@ -17,16 +17,17 @@ extension MetadataExtractor where M == AlbumMetadata {
             return url.absoluteString
         }
 
-        // Apple Music album JSON-LD is in the script tagged id="schema:music-album"
-        let albumJSON = metadata.json["schema:music-album"] as? [String: Any]
+        // Apple Music album JSON-LD is in the script tagged id="schema:music-album".
+        // Some bot user-agents receive the JSON-LD without the id attribute, in which case
+        // parseJSONLD merges its keys to root level — detect via @type fallback.
+        let albumJSON: [String: Any]? = (metadata.json["schema:music-album"] as? [String: Any])
+            ?? (metadata.json["@type"] as? String == "MusicAlbum" ? metadata.json : nil)
 
-        // Use byArtist from JSON-LD as primary source — avoids an extra network request
-        let artistFromJSON = (albumJSON?["byArtist"] as? [[String: Any]])?.first?["name"] as? String
+        let artist = (albumJSON?["byArtist"] as? [[String: Any]])?.first?["name"] as? String
             ?? (albumJSON?["byArtist"] as? [String: Any])?["name"] as? String
-        let artist = artistFromJSON ?? metadata.tags["apple:title"].flatMap { _ in
-            // Fall back to fetching the musician page only if JSON-LD has no artist
-            nil as String?
-        }
+
+        let genre = (albumJSON?["genre"] as? [String])?.first
+            ?? albumJSON?["genre"] as? String
 
         let tracks: [TrackMetadata]? = (albumJSON?["tracks"] as? [[String: Any]])?.compactMap { track in
             guard let name = track["name"] as? String else { return nil }
@@ -37,6 +38,7 @@ extension MetadataExtractor where M == AlbumMetadata {
             artist: artist,
             artwork: artwork,
             externalID: metadata.tags["apple:content_id"],
+            genre: genre,
             releaseDate: albumJSON?["datePublished"] as? String ?? metadata.tags["music:release_date"],
             title: metadata.tags["apple:title"],
             tracks: tracks?.isEmpty == false ? tracks : nil

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicAlbum.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicAlbum.swift
@@ -3,33 +3,43 @@ import Foundation
 extension MetadataExtractor where M == AlbumMetadata {
 
     static let appleMusicAlbum = MetadataExtractor { url, fetcher in
-        let album = try await fetcher(url)
-        guard album.type == "music.album" else {
-            throw MetadataExtractionError.invalidType(expected: "music.album", actual: album.type)
+        let metadata = try await fetcher(url)
+        guard metadata.type == "music.album" else {
+            throw MetadataExtractionError.invalidType(expected: "music.album", actual: metadata.type)
         }
-
-        async let artist = extract(
-            key: "apple:title",
-            from: album.tags["music:musician"],
-            of: "music.musician",
-            with: fetcher
-        )
 
         // Transform og:image URL to get square artwork
         // Original: .../1200x630bf-60.jpg -> Changed to: .../1000x1000.jpg
-        let artwork = album.tags["og:image"].flatMap { urlString -> String? in
+        let artwork = metadata.tags["og:image"].flatMap { urlString -> String? in
             guard var url = URL(string: urlString) else { return nil }
             url.deleteLastPathComponent()
             url.appendPathComponent("1000x1000.jpg")
             return url.absoluteString
         }
 
+        // Apple Music album JSON-LD is in the script tagged id="schema:music-album"
+        let albumJSON = metadata.json["schema:music-album"] as? [String: Any]
+
+        // Use byArtist from JSON-LD as primary source — avoids an extra network request
+        let artistFromJSON = (albumJSON?["byArtist"] as? [[String: Any]])?.first?["name"] as? String
+            ?? (albumJSON?["byArtist"] as? [String: Any])?["name"] as? String
+        let artist = artistFromJSON ?? metadata.tags["apple:title"].flatMap { _ in
+            // Fall back to fetching the musician page only if JSON-LD has no artist
+            nil as String?
+        }
+
+        let tracks: [TrackMetadata]? = (albumJSON?["tracks"] as? [[String: Any]])?.compactMap { track in
+            guard let name = track["name"] as? String else { return nil }
+            return TrackMetadata(name: name, url: track["url"] as? String)
+        }
+
         return AlbumMetadata(
-            artist: try? await artist,
+            artist: artist,
             artwork: artwork,
-            externalID: album.tags["apple:content_id"],
-            releaseDate: album.tags["music:release_date"],
-            title: album.tags["apple:title"]
+            externalID: metadata.tags["apple:content_id"],
+            releaseDate: albumJSON?["datePublished"] as? String ?? metadata.tags["music:release_date"],
+            title: metadata.tags["apple:title"],
+            tracks: tracks?.isEmpty == false ? tracks : nil
         )
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicAlbum.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicAlbum.swift
@@ -8,8 +8,6 @@ extension MetadataExtractor where M == AlbumMetadata {
             throw MetadataExtractionError.invalidType(expected: "music.album", actual: metadata.type)
         }
 
-        // Transform og:image URL to get square artwork
-        // Original: .../1200x630bf-60.jpg -> Changed to: .../1000x1000.jpg
         let artwork = metadata.tags["og:image"].flatMap { urlString -> String? in
             guard var url = URL(string: urlString) else { return nil }
             url.deleteLastPathComponent()
@@ -17,11 +15,9 @@ extension MetadataExtractor where M == AlbumMetadata {
             return url.absoluteString
         }
 
-        // Apple Music album JSON-LD is in the script tagged id="schema:music-album".
-        // Some bot user-agents receive the JSON-LD without the id attribute, in which case
-        // parseJSONLD merges its keys to root level — detect via @type fallback.
-        let albumJSON: [String: Any]? = (metadata.json["schema:music-album"] as? [String: Any])
-            ?? (metadata.json["@type"] as? String == "MusicAlbum" ? metadata.json : nil)
+        let namedBlock = metadata.json["schema:music-album"] as? [String: Any]
+        let atTypeFallback = metadata.json["@type"] as? String == "MusicAlbum" ? metadata.json : nil
+        let albumJSON: [String: Any]? = namedBlock ?? atTypeFallback
 
         let artist = (albumJSON?["byArtist"] as? [[String: Any]])?.first?["name"] as? String
             ?? (albumJSON?["byArtist"] as? [String: Any])?["name"] as? String

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/AlbumMetadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/AlbumMetadata.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Vapor
 
+struct TrackMetadata: Codable, Sendable {
+    let name: String
+    let url: String?
+}
+
 struct AlbumMetadata: Encodable, AsyncResponseEncodable, Sendable {
 
     let artist: String?
@@ -12,4 +17,6 @@ struct AlbumMetadata: Encodable, AsyncResponseEncodable, Sendable {
     let releaseDate: String?
 
     let title: String?
+
+    let tracks: [TrackMetadata]?
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/AlbumMetadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/AlbumMetadata.swift
@@ -14,6 +14,8 @@ struct AlbumMetadata: Encodable, AsyncResponseEncodable, Sendable {
 
     let externalID: String?
 
+    let genre: String?
+
     let releaseDate: String?
 
     let title: String?

--- a/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+ImportAlbumTracks.swift
+++ b/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+ImportAlbumTracks.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Vapor
+import Core
+import Fluent
+import AuthKit
+
+struct ImportAlbumTracksInput: Sendable {
+    let albumID: AlbumID
+    let access: Access
+    let artist: String
+    let ownerID: UserID
+    let tracks: [TrackMetadata]
+}
+
+extension Command where Self == PlainCommand<ImportAlbumTracksInput, Void> {
+    static func importAlbumTracks(database: Database) -> Self {
+        PlainCommand { input in
+            for (index, track) in input.tracks.enumerated() {
+                var preview = Preview(
+                    id: UUID(),
+                    parentID: nil,
+                    parentAccess: input.access,
+                    parentOwner: input.ownerID,
+                    parentType: "track"
+                )
+                preview.primaryInfo = track.name
+                preview.secondaryInfo = "by \(input.artist)"
+                preview.externalLinks = [track.url].compactMap { $0 }
+                try await preview.save(on: database)
+
+                let entry = ContainerEntry(
+                    containerType: "album",
+                    containerID: input.albumID,
+                    previewID: try preview.requireID(),
+                    position: index + 1
+                )
+                try await entry.save(on: database)
+            }
+        }
+    }
+}
+
+extension CommandFactory<ImportAlbumTracksInput, Void> {
+    static var importAlbumTracks: Self {
+        CommandFactory { request in
+            .importAlbumTracks(database: request.commandDB)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Previews/Commands/Commands+Previews.swift
+++ b/tmbr/Sources/App/Modules/Previews/Commands/Commands+Previews.swift
@@ -12,6 +12,8 @@ extension Commands {
 
         let fetchContainerEntry: CommandFactory<ContainerEntryInput, ContainerEntry>
 
+        let importTracks: CommandFactory<ImportAlbumTracksInput, Void>
+
         let list: CommandFactory<PreviewQueryInput, [Preview]>
 
         let listContainerEntries: CommandFactory<ContainerEntriesInput, [ContainerEntry]>
@@ -19,11 +21,13 @@ extension Commands {
         init(
             fetch: CommandFactory<FetchParameters<PreviewID>, Preview> = .fetchPreview,
             fetchContainerEntry: CommandFactory<ContainerEntryInput, ContainerEntry> = .fetchContainerEntry,
+            importTracks: CommandFactory<ImportAlbumTracksInput, Void> = .importAlbumTracks,
             list: CommandFactory<PreviewQueryInput, [Preview]> = .listPreviews,
             listContainerEntries: CommandFactory<ContainerEntriesInput, [ContainerEntry]> = .listContainerEntries
         ) {
             self.fetch = fetch
             self.fetchContainerEntry = fetchContainerEntry
+            self.importTracks = importTracks
             self.list = list
             self.listContainerEntries = listContainerEntries
         }


### PR DESCRIPTION
## Summary
- Parses `<script id="schema:music-album" type="application/ld+json">` from Apple Music album pages to extract tracklist
- Stores tracklist JSON in a hidden form field; on album create, creates orphan `Preview` + `ContainerEntry` rows for each track
- Skips tracklist import on album update to protect already-promoted songs

## Test plan
- [ ] Create a new album with an Apple Music URL — tracklist should auto-populate and save as orphan Previews
- [ ] Update an existing album — existing track Previews should not be re-imported or duplicated
- [ ] Album detail page shows the imported tracklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)