### PR TITLE
Stage 5: Playlist shell — model, CRUD, API, web routes, views

### DIFF
--- a/tmbr/Public/Scripts/Catalogue/Playlists/playlist-editor.js
+++ b/tmbr/Public/Scripts/Catalogue/Playlists/playlist-editor.js
@@ -28,9 +28,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const artwork = new ArtworkController({
         hiddenInput:      document.getElementById('editor-artwork-id'),
         externalUrlInput: document.getElementById('editor-artwork-source-url'),
-        placeholder:      document.getElementById('cover-placeholder'),
-        imageEl:          document.getElementById('cover-image'),
-        clearButton:      document.getElementById('cover-clear'),
+        placeholder:      document.getElementById('artwork-placeholder'),
+        imageEl:          document.getElementById('artwork-image'),
+        clearButton:      document.getElementById('artwork-clear'),
     }, {
         onChange:      () => saveDraft(),
         onOpenGallery: () => imagePicker.open('image'),

--- a/tmbr/Public/Scripts/Catalogue/Playlists/playlist-editor.js
+++ b/tmbr/Public/Scripts/Catalogue/Playlists/playlist-editor.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+    CatalogueEditorController.init({
+        type: 'playlist',
+        imageTitle: 'Select playlist artwork',
+        extraFields: [],
+        previewMappings: [
+            { sourceId: 'editor-description', outputId: 'preview-description' },
+        ],
+    });
+});

--- a/tmbr/Public/Scripts/Catalogue/Playlists/playlist-editor.js
+++ b/tmbr/Public/Scripts/Catalogue/Playlists/playlist-editor.js
@@ -28,9 +28,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const artwork = new ArtworkController({
         hiddenInput:      document.getElementById('editor-artwork-id'),
         externalUrlInput: document.getElementById('editor-artwork-source-url'),
-        placeholder:      document.getElementById('artwork-placeholder'),
-        imageEl:          document.getElementById('artwork-image'),
-        clearButton:      document.getElementById('artwork-clear'),
+        placeholder:      document.getElementById('cover-placeholder'),
+        imageEl:          document.getElementById('cover-image'),
+        clearButton:      document.getElementById('cover-clear'),
     }, {
         onChange:      () => saveDraft(),
         onOpenGallery: () => imagePicker.open('image'),

--- a/tmbr/Public/Scripts/Catalogue/Playlists/playlist-editor.js
+++ b/tmbr/Public/Scripts/Catalogue/Playlists/playlist-editor.js
@@ -1,10 +1,155 @@
 document.addEventListener('DOMContentLoaded', () => {
-    CatalogueEditorController.init({
-        type: 'playlist',
-        imageTitle: 'Select playlist artwork',
-        extraFields: [],
-        previewMappings: [
-            { sourceId: 'editor-description', outputId: 'preview-description' },
-        ],
+    const form = document.getElementById('editor-form');
+    if (!form) return;
+
+    const idInput            = document.getElementById('editor-id');
+    const titleInput         = document.getElementById('editor-title');
+    const descriptionInput   = document.getElementById('editor-description');
+    const tracklistJsonInput = document.getElementById('editor-tracklist-json');
+    const statusEl           = document.getElementById('autofill-status');
+
+    const resourcesSection = document.getElementById('resources-section');
+    const detailsSection   = document.getElementById('details-section');
+    const notesSection     = document.getElementById('notes-section');
+    const gallery          = document.getElementById('gallery');
+    const gallerySection   = document.getElementById('gallery-section');
+    const galleryStatus    = document.getElementById('gallery-status');
+    const galleryTitle     = document.getElementById('gallery-title');
+    const notesGalleryOpen = document.getElementById('notes-gallery-open');
+    const galleryClose     = document.getElementById('gallery-close');
+
+    const persistence = new PersistenceController();
+    const uploads     = new UploadsController();
+    const metadata    = new MetadataController({ endpoint: '/playlists/metadata' });
+
+    const itemID     = idInput?.value || '';
+    const storageKey = itemID ? `editor:playlist:${itemID}` : 'editor:playlist:new';
+
+    const artwork = new ArtworkController({
+        hiddenInput:      document.getElementById('editor-artwork-id'),
+        externalUrlInput: document.getElementById('editor-artwork-source-url'),
+        placeholder:      document.getElementById('artwork-placeholder'),
+        imageEl:          document.getElementById('artwork-image'),
+        clearButton:      document.getElementById('artwork-clear'),
+    }, {
+        onChange:      () => saveDraft(),
+        onOpenGallery: () => imagePicker.open('image'),
+    });
+    artwork.init();
+
+    const notes = new NotesController(
+        { section: notesSection },
+        { onInput: () => saveDraft(), onAccessChange: () => saveDraft() }
+    );
+    notes.init();
+
+    // No lookup for playlists
+    const duplicateAlert = new DuplicateAlertController(
+        { containerEl: document.getElementById('duplicate-container'), linkSelector: '#duplicate-playlist-link' },
+        { onNavigate: () => persistence.clear(storageKey) }
+    );
+    duplicateAlert.init();
+
+    const resourceInputs = new ResourceInputsController(
+        { section: resourcesSection },
+        { onUrlChange: (url) => autofill.fetchAndApply(url), onInput: () => saveDraft() }
+    );
+    resourceInputs.init();
+
+    function getState() {
+        return {
+            title:              titleInput?.value || '',
+            description:        descriptionInput?.value || '',
+            notes:              notes.getNotes(),
+            resourceURLs:       resourceInputs.getValues(),
+            artworkId:          artwork.getArtworkId(),
+            artworkThumbnailUrl: artwork.getThumbnailUrl(),
+            artworkExternalURL: artwork.getExternalURL(),
+        };
+    }
+
+    function setState(state) {
+        if (!state || typeof state !== 'object') return;
+        if (typeof state.title === 'string' && !titleInput.value) titleInput.value = state.title;
+        if (typeof state.description === 'string' && !descriptionInput.value) descriptionInput.value = state.description;
+        if (Array.isArray(state.notes)) notes.setNotes(state.notes, true);
+        if (Array.isArray(state.resourceURLs)) resourceInputs.setValues(state.resourceURLs);
+        if (artwork.isEmpty()) {
+            if (state.artworkId) artwork.setArtwork(state.artworkId, state.artworkThumbnailUrl);
+            else if (state.artworkExternalURL) artwork.setExternalURL(state.artworkExternalURL);
+        }
+    }
+
+    function saveDraft() { persistence.save(storageKey, getState()); }
+    function loadDraft() {
+        if (persistence.clearIfPending(storageKey)) return;
+        const saved = persistence.load(storageKey);
+        if (saved) setState(saved);
+    }
+
+    function applyMetadata(data) {
+        if (!titleInput.value && data.title) titleInput.value = data.title;
+        if (!descriptionInput.value && data.description) descriptionInput.value = data.description;
+        if (data.artwork && artwork.isEmpty()) artwork.setExternalURL(data.artwork);
+        if (Array.isArray(data.tracks) && data.tracks.length > 0 && tracklistJsonInput) {
+            tracklistJsonInput.value = JSON.stringify(data.tracks);
+        }
+    }
+
+    function fillPreview() {
+        const pf = document.getElementById('preview-form');
+        if (!pf) return;
+        const set = (id, v) => { const el = pf.querySelector(`#${id}`); if (el) el.value = v || ''; };
+        set('preview-title',        titleInput?.value || '');
+        set('preview-description',  descriptionInput?.value || '');
+        set('preview-artwork-url',  artwork.getThumbnailUrl());
+        set('preview-resource-urls', resourceInputs.getValues().join('\n'));
+        set('preview-notes',        notes.getValues().join('\n\n'));
+        pf.submit();
+    }
+
+    const autofill = {
+        async fetchAndApply(url) {
+            try {
+                const data = await metadata.fetch(url);
+                applyMetadata(data);
+                if (statusEl) { statusEl.textContent = ''; statusEl.hidden = true; }
+                saveDraft();
+            } catch (err) {
+                console.error(err);
+                handleAutofillError(err, url, statusEl);
+            }
+        }
+    };
+
+    retryPendingMetadata(autofill);
+    loadDraft();
+
+    titleInput?.addEventListener('input', saveDraft);
+    descriptionInput?.addEventListener('input', saveDraft);
+
+    const imagePicker = new ImagePickerController(
+        { gallery, gallerySection, galleryStatus, galleryTitle, notesOpenButton: notesGalleryOpen, galleryCloseButton: galleryClose },
+        { onSelectImage: (id, url) => artwork.setArtwork(id, url), onInsertMarkdown: (md) => notes.insertMarkdown(md), imageTitle: 'Select playlist artwork' }
+    );
+    imagePicker.init();
+
+    new DragAndDropController({ resourcesSection, detailsSection, notesSection }, { uploads, artwork, notes }).init();
+    new ShortcutsController([ShortcutsController.login, ShortcutsController.preview(() => fillPreview())]).init();
+
+    document.getElementById('editor-preview')?.addEventListener('click', () => fillPreview());
+
+    form.addEventListener('keydown', (e) => {
+        if (e.key !== 'Enter' || e.target.tagName !== 'INPUT') return;
+        e.preventDefault();
+        const focusable = Array.from(form.querySelectorAll('input:not([type="hidden"]), textarea')).filter(el => !el.disabled);
+        const idx = focusable.indexOf(e.target);
+        if (idx !== -1 && idx < focusable.length - 1) focusable[idx + 1].focus();
+    });
+
+    form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        persistence.markPendingClear(storageKey);
+        form.submit();
     });
 });

--- a/tmbr/Resources/Views/Catalogue/Playlists/playlist-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Playlists/playlist-editor.leaf
@@ -28,6 +28,14 @@
     <input id="editor-tracklist-json" type="hidden" name="tracklist-json" value="" />
     #endexport
 
+    #export("editor-image-picker"):
+    <figure id="artwork-placeholder" class="image-picker #if(!artworkThumbnailURL):empty#endif">
+        <img id="artwork-image" src="#(artworkThumbnailURL)" alt="Artwork" />
+        <span>#extend("Icons/gallery")</span>
+        <button id="artwork-clear" type="button" class="icon">#extend("Icons/trash")</button>
+    </figure>
+    #endexport
+
     #export("editor-preview-form"):
     <form id="preview-form" method="post" action="/playlists/preview" target="_blank" hidden>
         <input type="hidden" name="title" id="preview-title" />

--- a/tmbr/Resources/Views/Catalogue/Playlists/playlist-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Playlists/playlist-editor.leaf
@@ -1,0 +1,42 @@
+#extend("Catalogue/editor"):
+
+    #export("editor-title-input"):
+    <input
+        id="editor-title"
+        class="text-input title"
+        name="title"
+        type="text"
+        value="#(title)"
+        placeholder="Playlist title"
+        autocomplete="off"
+        spellcheck="true"
+    />
+    #endexport
+
+    #export("editor-fields"):
+    <textarea
+        id="editor-description"
+        class="text-input"
+        name="description"
+        placeholder="Description"
+        autocomplete="off"
+        spellcheck="true"
+        rows="3"
+    >#(description)</textarea>
+    #endexport
+
+    #export("editor-preview-form"):
+    <form id="preview-form" method="post" action="/playlists/preview" target="_blank" hidden>
+        <input type="hidden" name="title" id="preview-title" />
+        <input type="hidden" name="description" id="preview-description" />
+        <input type="hidden" name="artworkURL" id="preview-artwork-url" />
+        <input type="hidden" name="resourceURLs" id="preview-resource-urls" />
+        <input type="hidden" name="notes" id="preview-notes" />
+    </form>
+    #endexport
+
+    #export("editor-type-script"):
+    <script src="/Scripts/Catalogue/Playlists/playlist-editor.js"></script>
+    #endexport
+
+#endextend

--- a/tmbr/Resources/Views/Catalogue/Playlists/playlist-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Playlists/playlist-editor.leaf
@@ -14,6 +14,8 @@
     #endexport
 
     #export("editor-fields"):
+    <input id="editor-artwork-id" type="hidden" name="artwork-id" value="#(artworkId)" />
+    <input id="editor-artwork-source-url" type="hidden" name="artwork-source-url" value="#(artworkSourceURL)" />
     <textarea
         id="editor-description"
         class="text-input"
@@ -23,6 +25,7 @@
         spellcheck="true"
         rows="3"
     >#(description)</textarea>
+    <input id="editor-tracklist-json" type="hidden" name="tracklist-json" value="" />
     #endexport
 
     #export("editor-preview-form"):

--- a/tmbr/Resources/Views/Catalogue/Playlists/playlist.leaf
+++ b/tmbr/Resources/Views/Catalogue/Playlists/playlist.leaf
@@ -1,0 +1,21 @@
+#extend("Catalogue/details"):
+
+    #export("detail-header"):
+    <div class="details">
+        <h1>#(title)</h1>
+        #if(description):
+        <p>#(description)</p>
+        #endif
+        #extend("Catalogue/resources")
+    </div>
+    #if(artwork):
+    <div class="artwork">
+        <img src="#(artwork.url)" alt="Artwork image of #(title)">
+    </div>
+    #endif
+    #endexport
+
+    #export("detail-body"):
+    #endexport
+
+#endextend

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue.swift
@@ -38,6 +38,7 @@ extension Module where Self == Catalogue {
                     .albums,
                     .books,
                     .movies,
+                    .playlists,
                     .podcasts,
                     .songs,
                 ]

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Routes/CatalogueQueryMapper.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Routes/CatalogueQueryMapper.swift
@@ -6,6 +6,7 @@ struct CatalogueQueryMapper: Sendable {
         Album.previewType,
         Book.previewType,
         Movie.previewType,
+        Playlist.previewType,
         Podcast.previewType,
         Song.previewType,
     ]

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/PlaylistMetadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/PlaylistMetadata.swift
@@ -1,0 +1,1 @@
+struct PlaylistMetadata: Sendable {}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Playlist.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Playlist.swift
@@ -1,0 +1,10 @@
+extension Platform where M == PlaylistMetadata {
+
+    static var playlist: Platform<PlaylistMetadata> {
+        Platform(platforms: [
+            Platform(name: "Apple Music", checker: .appleMusic),
+            Platform(name: "Spotify", checker: .spotify),
+            Platform(name: "YouTube", checker: .youtube)
+        ])
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/Command+PlaylistSearch.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/Command+PlaylistSearch.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Core
+import Fluent
+import AuthKit
+
+struct PlaylistSearchResult: Sendable {
+
+    let previews: [Preview]
+
+    let noteMatches: [Preview]
+}
+
+extension Command where Self == PlainCommand<String?, PlaylistSearchResult> {
+
+    static func searchPlaylists(
+        database: Database,
+        permission: BasePermissionResolver<QueryBuilder<Preview>>,
+        noteSearch: CommandResolver<NoteQueryPayload, [Note]>
+    ) -> Self {
+        PlainCommand { term in
+            let safeTerm = term.flatMap { t -> String? in
+                let trimmed = t.trimmed
+                return trimmed.isEmpty ? nil : trimmed.replacingOccurrences(of: "'", with: "''")
+            }
+
+            let query = Preview.query(on: database)
+                .with(\.$image)
+                .filter(\.$parentType == Playlist.previewType)
+                .join(Playlist.self, on: \Playlist.$preview.$id == \Preview.$id)
+                .sort(\.$createdAt, .descending)
+
+            if let safeTerm {
+                query.group(.or) { group in
+                    group.filter(.sql(unsafeRaw: "playlists.title ILIKE '%\(safeTerm)%'"))
+                    group.filter(.sql(unsafeRaw: "playlists.description ILIKE '%\(safeTerm)%'"))
+                }
+            }
+
+            try await permission.grant(query)
+
+            async let previewsTask = query.all()
+            async let notesTask = noteSearch(NoteQueryPayload(term: term, types: [Playlist.previewType]))
+            let (previews, notes) = try await (previewsTask, notesTask)
+
+            let previewIDs = Set(previews.compactMap(\.id))
+            var seen = previewIDs
+            let noteMatches = notes.compactMap { note -> Preview? in
+                guard let id = note.attachment.id, !seen.contains(id) else { return nil }
+                seen.insert(id)
+                return note.attachment
+            }
+
+            return PlaylistSearchResult(previews: previews, noteMatches: noteMatches)
+        }
+    }
+}
+
+extension CommandFactory<String?, PlaylistSearchResult> {
+
+    static var searchPlaylists: Self {
+        CommandFactory { request in
+            .searchPlaylists(
+                database: request.commandDB,
+                permission: request.permissions.previews.query,
+                noteSearch: request.commands.notes.search
+            )
+            .logged(name: "Search Playlists", logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/CreatePlaylistCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/CreatePlaylistCommand.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Vapor
+import Core
+import Logging
+import Fluent
+import AuthKit
+
+struct CreatePlaylistCommand: Command {
+
+    private let configure: ModelConfiguration<Playlist, PlaylistInput>
+
+    private let database: Database
+
+    private let permission: AuthPermissionResolver<Void>
+
+    private let validate: Validator<PlaylistInput>
+
+    init(
+        configure: ModelConfiguration<Playlist, PlaylistInput>,
+        database: Database,
+        permission: AuthPermissionResolver<Void>,
+        validate: Validator<PlaylistInput>
+    ) {
+        self.configure = configure
+        self.database = database
+        self.permission = permission
+        self.validate = validate
+    }
+
+    func execute(_ input: PlaylistInput) async throws -> Playlist {
+        let user = try await permission.grant()
+        try validate(input)
+
+        var playlist = Playlist(owner: user.userID)
+        configure(&playlist, with: input)
+        try await playlist.save(on: database)
+
+        return playlist
+    }
+}
+
+extension CommandFactory<PlaylistInput, Playlist> {
+
+    static var createPlaylist: Self {
+        CommandFactory { request in
+            CreatePlaylistCommand(
+                configure: .playlist,
+                database: request.commandDB,
+                permission: request.permissions.playlists.create,
+                validate: .playlist
+            )
+            .logged(logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/EditPlaylistCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/EditPlaylistCommand.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Vapor
+import Core
+import Logging
+import Fluent
+import AuthKit
+
+typealias EditPlaylistInput = EditInput<Playlist, PlaylistInput>
+
+extension CommandFactory<EditPlaylistInput, Playlist> {
+
+    static var editPlaylist: Self {
+        CommandFactory { request in
+            PlainCommand.edit(
+                configure: .playlist,
+                database: request.commandDB,
+                permission: request.permissions.playlists.edit,
+                queryNotes: request.commands.notes.query,
+                validate: .playlist
+            )
+            .logged(name: "Edit Playlist Command", logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/FetchPlaylistCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/FetchPlaylistCommand.swift
@@ -1,0 +1,17 @@
+import Vapor
+import Core
+
+extension CommandFactory<FetchParameters<PlaylistID>, Playlist> {
+
+    static var fetchPlaylist: Self {
+        CommandFactory { request in
+            PlainCommand.fetch(
+                database: request.commandDB,
+                readPermission: request.permissions.playlists.access,
+                writePermission: request.permissions.playlists.edit,
+                load: \.$artwork, \.$owner, \.$post
+            )
+            .logged(name: "Fetch Playlist", logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/PlaylistInput.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/PlaylistInput.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Vapor
+import AuthKit
+import Core
+
+struct PlaylistInput {
+
+    fileprivate let access: Access
+
+    fileprivate let artwork: ImageID?
+
+    fileprivate let description: String?
+
+    fileprivate let resourceURLs: [String]
+
+    fileprivate let title: String
+
+    init(
+        access: Access,
+        artwork: ImageID?,
+        description: String?,
+        resourceURLs: [String],
+        title: String
+    ) {
+        self.access = access
+        self.artwork = artwork
+        self.description = description
+        self.resourceURLs = resourceURLs
+        self.title = title
+    }
+
+    init(payload: PlaylistPayload) {
+        self.init(
+            access: payload.access,
+            artwork: payload.artwork,
+            description: payload.description,
+            resourceURLs: payload.resourceURLs,
+            title: payload.title
+        )
+    }
+}
+
+extension ModelConfiguration where Model == Playlist, Parameters == PlaylistInput {
+
+    static var playlist: Self {
+        ModelConfiguration { playlist, input in
+            playlist.access = input.access
+            playlist.$artwork.id = input.artwork
+            playlist.description = input.description
+            playlist.resourceURLs = input.resourceURLs
+            playlist.title = input.title
+        }
+    }
+}
+
+extension Validator where Input == PlaylistInput {
+
+    static var playlist: Self {
+        Validator { playlist in
+            guard !playlist.title.trimmed.isEmpty else {
+                throw Abort(.badRequest, reason: "The playlist title is missing")
+            }
+        }
+    }
+}
+
+extension PlaylistInput {
+
+    func edit(id: PlaylistID) -> EditPlaylistInput {
+        EditPlaylistInput(id: id, parameters: self)
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Commands+Playlists.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Commands+Playlists.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Core
+
+extension Commands {
+    var playlists: Commands.Playlists.Type { Commands.Playlists.self }
+}
+
+extension Commands {
+
+    struct Playlists: CommandCollection, Sendable {
+
+        let create: CommandFactory<PlaylistInput, Playlist>
+
+        let delete: CommandFactory<PlaylistID, Void>
+
+        let edit: CommandFactory<EditPlaylistInput, Playlist>
+
+        let fetch: CommandFactory<FetchParameters<PlaylistID>, Playlist>
+
+        let search: CommandFactory<String?, PlaylistSearchResult>
+
+        init(
+            create: CommandFactory<PlaylistInput, Playlist> = .createPlaylist,
+            delete: CommandFactory<PlaylistID, Void> = .delete(\.playlists),
+            edit: CommandFactory<EditPlaylistInput, Playlist> = .editPlaylist,
+            fetch: CommandFactory<FetchParameters<PlaylistID>, Playlist> = .fetchPlaylist,
+            search: CommandFactory<String?, PlaylistSearchResult> = .searchPlaylists
+        ) {
+            self.create = create
+            self.delete = delete
+            self.edit = edit
+            self.fetch = fetch
+            self.search = search
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Models/Migrations/CreatePlaylist.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Models/Migrations/CreatePlaylist.swift
@@ -1,0 +1,29 @@
+import Fluent
+import Foundation
+import AuthKit
+
+struct CreatePlaylist: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        let accessType = try await database.enum("access").read()
+
+        try await database.schema(Playlist.schema)
+            .field("id", .int, .identifier(auto: true))
+            .field("access", accessType, .required)
+            .field("artwork_id", .int)
+            .field("description", .string)
+            .field("owner_id", .int, .required)
+            .field("post_id", .int)
+            .field("preview_id", .uuid, .required)
+            .field("resource_urls", .array(of: .string), .required, .sql(.default("{}")))
+            .field("title", .string, .required)
+            .foreignKey("artwork_id", references: Image.schema, "id", onDelete: .setNull)
+            .foreignKey("owner_id", references: User.schema, "id", onDelete: .cascade)
+            .foreignKey("post_id", references: Post.schema, "id", onDelete: .setNull)
+            .foreignKey("preview_id", references: Preview.schema, "id", onDelete: .cascade)
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(Playlist.schema).delete()
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Models/Migrations/DeferPlaylistPreviewForeignKey.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Models/Migrations/DeferPlaylistPreviewForeignKey.swift
@@ -1,0 +1,22 @@
+import Fluent
+import SQLKit
+
+struct DeferPlaylistPreviewForeignKey: AsyncMigration {
+
+    func prepare(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else {
+            database.logger.warning("DeferPlaylistPreviewForeignKey requires SQL database")
+            return
+        }
+        try await sql.raw("""
+            ALTER TABLE playlists
+            DROP CONSTRAINT IF EXISTS "fk:playlists.preview_id+playlists.id",
+            ADD CONSTRAINT "fk:playlists.preview_id+previews.id"
+                FOREIGN KEY (preview_id) REFERENCES previews(id)
+                ON DELETE CASCADE
+                DEFERRABLE INITIALLY DEFERRED
+            """).run()
+    }
+
+    func revert(on database: Database) async throws {}
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Models/Playlist.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Models/Playlist.swift
@@ -1,0 +1,85 @@
+import Fluent
+import Vapor
+import Foundation
+import AuthKit
+
+typealias PlaylistID = Playlist.IDValue
+
+final class Playlist: Model, Previewable, @unchecked Sendable {
+
+    static let previewType = "playlist"
+
+    static let schema = "playlists"
+
+    @ID(custom: "id", generatedBy: .database)
+    var id: Int?
+
+    @Enum(key: "access")
+    var access: Access
+
+    @OptionalParent(key: "artwork_id")
+    var artwork: Image?
+
+    @Field(key: "description")
+    var description: String?
+
+    @Parent(key: "owner_id")
+    private(set) var owner: User
+
+    @OptionalParent(key: "post_id")
+    var post: Post?
+
+    @Parent(key: "preview_id")
+    fileprivate(set) var preview: Preview
+
+    @Field(key: "resource_urls")
+    var resourceURLs: [String]
+
+    @Field(key: "title")
+    var title: String
+
+    var ownerID: UserID { $owner.id }
+
+    init() {}
+
+    init(owner: UserID) {
+        self.$owner.id = owner
+    }
+
+    init(
+        access: Access,
+        artwork: ImageID?,
+        description: String?,
+        owner: UserID,
+        resourceURLs: [String],
+        title: String
+    ) {
+        self.access = access
+        self.$artwork.id = artwork
+        self.description = description
+        self.$owner.id = owner
+        self.resourceURLs = resourceURLs
+        self.title = title
+    }
+}
+
+extension PreviewModelMiddleware where M == Playlist {
+
+    static var playlist: Self {
+        Self(
+            attach: { previewID, playlist in
+                playlist.$preview.id = previewID
+            },
+            configure: { preview, playlist in
+                preview.primaryInfo = playlist.title
+                preview.secondaryInfo = playlist.description
+                preview.$image.id = playlist.artwork?.id
+                preview.externalLinks = playlist.resourceURLs
+            },
+            fetch: { playlist, database in
+                try await playlist.$preview.load(on: database)
+                return playlist.preview
+            }
+        )
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Payloads/PlaylistPayload.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Payloads/PlaylistPayload.swift
@@ -1,0 +1,20 @@
+import Vapor
+import Foundation
+import AuthKit
+
+struct PlaylistPayload: Decodable, Sendable {
+
+    let _csrf: String?
+
+    let access: Access
+
+    let artwork: ImageID?
+
+    let description: String?
+
+    let notes: [NotePayload]?
+
+    let resourceURLs: [String]
+
+    let title: String
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Permissions/Permissions+Playlists.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Permissions/Permissions+Playlists.swift
@@ -1,0 +1,21 @@
+import AuthKit
+import Fluent
+
+extension PermissionScopes {
+    var playlists: PreviewablePermissionScope<Playlist>.Type { PreviewablePermissionScope<Playlist>.self }
+}
+
+extension PreviewablePermissionScope<Playlist> {
+    static var playlists: Self {
+        PreviewablePermissionScope(
+            access: .access("This playlist is private."),
+            create: .create("You don't have permission to create a playlist."),
+            delete: .delete("Only its owner can delete a playlist."),
+            edit: .edit("Only its owner can edit a playlist."),
+            query: .query(
+                access: \.$access,
+                owner: \.$owner.$id
+            )
+        )
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Playlists.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Playlists.swift
@@ -1,0 +1,44 @@
+import Vapor
+import Fluent
+import Core
+import AuthKit
+
+struct Playlists: Module {
+
+    private let commands: CommandCollection
+
+    private let permissions: PermissionScope
+
+    init(
+        commands: CommandCollection,
+        permissions: PermissionScope
+    ) {
+        self.commands = commands
+        self.permissions = permissions
+    }
+
+    func configure(_ app: Vapor.Application) async throws {
+        app.migrations.add(CreatePlaylist())
+        app.migrations.add(DeferPlaylistPreviewForeignKey())
+        app.databases.middleware.use(PreviewModelMiddleware.playlist, on: .psql)
+
+        try await app.permissions.add(scope: permissions)
+        try await app.commands.add(collection: commands)
+    }
+
+    func boot(_ routes: any Vapor.RoutesBuilder) async throws {
+        try routes.register(collection: PlaylistsAPIController())
+        try routes
+            .grouped(RecoverMiddleware())
+            .register(collection: PlaylistsWebController())
+    }
+}
+
+extension Module where Self == Playlists {
+    static var playlists: Self {
+        Playlists(
+            commands: Commands.Playlists(),
+            permissions: PreviewablePermissionScope.playlists
+        )
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/API/PlaylistsAPIController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/API/PlaylistsAPIController.swift
@@ -1,0 +1,97 @@
+import Vapor
+import AuthKit
+import Fluent
+import Core
+
+struct PlaylistsAPIController: RouteCollection {
+
+    func boot(routes: RoutesBuilder) throws {
+
+        let playlistsRoute = routes.grouped("api", "playlists")
+
+        // GET /api/playlists/:playlistID
+        playlistsRoute.get(":playlistID") { request async throws -> PlaylistResponse in
+            guard let playlistID = request.parameters.get("playlistID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Playlist ID")
+            }
+            async let playlist = request.commands.playlists.fetch(playlistID, for: .read)
+            async let notes = request.commands.notes.query(id: playlistID, of: Playlist.previewType)
+            return try PlaylistResponse(
+                playlist: await playlist,
+                notes: await notes,
+                baseURL: request.baseURL
+            )
+        }
+
+        // POST /api/playlists
+        playlistsRoute.post { request async throws -> PlaylistResponse in
+            let payload = try request.content.decode(PlaylistPayload.self)
+            return try await request.commands.transaction { commands in
+                let playlistInput = PlaylistInput(payload: payload)
+                let playlist = try await commands.playlists.create(playlistInput)
+                let notesInput = payload.notes.map {
+                    BatchCreateNoteInput(
+                        attachment: playlist.preview,
+                        notes: $0.map(NoteInput.init)
+                    )
+                }
+                let notes = try await notesInput.map(commands.notes.batchCreate)
+                return PlaylistResponse(
+                    playlist: playlist,
+                    notes: notes ?? [],
+                    baseURL: request.baseURL
+                )
+            }
+        }
+
+        // PUT /api/playlists/:playlistID
+        playlistsRoute.put(":playlistID") { request async throws -> PlaylistResponse in
+            guard let playlistID = request.parameters.get("playlistID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Playlist ID")
+            }
+            let payload = try request.content.decode(PlaylistPayload.self)
+            let input = PlaylistInput(payload: payload)
+            return try await request.commands.transaction { commands in
+                let playlist = try await commands.playlists.edit(input.edit(id: playlistID))
+                if let entries = payload.notes {
+                    let preview = try await commands.previews.fetch(playlist.$preview.id, for: .write)
+                    let syncEntries = entries.map { entry in
+                        SyncNoteEntry(id: entry.noteID, body: entry.body, access: entry.access, deleted: entry.deleted ?? false)
+                    }
+                    _ = try await commands.notes.sync(
+                        SyncNotesInput(attachment: preview, parentAccess: payload.access, entries: syncEntries)
+                    )
+                }
+                let notes = try await commands.notes.query(id: playlistID, of: Playlist.previewType)
+                return PlaylistResponse(playlist: playlist, notes: notes, baseURL: request.baseURL)
+            }
+        }
+
+        // DELETE /api/playlists/:playlistID
+        playlistsRoute.delete(":playlistID") { req async throws -> HTTPStatus in
+            guard let playlistID = req.parameters.get("playlistID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Playlist ID")
+            }
+            try await req.commands.playlists.delete(playlistID)
+            return .noContent
+        }
+
+        // POST /api/playlists/:playlistID/notes
+        playlistsRoute.post(":playlistID", "notes") { request async throws -> NoteResponse in
+            guard let playlistID = request.parameters.get("playlistID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Invalid Playlist ID")
+            }
+            let payload = try request.content.decode(NotePayload.self)
+            let playlist = try await request.commands.playlists.fetch(playlistID, for: .write)
+            let input = CreateNoteInput(
+                body: payload.body,
+                access: payload.access,
+                attachmentID: playlist.$preview.id
+            )
+            let note = try await request.commands.notes.create(input)
+            try await note.$attachment.load(on: request.commandDB)
+            try await note.$author.load(on: request.commandDB)
+            return NoteResponse(note: note, baseURL: request.baseURL)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/API/Responses/PlaylistResponse.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/API/Responses/PlaylistResponse.swift
@@ -1,0 +1,71 @@
+import Vapor
+import Foundation
+import AuthKit
+import Core
+
+struct PlaylistResponse: Encodable, Sendable, AsyncResponseEncodable {
+
+    private let id: PlaylistID
+
+    private let access: Access
+
+    private let artwork: ImageResponse?
+
+    private let description: String?
+
+    private let notes: [NoteResponse]
+
+    private let owner: UserResponse
+
+    private let preview: PreviewResponse
+
+    private let post: PostResponse?
+
+    private let resources: [Hyperlink]
+
+    private let title: String
+
+    init(
+        id: PlaylistID,
+        access: Access,
+        artwork: ImageResponse?,
+        description: String?,
+        notes: [NoteResponse],
+        owner: UserResponse,
+        preview: PreviewResponse,
+        post: PostResponse?,
+        resources: [Hyperlink],
+        title: String
+    ) {
+        self.id = id
+        self.access = access
+        self.artwork = artwork
+        self.description = description
+        self.notes = notes
+        self.owner = owner
+        self.preview = preview
+        self.post = post
+        self.resources = resources
+        self.title = title
+    }
+
+    init(
+        playlist: Playlist,
+        notes: [Note],
+        baseURL: String,
+        platform: Platform<PlaylistMetadata> = .playlist
+    ) {
+        self.init(
+            id: playlist.id!,
+            access: playlist.access,
+            artwork: playlist.artwork.map { ImageResponse(image: $0, baseURL: baseURL) },
+            description: playlist.description,
+            notes: notes.map { NoteResponse(note: $0, baseURL: baseURL) },
+            owner: UserResponse(user: playlist.owner),
+            preview: PreviewResponse(preview: playlist.preview, baseURL: baseURL),
+            post: playlist.post.map { PostResponse(post: $0, baseURL: baseURL) },
+            resources: playlist.resourceURLs.compactMap(platform.hyperlink),
+            title: playlist.title
+        )
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+Playlist.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+Playlist.swift
@@ -1,0 +1,94 @@
+import Vapor
+import Foundation
+import AuthKit
+import Core
+
+struct PlaylistViewModel: Encodable, Sendable {
+
+    private let id: PlaylistID
+
+    private let artwork: ImageViewModel?
+
+    private let allowsNewNote: Bool
+
+    private let description: String?
+
+    private let notes: [NoteViewModel]
+
+    private let notesEndpoint: String
+
+    private let post: PostItemViewModel?
+
+    private let resources: [Hyperlink]
+
+    private let title: String
+
+    init(
+        id: PlaylistID,
+        artwork: ImageViewModel?,
+        allowsNewNote: Bool,
+        description: String?,
+        notes: [NoteViewModel],
+        notesEndpoint: String,
+        post: PostItemViewModel?,
+        resources: [Hyperlink],
+        title: String
+    ) {
+        self.id = id
+        self.artwork = artwork
+        self.allowsNewNote = allowsNewNote
+        self.description = description
+        self.notes = notes
+        self.notesEndpoint = notesEndpoint
+        self.post = post
+        self.resources = resources
+        self.title = title
+    }
+
+    init(
+        playlist: Playlist,
+        notes: [Note],
+        baseURL: String,
+        allowsNewNote: Bool,
+        platform: Platform<PlaylistMetadata> = .playlist
+    ) throws {
+        let playlistID = try playlist.requireID()
+        self.init(
+            id: playlistID,
+            artwork: playlist.artwork.flatMap {
+                ImageViewModel(image: $0, baseURL: baseURL)
+            },
+            allowsNewNote: allowsNewNote,
+            description: playlist.description,
+            notes: try notes.map { try NoteViewModel(note: $0, isEditable: allowsNewNote) },
+            notesEndpoint: "/playlists/\(playlistID)/notes",
+            post: try playlist.post.map(PostItemViewModel.init),
+            resources: playlist.resourceURLs.compactMap(platform.hyperlink),
+            title: playlist.title
+        )
+    }
+}
+
+extension Template where Model == PlaylistViewModel {
+    static let playlist = Template(name: "Catalogue/Playlists/playlist")
+}
+
+extension Page {
+    static var playlist: Self {
+        Page(template: .playlist) { request in
+            guard let playlistID = request.parameters.get("playlistID", as: Int.self) else {
+                throw Abort(.badRequest)
+            }
+            async let playlist = request.commands.playlists.fetch(playlistID, for: .read)
+            async let notes = request.commands.notes.query(id: playlistID, of: Playlist.previewType)
+            let resolvedPlaylist = try await playlist
+            let allowsNewNote = (try? await request.permissions.playlists.edit.grant(resolvedPlaylist)) != nil
+            return try PlaylistViewModel(
+                playlist: resolvedPlaylist,
+                notes: await notes,
+                baseURL: request.baseURL,
+                allowsNewNote: allowsNewNote
+            )
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+PlaylistEditor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+PlaylistEditor.swift
@@ -105,7 +105,7 @@ struct PlaylistEditorViewModel: Encodable, Sendable {
 }
 
 extension Template where Model == PlaylistEditorViewModel {
-    static let playlistEditor = Template(name: "Catalogue/editor")
+    static let playlistEditor = Template(name: "Catalogue/Playlists/playlist-editor")
 }
 
 extension Page {

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+PlaylistEditor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+PlaylistEditor.swift
@@ -1,0 +1,142 @@
+import Core
+import Foundation
+import Vapor
+import Fluent
+import AuthKit
+
+struct PlaylistEditorViewModel: Encodable, Sendable {
+
+    struct NoteViewModel: Encodable, Sendable {
+        let id: String?
+        let body: String
+        let access: Access
+    }
+
+    private let artworkAspect: String = ""
+
+    private let id: Int?
+
+    private let pageTitle: String?
+
+    private let access: Access
+
+    private let artworkId: Int?
+
+    private let artworkSourceURL: String?
+
+    private let artworkThumbnailURL: String?
+
+    private let description: String
+
+    private let notes: [NoteViewModel]
+
+    private let resourceURLs: [String]
+
+    private let submit: Form.Submit
+
+    private let title: String
+
+    let _csrf: String?
+
+    private let error: String?
+
+    init(
+        id: Int? = nil,
+        pageTitle: String? = nil,
+        access: Access = .private,
+        artworkId: Int? = nil,
+        artworkSourceURL: String? = nil,
+        artworkThumbnailURL: String? = nil,
+        description: String = "",
+        notes: [NoteViewModel] = [],
+        resourceURLs: [String] = [],
+        submit: Form.Submit,
+        title: String = "",
+        csrf: String? = nil,
+        error: String? = nil
+    ) {
+        self.id = id
+        self.pageTitle = pageTitle
+        self.access = access
+        self.artworkId = artworkId
+        self.artworkSourceURL = artworkSourceURL
+        self.artworkThumbnailURL = artworkThumbnailURL
+        self.description = description
+        self.notes = notes
+        self.resourceURLs = resourceURLs
+        self.submit = submit
+        self.title = title
+        self._csrf = csrf
+        self.error = error
+    }
+
+    init(
+        playlist: Playlist,
+        notes: [Note],
+        baseURL: String,
+        csrf: String?
+    ) throws {
+        let id = try playlist.requireID()
+        let artworkId = playlist.$artwork.id
+        let artworkThumbnailURL: String?
+        if let artwork = playlist.artwork {
+            artworkThumbnailURL = "\(baseURL)/gallery/data/\(artwork.thumbnailKey)"
+        } else {
+            artworkThumbnailURL = nil
+        }
+        self.init(
+            id: id,
+            pageTitle: "Edit '\(playlist.title)'",
+            access: playlist.access,
+            artworkId: artworkId,
+            artworkSourceURL: nil,
+            artworkThumbnailURL: artworkThumbnailURL,
+            description: playlist.description ?? "",
+            notes: notes.map { NoteViewModel(id: $0.id?.uuidString, body: $0.body, access: $0.access) },
+            resourceURLs: playlist.resourceURLs,
+            submit: Form.Submit(
+                action: "/playlists/\(id)",
+                label: "Save"
+            ),
+            title: playlist.title,
+            csrf: csrf
+        )
+    }
+}
+
+extension Template where Model == PlaylistEditorViewModel {
+    static let playlistEditor = Template(name: "Catalogue/editor")
+}
+
+extension Page {
+    static var createPlaylist: Self {
+        Page(template: .playlistEditor) { req in
+            try await req.permissions.playlists.create()
+            let submit = Form.Submit(
+                action: "/playlists/new",
+                label: "Save"
+            )
+            let csrf = UUID().uuidString
+            req.session.data["csrf.editor"] = csrf
+            return PlaylistEditorViewModel(pageTitle: "New playlist", submit: submit, csrf: csrf)
+        }
+    }
+
+    static var editPlaylist: Self {
+        Page(template: .playlistEditor) { request in
+            guard let playlistID = request.parameters.get("playlistID", as: Int.self) else {
+                throw Abort(.badRequest, reason: "Playlist ID is incorrect or missing.")
+            }
+            async let playlist = request.commands.playlists.fetch(playlistID, for: .write)
+            async let notes = request.commands.notes.query(id: playlistID, of: Playlist.previewType)
+            let csrf = UUID().uuidString
+            request.session.data["csrf.editor"] = csrf
+            return try await PlaylistEditorViewModel(
+                playlist: playlist,
+                notes: notes,
+                baseURL: request.baseURL,
+                csrf: csrf
+            )
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+PlaylistPreview.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+PlaylistPreview.swift
@@ -1,0 +1,47 @@
+import Core
+import Foundation
+import Vapor
+import AuthKit
+
+private struct PlaylistPreviewPayload: Content {
+    let title: String
+    let description: String?
+    let artworkURL: String?
+    let resourceURLs: String?
+    let notes: String
+}
+
+extension Page {
+    static var playlistPreview: Self {
+        Page(template: .playlist) { req in
+            try await req.permissions.playlists.create.grant()
+            let payload = try req.content.decode(PlaylistPreviewPayload.self)
+            let formatter = MarkdownFormatter.html
+            let notes: [NoteViewModel] = payload.notes.isEmpty ? [] : [
+                NoteViewModel(
+                    id: UUID(),
+                    body: formatter.format(payload.notes),
+                    created: Date.now.formatted(.publishDate)
+                )
+            ]
+            let platform = Platform<PlaylistMetadata>.playlist
+            let resources = (payload.resourceURLs ?? "")
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map(String.init)
+                .compactMap(platform.hyperlink)
+            return PlaylistViewModel(
+                id: 0,
+                artwork: payload.artworkURL.flatMap { url in
+                    url.isEmpty ? nil : ImageViewModel(previewURL: url)
+                },
+                allowsNewNote: false,
+                description: payload.description,
+                notes: notes,
+                notesEndpoint: "",
+                post: nil,
+                resources: resources,
+                title: "Preview: \(payload.title)"
+            )
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+Playlists.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+Playlists.swift
@@ -1,0 +1,25 @@
+import Vapor
+import Core
+import Foundation
+
+extension Template where Model == CatalogueListViewModel {
+    static let playlists = Template(name: "Catalogue/list")
+}
+
+extension Page {
+    static var playlists: Self {
+        Page(template: .playlists) { req in
+            let term = try? req.query.get(String.self, at: "term")
+            async let composeURL: String? = (try? await req.permissions.playlists.create()) != nil ? "/playlists/new" : nil
+            async let result = req.commands.playlists.search(term)
+            let baseURL = req.baseURL
+            let resolved = try await result
+            return CatalogueListViewModel(
+                compose: await composeURL,
+                term: term,
+                previews: resolved.previews.map { PreviewViewModel(preview: $0, baseURL: baseURL) }
+                    + resolved.noteMatches.map { PreviewViewModel(preview: $0, baseURL: baseURL, isNoteMatch: true) }
+            )
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/PlaylistEditorPayload.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/PlaylistEditorPayload.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Vapor
+import AuthKit
+
+struct PlaylistEditorPayload: Decodable, Sendable {
+
+    let _csrf: String?
+
+    let access: Access
+
+    private let artworkIdRaw: String?
+
+    private let artworkSourceURLRaw: String?
+
+    let description: String?
+
+    let notes: [NotePayload]
+
+    let resourceURLs: [String]
+
+    let title: String
+
+    var artworkId: ImageID? {
+        guard let raw = artworkIdRaw, !raw.isEmpty else { return nil }
+        return Int(raw)
+    }
+
+    var artworkSourceURL: String? {
+        guard let raw = artworkSourceURLRaw, !raw.isEmpty else { return nil }
+        return raw
+    }
+
+    var filteredResourceURLs: [String] {
+        resourceURLs.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case _csrf
+        case access
+        case artworkIdRaw = "artwork-id"
+        case artworkSourceURLRaw = "artwork-source-url"
+        case description
+        case notes
+        case resourceURLs
+        case title
+    }
+
+    init(
+        _csrf: String? = nil,
+        access: Access = .private,
+        artworkIdRaw: String? = nil,
+        artworkSourceURLRaw: String? = nil,
+        description: String? = nil,
+        notes: [NotePayload] = [],
+        resourceURLs: [String] = [],
+        title: String = ""
+    ) {
+        self._csrf = _csrf
+        self.access = access
+        self.artworkIdRaw = artworkIdRaw
+        self.artworkSourceURLRaw = artworkSourceURLRaw
+        self.description = description
+        self.notes = notes
+        self.resourceURLs = resourceURLs
+        self.title = title
+    }
+}
+
+extension PlaylistInput {
+
+    init(payload: PlaylistEditorPayload, artworkId: ImageID? = nil) {
+        self.init(
+            access: payload.access,
+            artwork: artworkId ?? payload.artworkId,
+            description: payload.description,
+            resourceURLs: payload.filteredResourceURLs,
+            title: payload.title
+        )
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/PlaylistsWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/PlaylistsWebController.swift
@@ -1,0 +1,205 @@
+import Vapor
+import Fluent
+import AuthKit
+import Core
+
+struct PlaylistsWebController: RouteCollection {
+
+    private enum EditorMode {
+        case create
+        case update(playlistID: Int)
+    }
+
+    func boot(routes: RoutesBuilder) throws {
+        let recoveringRoute = routes.grouped("playlists")
+            .grouped(RecoverMiddleware())
+
+        recoveringRoute.get(page: .playlists)
+
+        recoveringRoute.get(":playlistID", page: .playlist)
+
+        recoveringRoute.get("new", page: .createPlaylist)
+        recoveringRoute.post("new", use: createPlaylist)
+
+        recoveringRoute.post("preview", page: .playlistPreview)
+
+        recoveringRoute.get(":playlistID", "edit", page: .editPlaylist)
+        recoveringRoute.post(":playlistID", use: updatePlaylist)
+
+        recoveringRoute.post(":playlistID", "notes", use: createNote)
+    }
+
+    @Sendable
+    private func createPlaylist(_ req: Request) async throws -> Response {
+        try await handleEditorSubmission(req, mode: .create)
+    }
+
+    @Sendable
+    private func updatePlaylist(_ req: Request) async throws -> Response {
+        guard let playlistID = req.parameters.get("playlistID", as: Int.self) else {
+            throw Abort(.badRequest, reason: "Invalid Playlist ID")
+        }
+        return try await handleEditorSubmission(req, mode: .update(playlistID: playlistID))
+    }
+
+    private func handleEditorSubmission(_ req: Request, mode: EditorMode) async throws -> Response {
+        do {
+            let payload = try req.content.decode(PlaylistEditorPayload.self)
+            guard let submittedCSRF = payload._csrf,
+                  submittedCSRF == req.session.data["csrf.editor"] else {
+                throw Abort(.forbidden, reason: "Invalid form token. Please reload the editor and try again.")
+            }
+
+            let artworkId = try await resolveArtwork(payload: payload, on: req)
+
+            let playlist = try await req.commands.transaction { commands in
+                let playlistInput = PlaylistInput(payload: payload, artworkId: artworkId)
+                let playlist: Playlist
+
+                switch mode {
+                case .create:
+                    playlist = try await commands.playlists.create(playlistInput)
+                    let preview = try await commands.previews.fetch(playlist.$preview.id, for: .write)
+                    let noteInputs = payload.notes.map { entry in
+                        NoteInput(body: entry.body, access: entry.access && payload.access)
+                    }
+                    _ = try await commands.notes.batchCreate(noteInputs, for: preview)
+                case .update(let playlistID):
+                    playlist = try await commands.playlists.edit(playlistInput.edit(id: playlistID))
+                    let preview = try await commands.previews.fetch(playlist.$preview.id, for: .write)
+                    let syncEntries = payload.notes.map { entry in
+                        SyncNoteEntry(
+                            id: entry.noteID,
+                            body: entry.body,
+                            access: entry.access,
+                            deleted: entry.deleted ?? false
+                        )
+                    }
+                    _ = try await commands.notes.sync(
+                        SyncNotesInput(attachment: preview, parentAccess: payload.access, entries: syncEntries)
+                    )
+                }
+
+                return playlist
+            }
+
+            req.session.data["csrf.editor"] = nil
+            return req.redirect(to: "/playlists/\(playlist.id!)")
+        } catch {
+            return try await renderEditorWithError(req, mode: mode, error: error)
+        }
+    }
+
+    private func resolveArtwork(payload: PlaylistEditorPayload, on req: Request) async throws -> ImageID? {
+        if let artworkId = payload.artworkId {
+            return artworkId
+        }
+
+        guard let artworkURL = payload.artworkSourceURL else {
+            return nil
+        }
+
+        if let existingImage = try await req.commands.gallery.lookup(artworkURL) {
+            return try existingImage.requireID()
+        }
+
+        let alt = payload.title.isEmpty ? "Playlist artwork" : payload.title
+        let newImage = try await req.commands.gallery.addFromURL(
+            ImageURLPayload(url: artworkURL, alt: alt)
+        )
+        return try newImage.requireID()
+    }
+
+    private func renderEditorWithError(
+        _ req: Request,
+        mode: EditorMode,
+        error: Error
+    ) async throws -> Response {
+        let submitted = (try? req.content.decode(PlaylistEditorPayload.self)) ?? PlaylistEditorPayload()
+        let submit: Form.Submit
+        let playlistID: Int?
+        let pageTitle: String
+
+        switch mode {
+        case .create:
+            playlistID = nil
+            submit = Form.Submit(action: "/playlists/new", label: "Save")
+            pageTitle = "New playlist"
+        case .update(let id):
+            playlistID = id
+            submit = Form.Submit(action: "/playlists/\(id)", label: "Save")
+            pageTitle = "Edit '\(submitted.title)'"
+        }
+
+        let noteViewModels = submitted.notes.map {
+            PlaylistEditorViewModel.NoteViewModel(id: $0.id, body: $0.body, access: $0.access)
+        }
+
+        let csrf = UUID().uuidString
+        let model = PlaylistEditorViewModel(
+            id: playlistID,
+            pageTitle: pageTitle,
+            access: submitted.access,
+            artworkId: submitted.artworkId,
+            artworkSourceURL: submitted.artworkSourceURL,
+            artworkThumbnailURL: submitted.artworkSourceURL,
+            description: submitted.description ?? "",
+            notes: noteViewModels,
+            resourceURLs: submitted.resourceURLs,
+            submit: submit,
+            title: submitted.title,
+            csrf: csrf,
+            error: editorErrorHTML(for: error, on: req)
+        )
+
+        let view = try await Template.playlistEditor.render(model, with: req.view)
+        let response = try await view.encodeResponse(for: req)
+        req.session.data["csrf.editor"] = csrf
+        return response
+    }
+
+    @Sendable
+    private func createNote(_ request: Request) async throws -> Response {
+        guard let playlistID = request.parameters.get("playlistID", as: Int.self) else {
+            return Response(status: .badRequest)
+        }
+        guard let payload = try? request.content.decode(NotePayload.self) else {
+            return Response(status: .badRequest)
+        }
+        do {
+            let playlist = try await request.commands.playlists.fetch(playlistID, for: .write)
+            let input = CreateNoteInput(
+                body: payload.body,
+                access: payload.access,
+                attachmentID: playlist.$preview.id
+            )
+            let note = try await request.commands.notes.create(input)
+            let model = try NoteViewModel(note: note, isEditable: true)
+            let view = try await Template.noteItem.render(NoteItemContext(note: model), with: request.view)
+            return try await view.encodeResponse(for: request)
+        } catch {
+            return Response(status: .unprocessableEntity)
+        }
+    }
+
+    private func editorErrorHTML(for error: Error, on req: Request) -> String {
+        if let abort = error as? AbortError {
+            switch abort.status {
+            case .unauthorized:
+                return "Please <a href=\"/signin?return=\(req.url.path)\">sign in</a> and try again."
+            case .forbidden:
+                return "You don't have permission to perform this action."
+            case .notFound:
+                return "This playlist doesn't exist or isn't available."
+            case .badRequest:
+                return abort.reason.isEmpty ? "Please check your input and try again." : abort.reason
+            default:
+                break
+            }
+        }
+        if error is ValidationsError {
+            return "Title is required."
+        }
+        return "Something went wrong. Please try again."
+    }
+}

--- a/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+ImportAlbumTracks.swift
+++ b/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+ImportAlbumTracks.swift
@@ -16,7 +16,7 @@ extension Command where Self == PlainCommand<ImportAlbumTracksInput, Void> {
     static func importAlbumTracks(database: Database) -> Self {
         PlainCommand { input in
             for (index, track) in input.tracks.enumerated() {
-                var preview = Preview(
+                let preview = Preview(
                     id: UUID(),
                     parentID: nil,
                     parentAccess: input.access,


### PR DESCRIPTION
## Summary
- Adds `Playlist` model (access, artwork, description, resourceURLs, title) with migrations and `PreviewModelMiddleware`
- Full CRUD: `PlaylistsAPIController`, `PlaylistsWebController`, list/detail/editor leaf templates, `playlist-editor.js`
- `Playlist.previewType = "playlist"` added to `CatalogueQueryMapper` so playlists surface in catalogue search
- `catalogue-editor.js` hardened: submit handler guards against missing release-date fields; metadata autofill skips types with no `metadataEndpoint`

## Test plan
- [ ] Create, view, edit, and delete a playlist
- [ ] Playlist list page with search works
- [ ] Preview button opens playlist preview in new tab
- [ ] Other catalogue types (albums, songs, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)