### PR TITLE
Stage 5: Playlist tracklist — ContainerEntry display, Apple Music import, promote

### DIFF
--- a/.claude/docs/plans/music-catalogue.md
+++ b/.claude/docs/plans/music-catalogue.md
@@ -8,35 +8,263 @@
 
 | Stage | Description | Status |
 |-------|-------------|--------|
+| Pre | Generalisation pass — unified list/editor/detail templates, JS factory | ✅ |
 | 1 | Album — model + migration + basic CRUD + metadata autofill | ✅ |
-| 2 | Album — AlbumTrack model + tracklist display | ⬜ |
-| 3 | Album — lazy track promotion (`?track=` param) | ⬜ |
-| 4 | Album — Apple Music metadata fetch + tracklist import | ⬜ |
-| 5 | Playlist — model + PlaylistEntry + basic CRUD | ⬜ |
-| 6 | Playlist — Apple Music metadata fetch | ⬜ |
-| 7 | Unified Music list page and API (`/music`) | ⬜ |
-| 8 | Unified "New Music" editor (`/music/new`) | ⬜ |
-| 9 | "Music" catalogue filter (virtual chip) | ⬜ |
+| 2 | Album — ContainerEntry tracklist + display + track auto-promotion | ✅ |
+| 3 | Album — Apple Music JSON-LD tracklist import on create | ✅ |
+| 4 | Playlist — model + basic CRUD (shell) | ✅ |
+| 5 | Playlist — ContainerEntry track management + Apple Music import | ⬜ |
+| 6 | Unified Music list page and API (`/music`) | ⬜ |
+| 7 | Unified "New Music" editor (`/music/new`) | ⬜ |
+| 8 | "Music" catalogue filter (virtual chip) | ⬜ |
 
-### Stage 1 checklist (✅ complete)
-- [x] `Album.swift` model (`previewType = "album"`)
-- [x] `CreateAlbum.swift` migration
-- [x] `AlbumInput.swift` — input + `ModelConfiguration` + `Validator`
-- [x] `CreateAlbumCommand.swift`, `EditAlbumCommand.swift`, `FetchAlbumCommand.swift`
-- [x] `Command+AlbumSearch.swift` — joins Preview + Album, searches title/artist/genre
-- [x] `Command+LookupAlbum.swift` — duplicate detection by URL
-- [x] `Commands+Albums.swift` — command collection
-- [x] `AlbumPayload.swift` — API payload
-- [x] `Permissions+Albums.swift`
-- [x] `AlbumResponse.swift`, `AlbumsAPIController.swift`
-- [x] `AlbumEditorPayload.swift`, `AlbumsWebController.swift`
-- [x] `Page+Album.swift`, `Page+Albums.swift`, `Page+AlbumEditor.swift`
-- [x] `Albums.swift` — module entry
-- [x] `albums.leaf`, `album.leaf`, `album-editor.leaf`
-- [x] `album-editor.js` — metadata autofill added (fetches `/albums/metadata` on URL insert)
-- [x] `FetchAlbumMetadataCommand.swift` + `MetadataExtractor+AppleMusicAlbum.swift` + `Platform+AlbumMetadata.swift`
-- [x] Register `.albums` in `Catalogue.swift`
-- [x] Add `Album.previewType` to `CatalogueQueryMapper.catalogueTypes`
+---
+
+## What Was Built (Stages Pre–4)
+
+### Generalisation pass (PR #152)
+Before implementing album tracklists, a cleanup pass unified all 5 existing catalogue types:
+- `CatalogueListViewModel` — single shared list ViewModel replaces 5 identical structs
+- `Catalogue/list.leaf` — single list template for all types
+- `Catalogue/editor.leaf` — single base editor template; each type extends it with `editor-fields`, `editor-title-input`, `editor-preview-form`, `editor-type-script`
+- `Catalogue/details.leaf` — pure frame; each type exports `detail-header` and `detail-body`
+- `CatalogueEditorController.init(config)` in `catalogue-editor.js` — JS factory that accepts a config object; per-type JS files are now ~10 lines each
+- Book/Movie renamed `artwork` → `cover` in their ViewModels and leaf files (they own their own templates)
+
+### Stage 1 (PR before #152 — already complete)
+Full Album module: model, migrations, CRUD commands, API, web routes, all views, Apple Music metadata autofill.
+
+### Stage 2 (PR #153)
+Instead of a dedicated `AlbumTrack` model, a generic `ContainerEntry` join table was introduced. See [Data Model](#data-model) below. Also implemented:
+- `ExtendPreview` migration — makes `Preview.parentID` nullable (orphan tracks have `parentType = "track"`, `parentID = nil`)
+- `CreateContainerEntries` migration — new `container_entries` table
+- `ContainerEntry` Fluent model
+- Album detail page fetches entries via `ContainerEntriesInput(containerType: "album", containerID:)` and renders a tracklist
+- `GET /catalogue/item/:id` — shallow detail page for orphan Previews (no backing model yet)
+- `POST /songs/promote` — auto-promotes an orphan track: reads `previewID`, creates a Song that adopts the orphan Preview's UUID (Preview's `parentType`/`parentID` are updated; ContainerEntry row is untouched)
+
+### Stage 3 (PR #154)
+Apple Music JSON-LD tracklist import on album create:
+- `HTMLMetadataParser.parseJSONLD` updated to handle multiple named `<script type="application/ld+json">` blocks, keyed by their `id` attribute
+- `MetadataExtractor.appleMusicAlbum` reads `metadata.json["schema:music-album"]` for `tracks[]` and `byArtist[]`
+- `AlbumMetadata` gains `tracks: [TrackMetadata]?`
+- `AlbumEditorPayload` decodes a hidden `tracklist-json` field populated by JS from the metadata response
+- `AlbumsWebController` calls `commands.previews.importTracks(ImportAlbumTracksInput(...))` on create — creates one orphan Preview + one ContainerEntry per track
+- Update path skips tracklist import to protect already-promoted songs
+
+### Stage 4 (PR #155)
+Full Playlist shell — mirrors the Album module but without `artist`, `releaseDate`, metadata/lookup commands, or tracklist. Playlist can have a `description`. `Playlist.previewType = "playlist"` added to `CatalogueQueryMapper`.
+
+---
+
+## Data Model
+
+### Song (unchanged)
+```
+songs:
+  id             Int (PK, auto)
+  title          String
+  artist         String
+  album          String?   ← plain string metadata from Apple Music, NOT a FK
+  genre          String?
+  release_date   Date?
+  access         Access
+  owner_id       FK → users (cascade)
+  artwork_id     FK → images (setNull)
+  preview_id     FK → previews (cascade)
+  resource_urls  [String]
+  post_id        FK → posts (setNull)
+```
+
+### Album
+```
+albums:
+  id             Int (PK, auto)
+  title          String
+  artist         String
+  release_date   Date?
+  genre          String?
+  access         Access
+  owner_id       FK → users (cascade)
+  artwork_id     FK → images (setNull)
+  preview_id     FK → previews (cascade)
+  resource_urls  [String]
+  post_id        FK → posts (setNull)
+```
+
+### Playlist
+```
+playlists:
+  id             Int (PK, auto)
+  title          String
+  description    String?
+  access         Access
+  owner_id       FK → users (cascade)
+  artwork_id     FK → images (setNull)
+  preview_id     FK → previews (cascade)
+  resource_urls  [String]
+  post_id        FK → posts (setNull)
+```
+
+### ContainerEntry (replaces AlbumTrack and PlaylistEntry)
+```
+container_entries:
+  id              UUID (PK)
+  container_type  String    ← "album" | "playlist"
+  container_id    Int       ← album.id or playlist.id
+  preview_id      UUID FK → previews (cascade)
+  position        Int
+  UNIQUE (container_type, container_id, preview_id)
+```
+
+Querying a container's tracks:
+```swift
+ContainerEntry.query(on: db)
+    .filter(\.$containerType == "album")
+    .filter(\.$containerID == albumID)
+    .sort(\.$position)
+    .with(\.$preview)
+    .all()
+```
+
+### Preview (modified)
+`parentID` is now nullable. Orphan tracks have:
+- `parentType = "track"`
+- `parentID = nil`
+- `primaryInfo` = track name
+- `secondaryInfo` = "by \(artist)"
+- `externalLinks` = [trackURL] if available
+
+A ContainerEntry pointing to an orphan Preview renders as a promotable track. A ContainerEntry pointing to a Preview with `parentType = "song"` renders as a link to `/songs/:parentID`.
+
+---
+
+## The Track Promotion Pattern (implemented)
+
+When a user taps an unlinked track on an album/playlist detail page:
+
+**Route**: `POST /songs/promote`
+
+1. Read `previewID` from form body
+2. Load the orphan Preview
+3. Build a `SongInput` from Preview fields (`primaryInfo` → title, `externalLinks` → resourceURLs)
+4. Run `CreateSongCommand` with `song.previewID = previewID` (adoption — Song takes over the orphan Preview's UUID)
+5. `PreviewModelMiddleware` updates the Preview's `parentType`, `parentID`, `primaryInfo`, `secondaryInfo`
+6. Redirect to `/songs/<song.id>`
+
+The ContainerEntry row is never touched — the promoted Song's Preview still carries its album/playlist membership.
+
+**Album/Playlist detail page tracklist rendering**:
+- `entry.preview.parentID != nil` → link to `/songs/:parentID`
+- `entry.preview.parentID == nil` → promotion form with POST to `/songs/promote`
+
+---
+
+## Remaining Stages
+
+### Stage 5 — Playlist track management + Apple Music import
+
+Playlists currently have no tracklist. This stage adds it using the same ContainerEntry machinery already in place for albums.
+
+**Track management** (user-curated playlists):
+Unlike albums where the tracklist comes from Apple Music import, playlist tracks can also be added manually by linking an existing Song. Two entry paths:
+1. **Import from Apple Music URL** — same flow as albums: paste a playlist URL, metadata fetch returns tracks, hidden field stores JSON, `PlaylistsWebController` creates orphan Previews + ContainerEntry rows on create
+2. **Manual add** (future, not this stage) — search for an existing Song and add it; deferred
+
+**Apple Music playlist import**:
+- Apple Music playlists embed JSON-LD with `og:type = "music.playlist"` — confirm the schema; likely similar to albums
+- Add `PlaylistMetadata` fields: `title`, `description`, `artwork`, `tracks: [TrackMetadata]?`
+- Add `FetchPlaylistMetadataCommand` + `MetadataExtractor.appleMusicPlaylist`
+- Add `metadata` command to `Commands.Playlists`
+- Add `GET /playlists/metadata` route
+- Update `playlist-editor.js` to call the metadata endpoint on URL paste
+- Update `PlaylistEditorPayload` to decode `tracklist-json`
+- Update `PlaylistsWebController.create` to call `importTracks` with `containerType = "playlist"`
+- `Page+Playlist.swift` — fetch ContainerEntry rows, render tracklist in `playlist.leaf`
+
+**Files to create/modify**:
+| Action | File |
+|--------|------|
+| CREATE | `Platform/Metadata/PlaylistMetadata.swift` (expand — add tracks field) |
+| CREATE | `Playlists/Commands/Command/FetchPlaylistMetadataCommand.swift` |
+| CREATE | `Platform/Extractors/MetadataExtractor+AppleMusicPlaylist.swift` |
+| MODIFY | `Playlists/Commands/Commands+Playlists.swift` (add metadata command) |
+| MODIFY | `Playlists/Routes/Web/PlaylistsWebController.swift` (metadata route + importTracks on create) |
+| MODIFY | `Playlists/Routes/Web/PlaylistEditorPayload.swift` (add tracklistJSONRaw) |
+| MODIFY | `Playlists/Routes/Web/Pages/Page+Playlist.swift` (fetch ContainerEntry rows, pass to ViewModel) |
+| MODIFY | `Resources/Views/Catalogue/Playlists/playlist.leaf` (add tracklist section) |
+| MODIFY | `Public/Scripts/Catalogue/Playlists/playlist-editor.js` (metadata endpoint + onMetadata callback) |
+
+---
+
+### Stage 6 — Unified Music list page and API (`/music`)
+
+A single `/music` page that shows Songs, Albums, and Playlists interleaved in one feed (most recently created first). Also a `/api/music` endpoint.
+
+**Backend**:
+- `Command+MusicSearch.swift` — queries Previews filtered to `parentType IN ("song", "album", "playlist")`, joins all three tables for search term matching, returns `MusicSearchResult`
+- `Commands+Music.swift` — `Commands.Music` collection with a `search` command
+- `MusicWebController` — `GET /music` page
+- `MusicAPIController` — `GET /api/music` endpoint
+- `Page+Music.swift` — reuses `CatalogueListViewModel` + `Template(name: "Catalogue/list")`
+
+**Modified files**:
+- `Catalogue.swift` — register Music module
+
+---
+
+### Stage 7 — Unified "New Music" editor (`/music/new`)
+
+A single entry point for creating any music item. The form starts with just a URL field. When a URL is pasted, the backend detects the type and returns metadata + a `musicType` discriminator. The form morphs to show the appropriate fields.
+
+**Type detection endpoint**: `GET /music/metadata?url=...`
+- Returns `{ musicType: "song" | "album" | "playlist", ...metadata fields }`
+- Reuses existing per-type metadata extractors; adds `musicType` field to the response
+
+**Form behaviour** (JS):
+1. User pastes a URL → call `/music/metadata?url=...`
+2. Response includes `musicType` → show the matching field set (artist+genre+releaseDate for song/album; description for playlist)
+3. If no URL or ambiguous → show a manual type selector (radio/segmented control)
+4. On submit → POST to the type-specific endpoint (`/songs`, `/albums`, `/playlists`)
+
+**Files to create**:
+| File | Purpose |
+|------|---------|
+| `Music/MusicWebController.swift` | `GET /music` + `GET /music/new` + `GET /music/metadata` |
+| `Music/MusicAPIController.swift` | `GET /api/music` |
+| `Music/Commands/Command+MusicSearch.swift` | Cross-type search |
+| `Music/Commands/Commands+Music.swift` | Music command collection |
+| `Music/Routes/Web/Pages/Page+Music.swift` | List page context |
+| `Music/Routes/Web/Pages/Page+MusicEditor.swift` | New music editor context |
+| `Resources/Views/Catalogue/Music/music-editor.leaf` | Unified editor template |
+| `Public/Scripts/Catalogue/Music/music-editor.js` | Type detection + form morphing |
+
+**Register in `Catalogue.swift`**.
+
+---
+
+### Stage 8 — "Music" catalogue filter (virtual chip)
+
+The catalogue filter UI shows a single **"Music"** chip that maps to all three music types.
+
+**Backend** (`CatalogueQueryMapper`):
+```swift
+private static let virtualTypes: [String: Set<String>] = [
+    "music": ["song", "album", "playlist"]
+]
+
+private func filter(types: Set<String>?) -> Set<String> {
+    guard let types else { return allowedTypes }
+    let expanded = types.flatMap { virtualTypes[$0] ?? [$0] }
+    return allowedTypes.filter { expanded.contains($0) }
+}
+```
+
+**Frontend** — catalogue filter UI sends `type=music` in the query string; the mapper expands it server-side.
+
+**Files to modify**:
+- `CatalogueQueryMapper.swift`
+- Catalogue filter leaf/JS (wherever the filter chips are rendered)
 
 ---
 
@@ -68,262 +296,35 @@ Two models: `Song` and `MusicCollection`. `MusicCollection.type` enum: `album` o
 - Album and Playlist have genuinely different fields — grouping them creates the same nullable-field problem
 - "MusicCollection" is an awkward name; the split between Song and Collection feels artificial when both are "Music" to the user
 
-### ✅ Chosen Approach: Three Separate Previewable Types
+### Mental Model 3: AlbumTrack / PlaylistEntry as dedicated join models
+Separate `album_tracks` and `playlist_entries` tables, each with a nullable `song_id` FK.
+
+**Why we moved away from it**:
+- Both tables were structurally identical except for the parent FK column
+- A generic `ContainerEntry` (`container_type` + `container_id` + `preview_id` + `position`) serves both without any schema duplication
+- ContainerEntry membership survives promotion unchanged — the link doesn't need updating when a Song is created; the Preview's `parentID` update is sufficient
+
+### ✅ Chosen Approach: Three Separate Previewable Types + ContainerEntry
 **Song** (existing), **Album** (new), **Playlist** (new) — each a standalone module under `Catalogue/`.
 
-**Why this is correct**:
-- Matches the existing architecture exactly: Books, Movies, Podcasts, Songs are all independent types with their own tables
-- No nullable conditional fields — each model only has the fields it needs
-- The `Preview` model already handles cross-type queries polymorphically via `parentType`, so three types appear seamlessly in search/feeds
-- Adding a new type is well-defined: copy the existing module structure, implement Previewable, register in Catalogue.swift
+Tracks/entries are represented as orphan `Preview` objects (`parentType = "track"`, `parentID = nil`) linked to their container via `ContainerEntry`. Promotion creates a Song that adopts the orphan Preview's UUID — the ContainerEntry row is never modified.
 
 ---
 
-## Data Model
+## Metadata Fetching
 
-### Song (no changes to existing model)
-```
-songs:
-  id             Int (PK, auto)
-  title          String (required)
-  artist         String (required)
-  album          String? ← stays as plain string metadata, NOT a FK to albums
-  genre          String?
-  release_date   Date?
-  access         Access enum
-  owner_id       FK → users (cascade)
-  artwork_id     FK → images (setNull)
-  preview_id     FK → previews (cascade)
-  resource_urls  [String]
-  post_id        FK → posts (setNull)
-```
+### Albums (implemented — Stage 3)
+Apple Music album pages embed `<script id="schema:music-album" type="application/ld+json">` with the full tracklist. `HTMLMetadataParser.parseJSONLD` was updated to key named JSON-LD blocks by their `id` attribute. `MetadataExtractor.appleMusicAlbum` reads this block for `tracks[]` and `byArtist[]`.
 
-The `album` string field on Song is intentional. It stores album metadata from the song's perspective (exactly as Apple Music returns it). It does NOT become a FK to the `albums` table. A Song doesn't need to know about an Album model — the relationship is owned by the join model (`AlbumTrack`).
-
-### Album (new)
-```
-albums:
-  id             Int (PK, auto)
-  title          String (required)
-  artist         String (required)
-  release_date   Date?
-  genre          String?
-  access         Access enum
-  owner_id       FK → users (cascade)
-  artwork_id     FK → images (setNull)
-  preview_id     FK → previews (cascade)
-  resource_urls  [String]
-  post_id        FK → posts (setNull)
-```
-
-### AlbumTrack (child of Album — NOT Previewable)
-```
-album_tracks:
-  id             Int (PK, auto)
-  album_id       FK → albums (cascade)
-  track_number   Int
-  name           String  ← always stored (even if song_id is set)
-  song_id        Int?    FK → songs (setNull) ← nil until promoted
-```
-
-### Playlist (new)
-```
-playlists:
-  id             Int (PK, auto)
-  title          String (required)
-  description    String?
-  access         Access enum
-  owner_id       FK → users (cascade)
-  artwork_id     FK → images (setNull)
-  preview_id     FK → previews (cascade)
-  resource_urls  [String]
-  post_id        FK → posts (setNull)
-```
-
-### PlaylistEntry (child of Playlist — NOT Previewable)
-```
-playlist_entries:
-  id             Int (PK, auto)
-  playlist_id    FK → playlists (cascade)
-  position       Int
-  name           String  ← always stored
-  song_id        Int?    FK → songs (setNull) ← nil until promoted
-```
-
----
-
-## The Lazy Track Promotion Pattern
-
-**Core idea**: When a user imports an Album or Playlist (e.g. from Apple Music), the tracks are stored as lightweight string metadata (`AlbumTrack.name` / `PlaylistEntry.name`). No Song entities are created. A track becomes a proper Song catalogue entry only when the user actively engages with it.
-
-### Promotion flow
-
-**Album/Playlist detail page renders a tracklist**:
-- Track has `song_id` set → render as link to Song detail page (`/songs/:id`)
-- Track has `song_id` nil → render as link to Song editor (`/songs/new?track=<track_id>`)
-
-**Song editor opened from a track context**:
-- Reads the `track` query parameter
-- Pre-fills `title` with track name, `album` with the album's title, copies album artwork, etc.
-- On save: CreateSongCommand creates the Song entity, then links `AlbumTrack.song_id` (or `PlaylistEntry.song_id`) back to the new Song ID
-
-**Next time the user views the album**: that track is now a link to the Song detail page — no more editor link.
-
-**Key benefit**: Zero friction to import an album. Zero obligation to catalogue every track. The user catalogues only what they care about, naturally, by interacting with tracks.
-
----
-
-## User-Facing Abstraction: "Music" as a Single Concept
-
-From the user's perspective, Song/Album/Playlist is an implementation detail. The surface-level concept is just **Music**.
-
-### Catalogue Filter
-
-The filter UI shows a single **"Music"** chip, not three separate Song/Album/Playlist options.
-
-Internally, selecting "Music" maps to `parentType IN ('song', 'album', 'playlist')` in the Preview query. The `CatalogueQueryMapper.filter()` expands a virtual `"music"` type string to all three concrete types before intersecting with allowed types.
-
-### Unified "New Music" Entry Point
-
-The compose UI has a single **"New Music"** action, not three separate buttons. Entry point: `GET /music/new`.
-
-**Type detection flow**:
-1. User lands on the music editor — sees a URL input field (same UX as the current song editor's resource URL field)
-2. User pastes a URL (Apple Music song / Apple Music album / etc.)
-3. The JS controller calls the metadata detection endpoint
-4. Backend returns metadata + a resolved `musicType: "song" | "album" | "playlist"` field
-5. The form morphs to display the appropriate fields for the detected type
-6. If no URL is pasted (or URL is ambiguous), a manual type selector is shown
-
-**On submit**: POSTs to the type-specific REST endpoint (`/songs`, `/albums`, `/playlists`) based on the resolved type. The unification is a frontend concern only — the backend stays RESTful and type-specific.
-
-**Deep-link routes stay unchanged**: `/songs/:id`, `/albums/:id`, `/playlists/:id` remain valid for direct linking, API access, and the lazy track promotion flow.
-
----
-
-## New Module Structure (when implementing)
-
-Following the established pattern (Books, Movies, Podcasts, Songs):
-
-```
-Sources/App/Modules/Catalogue/
-├── Albums/
-│   ├── Albums.swift                         # Module entry: migrations, middleware, routes
-│   ├── Models/
-│   │   ├── Album.swift                      # Previewable
-│   │   ├── AlbumTrack.swift                 # Child model (NOT Previewable) — Stage 2
-│   │   └── Migrations/
-│   │       ├── CreateAlbum.swift
-│   │       └── CreateAlbumTrack.swift       # Stage 2
-│   ├── Commands/
-│   │   ├── Commands+Albums.swift
-│   │   └── Command/
-│   │       ├── AlbumInput.swift
-│   │       ├── CreateAlbumCommand.swift
-│   │       ├── EditAlbumCommand.swift
-│   │       ├── FetchAlbumCommand.swift
-│   │       ├── Command+AlbumSearch.swift
-│   │       ├── Command+LookupAlbum.swift
-│   │       └── FetchAlbumMetadataCommand.swift  # ✅ Stage 1
-│   ├── Payloads/
-│   │   └── AlbumPayload.swift
-│   ├── Permissions/
-│   │   └── Permissions+Albums.swift
-│   └── Routes/
-│       ├── API/
-│       │   ├── AlbumsAPIController.swift
-│       │   └── Responses/AlbumResponse.swift
-│       └── Web/
-│           ├── AlbumsWebController.swift
-│           ├── AlbumEditorPayload.swift
-│           └── Pages/
-│               ├── Page+Album.swift
-│               ├── Page+AlbumEditor.swift
-│               └── Page+Albums.swift
-│
-├── Playlists/                               # Stage 5 — same structure, no metadata fetch command
-│   └── ...
-│
-├── Music/                                   # Stage 8 — unified entry point
-│   └── Routes/Web/
-│       └── MusicWebController.swift         # GET /music/new → unified editor
-│
-└── Catalogue/
-    └── Commands/
-        └── Command+CatalogueSearch.swift    # Stage 9 — expand "music" virtual type
-```
-
-**New Leaf templates**:
-```
-Resources/Views/Catalogue/Albums/album.leaf
-Resources/Views/Catalogue/Albums/album-editor.leaf
-Resources/Views/Catalogue/Albums/albums.leaf
-Resources/Views/Catalogue/Playlists/playlist.leaf       # Stage 5
-Resources/Views/Catalogue/Playlists/playlist-editor.leaf # Stage 5
-Resources/Views/Catalogue/Playlists/playlists.leaf       # Stage 5
-Resources/Views/Catalogue/Music/music-editor.leaf        # Stage 8
-```
-
-**Modified files**:
-- `Sources/App/Modules/Catalogue/Catalogue.swift` — register Album (Stage 1), Playlist (Stage 5), Music (Stage 8)
-- `Sources/App/Modules/Catalogue/Catalogue/Routes/CatalogueQueryMapper.swift` — add Album+Playlist types (Stage 1+5); expand "music" virtual type (Stage 9)
-- `Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift` — handle `?track=` context (Stage 3)
-
----
-
-## Metadata Fetching for Albums (Stage 4)
-
-Platform focus: **Apple Music** (primary). Spotify secondary if needed.
-
-Apple Music URL patterns:
-- Song: `https://music.apple.com/us/album/name/id?i=trackID` — `og:type = "music.song"`
-- Album: `https://music.apple.com/us/album/name/id` — `og:type = "music.album"`
-
-The Apple Music checker (`PlatformChecker.appleMusic`) already matches both. The extractor gates on `og:type`:
-- Existing `MetadataExtractor.appleMusicSong` gates on `"music.song"`
-- `MetadataExtractor.appleMusicAlbum` (already implemented for basic fields) gates on `"music.album"`
-
-**Tracklist source (confirmed)**: The Apple Music album page embeds a `<script id="schema:music-album" type="application/ld+json">` block. A single page fetch is sufficient — no extra API or per-track requests needed.
-
-JSON-LD schema (`Metadata.json["schema:music-album"]`):
-```json
-{
-  "@type": "MusicAlbum",
-  "name": "...",
-  "byArtist": [{ "@type": "MusicGroup", "name": "gyuris" }],
-  "datePublished": "2026-05-14",
-  "genre": ["Hip-Hop/Rap", "Music"],
-  "tracks": [
-    { "@type": "MusicRecording", "name": "intro", "duration": "PT3M6S", "url": "https://music.apple.com/gb/song/intro/6768228102" },
-    ...
-  ]
-}
-```
-
-Stage 4 work:
-- Add `TrackMetadata` type + `tracks: [TrackMetadata]?` to `AlbumMetadata`
-- Update `MetadataExtractor.appleMusicAlbum` to parse `Metadata.json["schema:music-album"]` for `tracks[]` + use `byArtist[0].name` as fallback artist (avoids extra `music:musician` fetch)
-- Update `CreateAlbumCommand` to insert `AlbumTrack` rows (all `song_id = nil`)
-
-`FetchAlbumMetadataCommand` returns `AlbumMetadata(title, artist, releaseDate, artwork, tracks: [TrackMetadata])`.
-`CreateAlbumCommand` creates the Album + `AlbumTrack` rows (all with `song_id = nil`).
-
----
-
-## Open Decision: Track-to-Song Linking Implementation (Stage 3)
-
-When `GET /songs/new?track=42` is hit, two options for handling the link-back on save:
-
-**Option A**: `SongsWebController` handles everything — reads the `track` param, pre-fills the ViewModel, and on POST: runs `CreateSongCommand` then updates `AlbumTrack.song_id`.
-
-**Option B**: A separate route `POST /albums/:albumID/tracks/:trackID/promote` that owns the linking logic.
-
-Option A is simpler and reuses the existing song editor. Option B is cleaner separation of concerns. Decide at implementation time — likely Option A first, refactor if it gets messy.
+### Playlists (Stage 5)
+Apple Music playlist pages likely embed a similar JSON-LD block. Confirm the schema on a real playlist URL, then implement `MetadataExtractor.appleMusicPlaylist` following the same pattern.
 
 ---
 
 ## UI Notes
 
-- Album detail info line: `genre · release year` (no parent "album" field — Album is the top-level entity)
-- Song detail info line unchanged: `album name · genre · release year`
-- Album editor: title, artist, genre, release date, artwork, resource URLs, notes (no metadata autofill until Stage 4)
+- Album detail info line: `genre · release year`
+- Song detail info line: `album name · genre · release year`
+- Playlist detail: description below title; no artist or release date
+- Tracklist rendering (album and playlist detail): promoted tracks link to `/songs/:id`; orphan tracks show a promote button (`POST /songs/promote`)
+- Unified Music editor (`/music/new`): starts as a URL-only form; morphs based on detected `musicType`

--- a/tmbr/Resources/Views/Catalogue/Albums/album.leaf
+++ b/tmbr/Resources/Views/Catalogue/Albums/album.leaf
@@ -17,7 +17,10 @@
                     #if(track.href):
                     <a href="#(track.href)">#(track.title)</a>
                     #else:
-                    <span>#(track.title)</span>
+                    <form method="post" action="/songs/promote">
+                        <input type="hidden" name="previewID" value="#(track.previewID)" />
+                        <button type="submit" class="link">#(track.title)</button>
+                    </form>
                     #endif
                 </li>
                 #endfor

--- a/tmbr/Resources/Views/Catalogue/Playlists/playlist.leaf
+++ b/tmbr/Resources/Views/Catalogue/Playlists/playlist.leaf
@@ -16,6 +16,25 @@
     #endexport
 
     #export("detail-body"):
+    #if(tracks):
+    <section id="tracks-section">
+        <h3>Tracklist</h3>
+        <ol class="tracklist">
+            #for(track in tracks):
+            <li>
+                #if(track.href):
+                <a href="#(track.href)">#(track.title)</a>
+                #else:
+                <form method="post" action="/songs/promote">
+                    <input type="hidden" name="previewID" value="#(track.previewID)" />
+                    <button type="submit" class="link">#(track.title)</button>
+                </form>
+                #endif
+            </li>
+            #endfor
+        </ol>
+    </section>
+    #endif
     #endexport
 
 #endextend

--- a/tmbr/Sources/App/Modules/Catalogue/Albums/Routes/Web/Pages/Page+Album.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Albums/Routes/Web/Pages/Page+Album.swift
@@ -7,14 +7,17 @@ struct TrackViewModel: Encodable, Sendable {
     let position: Int
     let title: String
     let href: String?
+    let previewID: String?
 
     init(entry: ContainerEntry) {
         position = entry.position
         title = entry.preview.primaryInfo
         if let parentID = entry.preview.parentID {
             href = "/\(entry.preview.parentType)s/\(parentID)"
+            previewID = nil
         } else {
             href = nil
+            previewID = entry.preview.id?.uuidString
         }
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicPlaylist.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicPlaylist.swift
@@ -18,7 +18,7 @@ extension MetadataExtractor where M == PlaylistMetadata {
         // Apple Music playlists embed JSON-LD in a block tagged id="schema:music-playlist"
         let playlistJSON = metadata.json["schema:music-playlist"] as? [String: Any]
 
-        let tracks: [TrackMetadata]? = (playlistJSON?["tracks"] as? [[String: Any]])?.compactMap { track in
+        let tracks: [TrackMetadata]? = (playlistJSON?["track"] as? [[String: Any]])?.compactMap { track in
             guard let name = track["name"] as? String else { return nil }
             return TrackMetadata(name: name, url: track["url"] as? String)
         }

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicPlaylist.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicPlaylist.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+extension MetadataExtractor where M == PlaylistMetadata {
+
+    static let appleMusicPlaylist = MetadataExtractor { url, fetcher in
+        let metadata = try await fetcher(url)
+        guard metadata.type == "music.playlist" else {
+            throw MetadataExtractionError.invalidType(expected: "music.playlist", actual: metadata.type)
+        }
+
+        let artwork = metadata.tags["og:image"].flatMap { urlString -> String? in
+            guard var url = URL(string: urlString) else { return nil }
+            url.deleteLastPathComponent()
+            url.appendPathComponent("1000x1000.jpg")
+            return url.absoluteString
+        }
+
+        // Apple Music playlists embed JSON-LD in a block tagged id="schema:music-playlist"
+        let playlistJSON = metadata.json["schema:music-playlist"] as? [String: Any]
+
+        let tracks: [TrackMetadata]? = (playlistJSON?["tracks"] as? [[String: Any]])?.compactMap { track in
+            guard let name = track["name"] as? String else { return nil }
+            return TrackMetadata(name: name, url: track["url"] as? String)
+        }
+
+        return PlaylistMetadata(
+            artwork: artwork,
+            description: metadata.tags["og:description"],
+            title: metadata.tags["og:title"] ?? metadata.tags["apple:title"],
+            tracks: tracks?.isEmpty == false ? tracks : nil
+        )
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicSong.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+AppleMusicSong.swift
@@ -33,11 +33,17 @@ extension MetadataExtractor where M == SongMetadata {
             return url.absoluteString
         }
 
+        let songJSON = song.json["schema:music-song"] as? [String: Any]
+            ?? (song.json["@type"] as? String == "MusicRecording" ? song.json : nil)
+        let genre = (songJSON?["genre"] as? [String])?.first
+            ?? songJSON?["genre"] as? String
+
         return SongMetadata(
             album: try? await album,
             artist: try? await artist,
             artwork: artwork,
             externalID: song.tags["apple:content_id"],
+            genre: genre,
             releaseDate: song.tags["music:release_date"],
             title: song.tags["apple:title"]
         )

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+SpotifySong.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Extractors/MetadataExtractor+SpotifySong.swift
@@ -24,6 +24,7 @@ extension MetadataExtractor where M == SongMetadata {
             artist: song.tags["music:musician_description"],
             artwork: song.tags["og:image"],
             externalID: songID,
+            genre: nil,
             releaseDate: song.tags["music:release_date"],
             title: song.tags["og:title"]
         )

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/PlaylistMetadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/PlaylistMetadata.swift
@@ -1,1 +1,9 @@
-struct PlaylistMetadata: Sendable {}
+import Vapor
+import Core
+
+struct PlaylistMetadata: Encodable, AsyncResponseEncodable, Sendable {
+    let artwork: String?
+    let description: String?
+    let title: String?
+    let tracks: [TrackMetadata]?
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/SongMetadata.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Metadata/SongMetadata.swift
@@ -11,6 +11,8 @@ struct SongMetadata: Encodable, AsyncResponseEncodable, Sendable {
 
     let externalID: String?
 
+    let genre: String?
+
     let releaseDate: String?
 
     let title: String?

--- a/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Playlist.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Platform/Platforms/Platform+Playlist.swift
@@ -2,7 +2,7 @@ extension Platform where M == PlaylistMetadata {
 
     static var playlist: Platform<PlaylistMetadata> {
         Platform(platforms: [
-            Platform(name: "Apple Music", checker: .appleMusic),
+            Platform(name: "Apple Music", checker: .appleMusic, extractor: .appleMusicPlaylist),
             Platform(name: "Spotify", checker: .spotify),
             Platform(name: "YouTube", checker: .youtube)
         ])

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/FetchPlaylistMetadataCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/FetchPlaylistMetadataCommand.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Vapor
+import Core
+
+struct FetchPlaylistMetadataCommand: Command {
+
+    private let fetch: CommandResolver<URL, Metadata>
+
+    private let platform: Platform<PlaylistMetadata>
+
+    init(
+        fetch: CommandResolver<URL, Metadata>,
+        platform: Platform<PlaylistMetadata> = .playlist
+    ) {
+        self.fetch = fetch
+        self.platform = platform
+    }
+
+    func execute(_ url: URL) async throws -> PlaylistMetadata {
+        guard let metadata = try await platform.metadata(for: url, fetcher: fetch.callAsFunction) else {
+            throw Abort(.badRequest, reason: "Could not extract metadata from URL.")
+        }
+        return metadata
+    }
+}
+
+extension CommandFactory<URL, PlaylistMetadata> {
+
+    static var fetchPlaylistMetadata: Self {
+        CommandFactory { request in
+            FetchPlaylistMetadataCommand(
+                fetch: request.commands.catalogue.metadata
+            )
+            .logged(logger: request.logger)
+        }
+    }
+}

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/PlaylistInput.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Command/PlaylistInput.swift
@@ -15,18 +15,22 @@ struct PlaylistInput {
 
     fileprivate let title: String
 
+    let tracks: [TrackMetadata]?
+
     init(
         access: Access,
         artwork: ImageID?,
         description: String?,
         resourceURLs: [String],
-        title: String
+        title: String,
+        tracks: [TrackMetadata]? = nil
     ) {
         self.access = access
         self.artwork = artwork
         self.description = description
         self.resourceURLs = resourceURLs
         self.title = title
+        self.tracks = tracks
     }
 
     init(payload: PlaylistPayload) {

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Commands+Playlists.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Commands/Commands+Playlists.swift
@@ -17,6 +17,8 @@ extension Commands {
 
         let fetch: CommandFactory<FetchParameters<PlaylistID>, Playlist>
 
+        let metadata: CommandFactory<URL, PlaylistMetadata>
+
         let search: CommandFactory<String?, PlaylistSearchResult>
 
         init(
@@ -24,12 +26,14 @@ extension Commands {
             delete: CommandFactory<PlaylistID, Void> = .delete(\.playlists),
             edit: CommandFactory<EditPlaylistInput, Playlist> = .editPlaylist,
             fetch: CommandFactory<FetchParameters<PlaylistID>, Playlist> = .fetchPlaylist,
+            metadata: CommandFactory<URL, PlaylistMetadata> = .fetchPlaylistMetadata,
             search: CommandFactory<String?, PlaylistSearchResult> = .searchPlaylists
         ) {
             self.create = create
             self.delete = delete
             self.edit = edit
             self.fetch = fetch
+            self.metadata = metadata
             self.search = search
         }
     }

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+Playlist.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+Playlist.swift
@@ -87,7 +87,7 @@ extension Page {
             }
             async let playlist = request.commands.playlists.fetch(playlistID, for: .read)
             async let notes = request.commands.notes.query(id: playlistID, of: Playlist.previewType)
-            async let entries = request.commands.previews.listEntries(
+            async let entries = request.commands.previews.listContainerEntries(
                 ContainerEntriesInput(containerType: "playlist", containerID: playlistID)
             )
             let resolvedPlaylist = try await playlist

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+Playlist.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/Pages/Page+Playlist.swift
@@ -23,6 +23,8 @@ struct PlaylistViewModel: Encodable, Sendable {
 
     private let title: String
 
+    private let tracks: [TrackViewModel]
+
     init(
         id: PlaylistID,
         artwork: ImageViewModel?,
@@ -32,7 +34,8 @@ struct PlaylistViewModel: Encodable, Sendable {
         notesEndpoint: String,
         post: PostItemViewModel?,
         resources: [Hyperlink],
-        title: String
+        title: String,
+        tracks: [TrackViewModel] = []
     ) {
         self.id = id
         self.artwork = artwork
@@ -43,11 +46,13 @@ struct PlaylistViewModel: Encodable, Sendable {
         self.post = post
         self.resources = resources
         self.title = title
+        self.tracks = tracks
     }
 
     init(
         playlist: Playlist,
         notes: [Note],
+        tracks: [TrackViewModel],
         baseURL: String,
         allowsNewNote: Bool,
         platform: Platform<PlaylistMetadata> = .playlist
@@ -64,7 +69,8 @@ struct PlaylistViewModel: Encodable, Sendable {
             notesEndpoint: "/playlists/\(playlistID)/notes",
             post: try playlist.post.map(PostItemViewModel.init),
             resources: playlist.resourceURLs.compactMap(platform.hyperlink),
-            title: playlist.title
+            title: playlist.title,
+            tracks: tracks
         )
     }
 }
@@ -81,11 +87,16 @@ extension Page {
             }
             async let playlist = request.commands.playlists.fetch(playlistID, for: .read)
             async let notes = request.commands.notes.query(id: playlistID, of: Playlist.previewType)
+            async let entries = request.commands.previews.listEntries(
+                ContainerEntriesInput(containerType: "playlist", containerID: playlistID)
+            )
             let resolvedPlaylist = try await playlist
             let allowsNewNote = (try? await request.permissions.playlists.edit.grant(resolvedPlaylist)) != nil
+            let tracks = try await entries.map(TrackViewModel.init)
             return try PlaylistViewModel(
                 playlist: resolvedPlaylist,
                 notes: await notes,
+                tracks: tracks,
                 baseURL: request.baseURL,
                 allowsNewNote: allowsNewNote
             )

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/PlaylistEditorPayload.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/PlaylistEditorPayload.swift
@@ -16,6 +16,8 @@ struct PlaylistEditorPayload: Decodable, Sendable {
 
     let notes: [NotePayload]
 
+    private let tracklistJSONRaw: String?
+
     let resourceURLs: [String]
 
     let title: String
@@ -34,6 +36,12 @@ struct PlaylistEditorPayload: Decodable, Sendable {
         resourceURLs.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
     }
 
+    var tracks: [TrackMetadata]? {
+        guard let raw = tracklistJSONRaw, !raw.isEmpty,
+              let data = raw.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode([TrackMetadata].self, from: data)
+    }
+
     enum CodingKeys: String, CodingKey {
         case _csrf
         case access
@@ -41,6 +49,7 @@ struct PlaylistEditorPayload: Decodable, Sendable {
         case artworkSourceURLRaw = "artwork-source-url"
         case description
         case notes
+        case tracklistJSONRaw = "tracklist-json"
         case resourceURLs
         case title
     }
@@ -52,6 +61,7 @@ struct PlaylistEditorPayload: Decodable, Sendable {
         artworkSourceURLRaw: String? = nil,
         description: String? = nil,
         notes: [NotePayload] = [],
+        tracklistJSONRaw: String? = nil,
         resourceURLs: [String] = [],
         title: String = ""
     ) {
@@ -61,6 +71,7 @@ struct PlaylistEditorPayload: Decodable, Sendable {
         self.artworkSourceURLRaw = artworkSourceURLRaw
         self.description = description
         self.notes = notes
+        self.tracklistJSONRaw = tracklistJSONRaw
         self.resourceURLs = resourceURLs
         self.title = title
     }
@@ -74,7 +85,8 @@ extension PlaylistInput {
             artwork: artworkId ?? payload.artworkId,
             description: payload.description,
             resourceURLs: payload.filteredResourceURLs,
-            title: payload.title
+            title: payload.title,
+            tracks: payload.tracks
         )
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/PlaylistsWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Playlists/Routes/Web/PlaylistsWebController.swift
@@ -11,6 +11,7 @@ struct PlaylistsWebController: RouteCollection {
     }
 
     func boot(routes: RoutesBuilder) throws {
+        let playlistsRoute = routes.grouped("playlists")
         let recoveringRoute = routes.grouped("playlists")
             .grouped(RecoverMiddleware())
 
@@ -21,12 +22,19 @@ struct PlaylistsWebController: RouteCollection {
         recoveringRoute.get("new", page: .createPlaylist)
         recoveringRoute.post("new", use: createPlaylist)
 
+        playlistsRoute.get("metadata", use: metadata)
         recoveringRoute.post("preview", page: .playlistPreview)
 
         recoveringRoute.get(":playlistID", "edit", page: .editPlaylist)
         recoveringRoute.post(":playlistID", use: updatePlaylist)
 
         recoveringRoute.post(":playlistID", "notes", use: createNote)
+    }
+
+    @Sendable
+    private func metadata(_ request: Request) async throws -> PlaylistMetadata {
+        let url = try request.query.get(String.self, at: "url")
+        return try await request.commands.playlists.metadata(url)
     }
 
     @Sendable
@@ -64,6 +72,18 @@ struct PlaylistsWebController: RouteCollection {
                         NoteInput(body: entry.body, access: entry.access && payload.access)
                     }
                     _ = try await commands.notes.batchCreate(noteInputs, for: preview)
+                    if let tracks = playlistInput.tracks, !tracks.isEmpty {
+                        try await commands.previews.importTracks(
+                            ImportAlbumTracksInput(
+                                albumID: try playlist.requireID(),
+                                access: payload.access,
+                                artist: nil,
+                                ownerID: preview.$parentOwner.id,
+                                tracks: tracks,
+                                containerType: "playlist"
+                            )
+                        )
+                    }
                 case .update(let playlistID):
                     playlist = try await commands.playlists.edit(playlistInput.edit(id: playlistID))
                     let preview = try await commands.previews.fetch(playlist.$preview.id, for: .write)

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/CreateSongCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/CreateSongCommand.swift
@@ -40,7 +40,7 @@ struct CreateSongCommand: Command {
 }
 
 extension CommandFactory<SongInput, Song> {
-    
+
     static var createSong: Self {
         CommandFactory { request in
             CreateSongCommand(
@@ -48,6 +48,18 @@ extension CommandFactory<SongInput, Song> {
                 database: request.commandDB,
                 permission: request.permissions.songs.create,
                 validate: .song
+            )
+            .logged(logger: request.logger)
+        }
+    }
+
+    static var promoteCreate: Self {
+        CommandFactory { request in
+            CreateSongCommand(
+                configure: .song,
+                database: request.commandDB,
+                permission: request.permissions.songs.create,
+                validate: .songPromotion
             )
             .logged(logger: request.logger)
         }

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/CreateSongCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/CreateSongCommand.swift
@@ -53,15 +53,5 @@ extension CommandFactory<SongInput, Song> {
         }
     }
 
-    static var promoteCreate: Self {
-        CommandFactory { request in
-            CreateSongCommand(
-                configure: .song,
-                database: request.commandDB,
-                permission: request.permissions.songs.create,
-                validate: .songPromotion
-            )
-            .logged(logger: request.logger)
-        }
-    }
+
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/PromoteSongCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/PromoteSongCommand.swift
@@ -11,35 +11,85 @@ struct PromoteSongCommand: Command {
 
     private let fetchAlbum: CommandResolver<FetchParameters<AlbumID>, Album>
 
+    private let fetchSongMetadata: CommandResolver<URL, SongMetadata>
+
+    private let galleryLookup: CommandResolver<String, Image?>
+
+    private let galleryAddFromURL: CommandResolver<ImageURLPayload, Image>
+
     private let create: CommandResolver<SongInput, Song>
 
     init(
         fetchPreview: CommandResolver<FetchParameters<PreviewID>, Preview>,
         fetchContainerEntry: CommandResolver<ContainerEntryInput, ContainerEntry>,
         fetchAlbum: CommandResolver<FetchParameters<AlbumID>, Album>,
+        fetchSongMetadata: CommandResolver<URL, SongMetadata>,
+        galleryLookup: CommandResolver<String, Image?>,
+        galleryAddFromURL: CommandResolver<ImageURLPayload, Image>,
         create: CommandResolver<SongInput, Song>
     ) {
         self.fetchPreview = fetchPreview
         self.fetchContainerEntry = fetchContainerEntry
         self.fetchAlbum = fetchAlbum
+        self.fetchSongMetadata = fetchSongMetadata
+        self.galleryLookup = galleryLookup
+        self.galleryAddFromURL = galleryAddFromURL
         self.create = create
     }
 
     func execute(_ previewID: UUID) async throws -> Song {
         let preview = try await fetchPreview(previewID, for: .read)
-        let entry = try await fetchContainerEntry(ContainerEntryInput(previewID: previewID, containerType: "album"))
-        let album = try await fetchAlbum(entry.containerID, for: .read)
-        return try await create(SongInput(
-            previewID: previewID,
-            access: preview.parentAccess,
-            album: album.title,
-            artist: album.artist,
-            artwork: album.$artwork.id,
-            genre: album.genre,
-            releaseDate: nil,
-            resourceURLs: preview.externalLinks,
-            title: preview.primaryInfo
-        ))
+        let entry = try await fetchContainerEntry(ContainerEntryInput(previewID: previewID))
+
+        if entry.containerType == "album" {
+            let album = try await fetchAlbum(entry.containerID, for: .read)
+            return try await create(SongInput(
+                previewID: previewID,
+                access: preview.parentAccess,
+                album: album.title,
+                artist: album.artist,
+                artwork: album.$artwork.id,
+                genre: album.genre,
+                releaseDate: album.releaseDate,
+                resourceURLs: preview.externalLinks,
+                title: preview.primaryInfo
+            ))
+        } else {
+            let songMeta = await fetchMetadataFromURL(preview.externalLinks.first)
+            let artworkID = await resolveArtwork(songMeta?.artwork, title: preview.primaryInfo)
+            return try await create(SongInput(
+                previewID: previewID,
+                access: preview.parentAccess,
+                album: songMeta?.album,
+                artist: songMeta?.artist ?? "",
+                artwork: artworkID,
+                genre: songMeta?.genre,
+                releaseDate: songMeta?.releaseDate.flatMap(Self.parseDate),
+                resourceURLs: preview.externalLinks,
+                title: preview.primaryInfo
+            ))
+        }
+    }
+
+    private func fetchMetadataFromURL(_ urlString: String?) async -> SongMetadata? {
+        guard let urlString, let url = URL(string: urlString) else { return nil }
+        return try? await fetchSongMetadata(url)
+    }
+
+    private func resolveArtwork(_ urlString: String?, title: String) async -> ImageID? {
+        guard let urlString else { return nil }
+        if let existing = try? await galleryLookup(urlString) {
+            return try? existing.requireID()
+        }
+        return try? await galleryAddFromURL(ImageURLPayload(url: urlString, alt: title)).requireID()
+    }
+
+    private static func parseDate(from string: String) -> Date? {
+        if let date = ISO8601DateFormatter().date(from: string) { return date }
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f.date(from: string)
     }
 }
 
@@ -50,7 +100,10 @@ extension CommandFactory<UUID, Song> {
                 fetchPreview: request.commands.previews.fetch,
                 fetchContainerEntry: request.commands.previews.fetchContainerEntry,
                 fetchAlbum: request.commands.albums.fetch,
-                create: request.commands.songs.create
+                fetchSongMetadata: request.commands.songs.metadata,
+                galleryLookup: request.commands.gallery.lookup,
+                galleryAddFromURL: request.commands.gallery.addFromURL,
+                create: request.commands.songs.promoteCreate
             )
             .logged(name: "Promote Song", logger: request.logger)
         }

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/PromoteSongCommand.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/PromoteSongCommand.swift
@@ -2,6 +2,7 @@ import Foundation
 import Vapor
 import Core
 import AuthKit
+import Fluent
 
 struct PromoteSongCommand: Command {
 
@@ -17,7 +18,13 @@ struct PromoteSongCommand: Command {
 
     private let galleryAddFromURL: CommandResolver<ImageURLPayload, Image>
 
-    private let create: CommandResolver<SongInput, Song>
+    private let configure: ModelConfiguration<Song, SongInput>
+
+    private let database: Database
+
+    private let permission: AuthPermissionResolver<Void>
+
+    private let validate: Validator<SongInput>
 
     init(
         fetchPreview: CommandResolver<FetchParameters<PreviewID>, Preview>,
@@ -26,7 +33,10 @@ struct PromoteSongCommand: Command {
         fetchSongMetadata: CommandResolver<URL, SongMetadata>,
         galleryLookup: CommandResolver<String, Image?>,
         galleryAddFromURL: CommandResolver<ImageURLPayload, Image>,
-        create: CommandResolver<SongInput, Song>
+        configure: ModelConfiguration<Song, SongInput>,
+        database: Database,
+        permission: AuthPermissionResolver<Void>,
+        validate: Validator<SongInput>
     ) {
         self.fetchPreview = fetchPreview
         self.fetchContainerEntry = fetchContainerEntry
@@ -34,7 +44,10 @@ struct PromoteSongCommand: Command {
         self.fetchSongMetadata = fetchSongMetadata
         self.galleryLookup = galleryLookup
         self.galleryAddFromURL = galleryAddFromURL
-        self.create = create
+        self.configure = configure
+        self.database = database
+        self.permission = permission
+        self.validate = validate
     }
 
     func execute(_ previewID: UUID) async throws -> Song {
@@ -43,7 +56,7 @@ struct PromoteSongCommand: Command {
 
         if entry.containerType == "album" {
             let album = try await fetchAlbum(entry.containerID, for: .read)
-            return try await create(SongInput(
+            return try await save(SongInput(
                 previewID: previewID,
                 access: preview.parentAccess,
                 album: album.title,
@@ -57,7 +70,7 @@ struct PromoteSongCommand: Command {
         } else {
             let songMeta = await fetchMetadataFromURL(preview.externalLinks.first)
             let artworkID = await resolveArtwork(songMeta?.artwork, title: preview.primaryInfo)
-            return try await create(SongInput(
+            return try await save(SongInput(
                 previewID: previewID,
                 access: preview.parentAccess,
                 album: songMeta?.album,
@@ -69,6 +82,15 @@ struct PromoteSongCommand: Command {
                 title: preview.primaryInfo
             ))
         }
+    }
+
+    private func save(_ input: SongInput) async throws -> Song {
+        try validate(input)
+        let user = try await permission.grant()
+        var song = Song(owner: user.userID)
+        configure(&song, with: input)
+        try await song.save(on: database)
+        return song
     }
 
     private func fetchMetadataFromURL(_ urlString: String?) async -> SongMetadata? {
@@ -103,7 +125,10 @@ extension CommandFactory<UUID, Song> {
                 fetchSongMetadata: request.commands.songs.metadata,
                 galleryLookup: request.commands.gallery.lookup,
                 galleryAddFromURL: request.commands.gallery.addFromURL,
-                create: request.commands.songs.promoteCreate
+                configure: .song,
+                database: request.commandDB,
+                permission: request.permissions.songs.create,
+                validate: .songPromotion
             )
             .logged(name: "Promote Song", logger: request.logger)
         }

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/SongInput.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Command/SongInput.swift
@@ -86,6 +86,15 @@ extension Validator where Input == SongInput {
             }
         }
     }
+
+    // Lenient validator for the promote path — artist may be unknown (e.g. playlist track)
+    static var songPromotion: Self {
+        Validator { song in
+            guard !song.title.trimmed.isEmpty else {
+                throw Abort(.badRequest, reason: "The song title is missing")
+            }
+        }
+    }
 }
 
 extension SongInput {

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Commands+Songs.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Commands+Songs.swift
@@ -23,8 +23,6 @@ extension Commands {
 
         let promote: CommandFactory<UUID, Song>
 
-        let promoteCreate: CommandFactory<SongInput, Song>
-
         let search: CommandFactory<String?, SongSearchResult>
 
         init(
@@ -35,7 +33,6 @@ extension Commands {
             lookup: CommandFactory<String, Song?> = .lookupSong,
             metadata: CommandFactory<URL, SongMetadata> = .fetchMetadata,
             promote: CommandFactory<UUID, Song> = .promoteSong,
-            promoteCreate: CommandFactory<SongInput, Song> = .promoteCreate,
             search: CommandFactory<String?, SongSearchResult> = .searchSongs
         ) {
             self.create = create
@@ -45,7 +42,6 @@ extension Commands {
             self.lookup = lookup
             self.metadata = metadata
             self.promote = promote
-            self.promoteCreate = promoteCreate
             self.search = search
         }
     }

--- a/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Commands+Songs.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Songs/Commands/Commands+Songs.swift
@@ -23,6 +23,8 @@ extension Commands {
 
         let promote: CommandFactory<UUID, Song>
 
+        let promoteCreate: CommandFactory<SongInput, Song>
+
         let search: CommandFactory<String?, SongSearchResult>
 
         init(
@@ -33,6 +35,7 @@ extension Commands {
             lookup: CommandFactory<String, Song?> = .lookupSong,
             metadata: CommandFactory<URL, SongMetadata> = .fetchMetadata,
             promote: CommandFactory<UUID, Song> = .promoteSong,
+            promoteCreate: CommandFactory<SongInput, Song> = .promoteCreate,
             search: CommandFactory<String?, SongSearchResult> = .searchSongs
         ) {
             self.create = create
@@ -42,6 +45,7 @@ extension Commands {
             self.lookup = lookup
             self.metadata = metadata
             self.promote = promote
+            self.promoteCreate = promoteCreate
             self.search = search
         }
     }

--- a/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+FetchContainerEntry.swift
+++ b/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+FetchContainerEntry.swift
@@ -5,18 +5,24 @@ import Fluent
 
 struct ContainerEntryInput: Sendable {
     let previewID: UUID
-    let containerType: String
+    let containerType: String?
+
+    init(previewID: UUID, containerType: String? = nil) {
+        self.previewID = previewID
+        self.containerType = containerType
+    }
 }
 
 extension Command where Self == PlainCommand<ContainerEntryInput, ContainerEntry> {
     static func fetchContainerEntry(database: Database) -> Self {
         PlainCommand { input in
-            guard let entry = try await ContainerEntry.query(on: database)
+            var query = ContainerEntry.query(on: database)
                 .filter(\.$preview.$id == input.previewID)
-                .filter(\.$containerType == input.containerType)
-                .first()
-            else {
-                throw Abort(.notFound, reason: "No \(input.containerType) container entry found for this preview")
+            if let type = input.containerType {
+                query = query.filter(\.$containerType == type)
+            }
+            guard let entry = try await query.first() else {
+                throw Abort(.notFound, reason: "No container entry found for this preview")
             }
             return entry
         }

--- a/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+ImportAlbumTracks.swift
+++ b/tmbr/Sources/App/Modules/Previews/Commands/Command/Command+ImportAlbumTracks.swift
@@ -5,11 +5,28 @@ import Fluent
 import AuthKit
 
 struct ImportAlbumTracksInput: Sendable {
-    let albumID: AlbumID
+    let albumID: Int
     let access: Access
-    let artist: String
+    let artist: String?
     let ownerID: UserID
     let tracks: [TrackMetadata]
+    let containerType: String
+
+    init(
+        albumID: Int,
+        access: Access,
+        artist: String?,
+        ownerID: UserID,
+        tracks: [TrackMetadata],
+        containerType: String = "album"
+    ) {
+        self.albumID = albumID
+        self.access = access
+        self.artist = artist
+        self.ownerID = ownerID
+        self.tracks = tracks
+        self.containerType = containerType
+    }
 }
 
 extension Command where Self == PlainCommand<ImportAlbumTracksInput, Void> {
@@ -24,12 +41,14 @@ extension Command where Self == PlainCommand<ImportAlbumTracksInput, Void> {
                     parentType: "track"
                 )
                 preview.primaryInfo = track.name
-                preview.secondaryInfo = "by \(input.artist)"
+                if let artist = input.artist {
+                    preview.secondaryInfo = "by \(artist)"
+                }
                 preview.externalLinks = [track.url].compactMap { $0 }
                 try await preview.save(on: database)
 
                 let entry = ContainerEntry(
-                    containerType: "album",
+                    containerType: input.containerType,
                     containerID: input.albumID,
                     previewID: try preview.requireID(),
                     position: index + 1


### PR DESCRIPTION
## Summary
- `PlaylistMetadata` expanded with `title`, `description`, `artwork`, `tracks`; `FetchPlaylistMetadataCommand` + `MetadataExtractor.appleMusicPlaylist` added
- `GET /playlists/metadata` route wired up; `playlist-editor.js` calls it on URL paste and stores tracks in hidden `tracklist-json` field
- `PlaylistsWebController.create` imports orphan Preview + ContainerEntry rows for each track (same pattern as albums)
- `Page+Playlist.swift` fetches ContainerEntry rows and passes `TrackViewModel[]` to the template; `playlist.leaf` renders the tracklist with promote forms for unlinked tracks
- `promote` route in `SongsWebController` extended to handle both `"album"` and `"playlist"` container types
- `TrackViewModel` gains `previewID` field; `album.leaf` updated to show promote form instead of `<span>` for unlinked tracks

## Test plan
- [ ] Paste an Apple Music playlist URL in the playlist editor — tracklist should populate on save
- [ ] Playlist detail page shows the tracklist; unlinked tracks show a promote button
- [ ] Promoting a playlist track creates a Song and redirects to `/songs/:id`
- [ ] Albums: unlinked tracks now show a promote button (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)