### PR TITLE
Stage 7: Unified /music/new editor with URL-driven type detection

### DIFF
--- a/tmbr/Public/Scripts/Catalogue/Music/music-editor.js
+++ b/tmbr/Public/Scripts/Catalogue/Music/music-editor.js
@@ -1,0 +1,91 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const urlInput = document.getElementById('music-editor-url');
+    const typeSelector = document.getElementById('music-type-selector');
+    const fieldsContainer = document.getElementById('music-editor-fields');
+    const statusEl = document.getElementById('music-autofill-status');
+    const form = document.getElementById('music-editor-form');
+
+    if (!urlInput || !form) return;
+
+    // Type → target form action
+    const typeActions = {
+        song: '/songs/new',
+        album: '/albums/new',
+        playlist: '/playlists/new',
+    };
+
+    let debounceTimer = null;
+    let currentType = null;
+
+    function setStatus(msg, hidden = false) {
+        if (!statusEl) return;
+        statusEl.textContent = msg;
+        statusEl.hidden = hidden;
+    }
+
+    function applyMetadata(data) {
+        currentType = data.musicType;
+        if (!currentType || currentType === 'unknown') {
+            typeSelector.hidden = false;
+            fieldsContainer.hidden = true;
+            setStatus('Could not detect music type — please select manually.', false);
+            return;
+        }
+        typeSelector.hidden = true;
+        fieldsContainer.hidden = false;
+        setStatus('');
+
+        // Redirect to the type-specific editor pre-filled via query string
+        const params = new URLSearchParams();
+        if (data.title) params.set('title', data.title);
+        if (data.artist) params.set('artist', data.artist);
+        if (data.description) params.set('description', data.description);
+        if (data.artwork) params.set('artworkURL', data.artwork);
+        if (data.releaseDate) params.set('releaseDate', data.releaseDate);
+        if (data.genre) params.set('genre', data.genre);
+        if (Array.isArray(data.tracks) && data.tracks.length > 0) {
+            params.set('tracklistJSON', JSON.stringify(data.tracks));
+        }
+        params.set('url', urlInput.value);
+
+        const action = typeActions[currentType];
+        if (action) {
+            window.location.href = `${action}?${params}`;
+        }
+    }
+
+    async function fetchMetadata(url) {
+        try {
+            setStatus('Detecting…', false);
+            const res = await fetch(`/music/metadata?url=${encodeURIComponent(url)}`);
+            if (!res.ok) throw new Error(`Status ${res.status}`);
+            const data = await res.json();
+            applyMetadata(data);
+        } catch (err) {
+            console.error(err);
+            setStatus('Could not fetch metadata. Please paste a valid Apple Music link.', false);
+            typeSelector.hidden = false;
+        }
+    }
+
+    urlInput.addEventListener('input', () => {
+        clearTimeout(debounceTimer);
+        const value = urlInput.value.trim();
+        if (!value) {
+            typeSelector.hidden = true;
+            fieldsContainer.hidden = true;
+            setStatus('', true);
+            return;
+        }
+        debounceTimer = setTimeout(() => fetchMetadata(value), 500);
+    });
+
+    // Manual type selection → redirect to type-specific editor with URL prefilled
+    typeSelector.addEventListener('change', (e) => {
+        const type = e.target.value;
+        const action = typeActions[type];
+        if (action && urlInput.value) {
+            window.location.href = `${action}?url=${encodeURIComponent(urlInput.value)}`;
+        }
+    });
+});

--- a/tmbr/Public/Scripts/Catalogue/Music/music-editor.js
+++ b/tmbr/Public/Scripts/Catalogue/Music/music-editor.js
@@ -1,91 +1,281 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const urlInput = document.getElementById('music-editor-url');
-    const typeSelector = document.getElementById('music-type-selector');
-    const fieldsContainer = document.getElementById('music-editor-fields');
-    const statusEl = document.getElementById('music-autofill-status');
-    const form = document.getElementById('music-editor-form');
+    const form = document.getElementById('editor-form');
+    if (!form) return;
 
-    if (!urlInput || !form) return;
+    const titleInput = document.getElementById('editor-title');
+    const statusEl  = document.getElementById('autofill-status');
 
-    // Type → target form action
+    const resourcesSection = document.getElementById('resources-section');
+    const detailsSection   = document.getElementById('details-section');
+    const notesSection     = document.getElementById('notes-section');
+    const gallery          = document.getElementById('gallery');
+    const gallerySection   = document.getElementById('gallery-section');
+    const galleryStatus    = document.getElementById('gallery-status');
+    const galleryTitle     = document.getElementById('gallery-title');
+    const notesGalleryOpen = document.getElementById('notes-gallery-open');
+    const galleryClose     = document.getElementById('gallery-close');
+
+    const persistence = new PersistenceController();
+    const uploads     = new UploadsController();
+    const metadata    = new MetadataController({ endpoint: '/music/metadata' });
+
+    const storageKey = 'editor:music:new';
+
     const typeActions = {
-        song: '/songs/new',
-        album: '/albums/new',
+        song:     '/songs/new',
+        album:    '/albums/new',
         playlist: '/playlists/new',
     };
 
-    let debounceTimer = null;
-    let currentType = null;
+    const typePreviewActions = {
+        song:     '/songs/preview',
+        album:    '/albums/preview',
+        playlist: '/playlists/preview',
+    };
 
-    function setStatus(msg, hidden = false) {
-        if (!statusEl) return;
-        statusEl.textContent = msg;
-        statusEl.hidden = hidden;
+    const fields = {
+        song: {
+            group:          document.querySelector('[data-music-type="song"]'),
+            artist:         document.getElementById('editor-song-artist'),
+            album:          document.getElementById('editor-song-album'),
+            releaseDate:    document.getElementById('editor-song-release-date'),
+            releaseDateISO: document.getElementById('editor-song-release-date-iso'),
+            genre:          document.getElementById('editor-song-genre'),
+        },
+        album: {
+            group:          document.querySelector('[data-music-type="album"]'),
+            artist:         document.getElementById('editor-album-artist'),
+            releaseDate:    document.getElementById('editor-album-release-date'),
+            releaseDateISO: document.getElementById('editor-album-release-date-iso'),
+            genre:          document.getElementById('editor-album-genre'),
+            tracklistJson:  document.getElementById('editor-album-tracklist-json'),
+        },
+        playlist: {
+            group:          document.querySelector('[data-music-type="playlist"]'),
+            description:    document.getElementById('editor-playlist-description'),
+            tracklistJson:  document.getElementById('editor-playlist-tracklist-json'),
+        },
+    };
+
+    let currentType = 'song';
+
+    const artwork = new ArtworkController({
+        hiddenInput:      document.getElementById('editor-artwork-id'),
+        externalUrlInput: document.getElementById('editor-artwork-source-url'),
+        placeholder:      document.getElementById('artwork-placeholder'),
+        imageEl:          document.getElementById('artwork-image'),
+        clearButton:      document.getElementById('artwork-clear'),
+    }, {
+        onChange:      () => saveDraft(),
+        onOpenGallery: () => imagePicker.open('image'),
+    });
+    artwork.init();
+
+    const notes = new NotesController(
+        { section: notesSection },
+        { onInput: () => saveDraft(), onAccessChange: () => saveDraft() }
+    );
+    notes.init();
+
+    const lookup = new LookupController({ endpoint: '/songs/lookup', excludeID: null });
+    const duplicateAlert = new DuplicateAlertController(
+        { containerEl: document.getElementById('duplicate-container'), linkSelector: '#duplicate-song-link' },
+        { onNavigate: () => persistence.clear(storageKey) }
+    );
+    duplicateAlert.init();
+
+    function selectType(type) {
+        if (!fields[type]) return;
+        currentType = type;
+
+        document.querySelectorAll('input[name="music-type"]').forEach(r => {
+            r.checked = r.value === type;
+        });
+
+        Object.entries(fields).forEach(([t, f]) => {
+            const active = t === type;
+            f.group.hidden = !active;
+            f.group.querySelectorAll('input, textarea').forEach(el => {
+                el.disabled = !active;
+            });
+        });
+
+        form.action = typeActions[type];
     }
 
     function applyMetadata(data) {
-        currentType = data.musicType;
-        if (!currentType || currentType === 'unknown') {
-            typeSelector.hidden = false;
-            fieldsContainer.hidden = true;
-            setStatus('Could not detect music type — please select manually.', false);
-            return;
+        if (data.musicType && data.musicType !== 'unknown') {
+            selectType(data.musicType);
         }
-        typeSelector.hidden = true;
-        fieldsContainer.hidden = false;
-        setStatus('');
+        const type = currentType;
+        const f = fields[type];
 
-        // Redirect to the type-specific editor pre-filled via query string
-        const params = new URLSearchParams();
-        if (data.title) params.set('title', data.title);
-        if (data.artist) params.set('artist', data.artist);
-        if (data.description) params.set('description', data.description);
-        if (data.artwork) params.set('artworkURL', data.artwork);
-        if (data.releaseDate) params.set('releaseDate', data.releaseDate);
-        if (data.genre) params.set('genre', data.genre);
-        if (Array.isArray(data.tracks) && data.tracks.length > 0) {
-            params.set('tracklistJSON', JSON.stringify(data.tracks));
+        if (!titleInput.value && data.title) titleInput.value = data.title;
+        if (artwork.isEmpty() && data.artwork) artwork.setExternalURL(data.artwork);
+
+        if (type === 'song' || type === 'album') {
+            if (f.artist && !f.artist.value && data.artist) f.artist.value = data.artist;
+            if (f.genre && !f.genre.value && data.genre) f.genre.value = data.genre;
+            if (f.releaseDate && data.releaseDate) f.releaseDate.value = data.releaseDate.substring(0, 10);
         }
-        params.set('url', urlInput.value);
-
-        const action = typeActions[currentType];
-        if (action) {
-            window.location.href = `${action}?${params}`;
+        if (type === 'song' && fields.song.album && !fields.song.album.value && data.album) {
+            fields.song.album.value = data.album;
+        }
+        if ((type === 'album' || type === 'playlist') && f.tracklistJson) {
+            if (Array.isArray(data.tracks) && data.tracks.length > 0) {
+                f.tracklistJson.value = JSON.stringify(data.tracks);
+            }
+        }
+        if (type === 'playlist' && f.description && !f.description.value && data.description) {
+            f.description.value = data.description;
         }
     }
 
-    async function fetchMetadata(url) {
-        try {
-            setStatus('Detecting…', false);
-            const res = await fetch(`/music/metadata?url=${encodeURIComponent(url)}`);
-            if (!res.ok) throw new Error(`Status ${res.status}`);
-            const data = await res.json();
-            applyMetadata(data);
-        } catch (err) {
-            console.error(err);
-            setStatus('Could not fetch metadata. Please paste a valid Apple Music link.', false);
-            typeSelector.hidden = false;
+    const resourceInputs = new ResourceInputsController(
+        { section: resourcesSection },
+        {
+            onUrlChange: (url) => autofill.fetchAndApply(url),
+            onInput: () => saveDraft(),
         }
-    }
+    );
+    resourceInputs.init();
 
-    urlInput.addEventListener('input', () => {
-        clearTimeout(debounceTimer);
-        const value = urlInput.value.trim();
-        if (!value) {
-            typeSelector.hidden = true;
-            fieldsContainer.hidden = true;
-            setStatus('', true);
-            return;
-        }
-        debounceTimer = setTimeout(() => fetchMetadata(value), 500);
+    document.querySelectorAll('input[name="music-type"]').forEach(radio => {
+        radio.addEventListener('change', () => {
+            if (radio.checked) { selectType(radio.value); saveDraft(); }
+        });
     });
 
-    // Manual type selection → redirect to type-specific editor with URL prefilled
-    typeSelector.addEventListener('change', (e) => {
-        const type = e.target.value;
-        const action = typeActions[type];
-        if (action && urlInput.value) {
-            window.location.href = `${action}?url=${encodeURIComponent(urlInput.value)}`;
+    function getState() {
+        return {
+            type:         currentType,
+            title:        titleInput?.value || '',
+            notes:        notes.getNotes(),
+            resourceURLs: resourceInputs.getValues(),
+            artworkId:           artwork.getArtworkId(),
+            artworkThumbnailUrl: artwork.getThumbnailUrl(),
+            artworkExternalURL:  artwork.getExternalURL(),
+            song: {
+                artist:      fields.song.artist?.value || '',
+                album:       fields.song.album?.value || '',
+                releaseDate: fields.song.releaseDate?.value || '',
+                genre:       fields.song.genre?.value || '',
+            },
+            album: {
+                artist:        fields.album.artist?.value || '',
+                releaseDate:   fields.album.releaseDate?.value || '',
+                genre:         fields.album.genre?.value || '',
+                tracklistJson: fields.album.tracklistJson?.value || '',
+            },
+            playlist: {
+                description:   fields.playlist.description?.value || '',
+                tracklistJson: fields.playlist.tracklistJson?.value || '',
+            },
+        };
+    }
+
+    function setState(state) {
+        if (!state || typeof state !== 'object') return;
+        if (state.type) selectType(state.type);
+        if (state.title && !titleInput.value) titleInput.value = state.title;
+        if (Array.isArray(state.notes)) notes.setNotes(state.notes, true);
+        if (Array.isArray(state.resourceURLs)) resourceInputs.setValues(state.resourceURLs);
+        if (artwork.isEmpty()) {
+            if (state.artworkId) artwork.setArtwork(state.artworkId, state.artworkThumbnailUrl);
+            else if (state.artworkExternalURL) artwork.setExternalURL(state.artworkExternalURL);
         }
+        const s = state.song || {};
+        const a = state.album || {};
+        const p = state.playlist || {};
+        if (s.artist && !fields.song.artist?.value) fields.song.artist.value = s.artist;
+        if (s.album && !fields.song.album?.value) fields.song.album.value = s.album;
+        if (s.releaseDate && !fields.song.releaseDate?.value) fields.song.releaseDate.value = s.releaseDate;
+        if (s.genre && !fields.song.genre?.value) fields.song.genre.value = s.genre;
+        if (a.artist && !fields.album.artist?.value) fields.album.artist.value = a.artist;
+        if (a.releaseDate && !fields.album.releaseDate?.value) fields.album.releaseDate.value = a.releaseDate;
+        if (a.genre && !fields.album.genre?.value) fields.album.genre.value = a.genre;
+        if (a.tracklistJson && fields.album.tracklistJson) fields.album.tracklistJson.value = a.tracklistJson;
+        if (p.description && !fields.playlist.description?.value) fields.playlist.description.value = p.description;
+        if (p.tracklistJson && fields.playlist.tracklistJson) fields.playlist.tracklistJson.value = p.tracklistJson;
+    }
+
+    function saveDraft() { persistence.save(storageKey, getState()); }
+    function loadDraft() {
+        if (persistence.clearIfPending(storageKey)) return;
+        const saved = persistence.load(storageKey);
+        if (saved) setState(saved);
+    }
+
+    function fillPreview() {
+        const pf = document.getElementById('preview-form');
+        if (!pf) return;
+        pf.action = typePreviewActions[currentType];
+        const set = (id, v) => { const el = pf.querySelector(`#${id}`); if (el) el.value = v || ''; };
+        const f = fields[currentType];
+        set('preview-title', titleInput?.value || '');
+        set('preview-artwork-url', artwork.getThumbnailUrl());
+        set('preview-resource-urls', resourceInputs.getValues().join('\n'));
+        set('preview-notes', notes.getValues().join('\n\n'));
+        if (currentType === 'song' || currentType === 'album') {
+            set('preview-artist', f.artist?.value || '');
+            set('preview-genre', f.genre?.value || '');
+            set('preview-release-date', f.releaseDate?.value || '');
+        }
+        if (currentType === 'song') set('preview-album', fields.song.album?.value || '');
+        if (currentType === 'playlist') set('preview-description', f.description?.value || '');
+        pf.submit();
+    }
+
+    const autofill = {
+        async fetchAndApply(url) {
+            try {
+                const data = await metadata.fetch(url);
+                if (statusEl) { statusEl.textContent = ''; statusEl.hidden = true; }
+                applyMetadata(data);
+                if (currentType === 'song') {
+                    const html = await lookup.fetch(url).catch(() => null);
+                    if (html) duplicateAlert.show(html);
+                }
+                saveDraft();
+            } catch (err) {
+                handleAutofillError(err, url, statusEl);
+            }
+        }
+    };
+    retryPendingMetadata(autofill);
+    loadDraft();
+
+    titleInput?.addEventListener('input', saveDraft);
+
+    const imagePicker = new ImagePickerController(
+        { gallery, gallerySection, galleryStatus, galleryTitle, notesOpenButton: notesGalleryOpen, galleryCloseButton: galleryClose },
+        { onSelectImage: (id, url) => artwork.setArtwork(id, url), onInsertMarkdown: (md) => notes.insertMarkdown(md), imageTitle: 'Select artwork' }
+    );
+    imagePicker.init();
+
+    new DragAndDropController({ resourcesSection, detailsSection, notesSection }, { uploads, artwork, notes }).init();
+    new ShortcutsController([ShortcutsController.login, ShortcutsController.preview(() => fillPreview())]).init();
+
+    document.getElementById('editor-preview')?.addEventListener('click', () => fillPreview());
+
+    form.addEventListener('keydown', (e) => {
+        if (e.key !== 'Enter' || e.target.tagName !== 'INPUT') return;
+        e.preventDefault();
+        const focusable = Array.from(form.querySelectorAll('input:not([type="hidden"]), textarea')).filter(el => !el.disabled);
+        const idx = focusable.indexOf(e.target);
+        if (idx !== -1 && idx < focusable.length - 1) focusable[idx + 1].focus();
+    });
+
+    form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        form.action = typeActions[currentType];
+        const f = fields[currentType];
+        if (f.releaseDate && f.releaseDateISO) {
+            const date = parseReleaseDate(f.releaseDate.value.trim());
+            if (date) f.releaseDateISO.value = date.toISOString();
+            else f.releaseDateISO.disabled = true;
+        }
+        persistence.markPendingClear(storageKey);
+        form.submit();
     });
 });

--- a/tmbr/Public/Styles/Shared/editor.css
+++ b/tmbr/Public/Styles/Shared/editor.css
@@ -570,6 +570,31 @@ dialog::backdrop {
  ------------------------------------------------
  */
 
+/*
+ ------------------------------------------------
+ Music type picker
+ ------------------------------------------------
+ */
+
+.type-picker {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+    margin: 8px 0 4px;
+}
+
+.type-picker label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    font-size: 1.5rem;
+    font-weight: 500;
+    font-family: system-ui, -apple-system, Helvetica, sans-serif;
+    opacity: 0.75;
+    user-select: none;
+}
+
 @media screen and (max-width: 600px) {
 
     #details-section .details-content {

--- a/tmbr/Resources/Views/Catalogue/Music/music-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Music/music-editor.leaf
@@ -1,0 +1,25 @@
+#extend("Shared/page"):
+    #export("styles"):
+    <link rel="stylesheet" href="/Styles/Shared/editor.css">
+    #endexport
+
+    #export("main"):
+    <form id="music-editor-form" method="post" action="#(composeAction)">
+        <input id="music-editor-url" class="text-input title" type="url" placeholder="Paste an Apple Music link…" autocomplete="off" />
+
+        <div id="music-type-selector" hidden>
+            <label><input type="radio" name="music-type" value="song" /> Song</label>
+            <label><input type="radio" name="music-type" value="album" /> Album</label>
+            <label><input type="radio" name="music-type" value="playlist" /> Playlist</label>
+        </div>
+
+        <div id="music-editor-fields" hidden>
+            <p id="music-autofill-status" class="system-info" hidden></p>
+        </div>
+    </form>
+    #endexport
+
+    #export("scripts"):
+        <script src="/Scripts/Catalogue/Music/music-editor.js"></script>
+    #endexport
+#endextend

--- a/tmbr/Resources/Views/Catalogue/Music/music-editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/Music/music-editor.leaf
@@ -1,25 +1,156 @@
-#extend("Shared/page"):
-    #export("styles"):
-    <link rel="stylesheet" href="/Styles/Shared/editor.css">
+#extend("Catalogue/editor"):
+
+    #export("editor-title-input"):
+    <input
+        id="editor-title"
+        class="text-input title"
+        name="title"
+        type="text"
+        value=""
+        placeholder="Title"
+        autocomplete="off"
+        spellcheck="true"
+    />
     #endexport
 
-    #export("main"):
-    <form id="music-editor-form" method="post" action="#(composeAction)">
-        <input id="music-editor-url" class="text-input title" type="url" placeholder="Paste an Apple Music link…" autocomplete="off" />
+    #export("editor-type-picker"):
+    <div class="type-picker" role="group" aria-label="Music type">
+        <label>
+            <input type="radio" name="music-type" value="song" checked />
+            Song
+        </label>
+        <label>
+            <input type="radio" name="music-type" value="album" />
+            Album
+        </label>
+        <label>
+            <input type="radio" name="music-type" value="playlist" />
+            Playlist
+        </label>
+    </div>
+    #endexport
 
-        <div id="music-type-selector" hidden>
-            <label><input type="radio" name="music-type" value="song" /> Song</label>
-            <label><input type="radio" name="music-type" value="album" /> Album</label>
-            <label><input type="radio" name="music-type" value="playlist" /> Playlist</label>
-        </div>
+    #export("editor-fields"):
+    <input id="editor-artwork-id" type="hidden" name="artwork-id" value="" />
+    <input id="editor-artwork-source-url" type="hidden" name="artwork-source-url" value="" />
 
-        <div id="music-editor-fields" hidden>
-            <p id="music-autofill-status" class="system-info" hidden></p>
-        </div>
+    <div class="music-type-fields" data-music-type="song">
+        <input
+            id="editor-song-artist"
+            class="text-input"
+            name="artist"
+            type="text"
+            value=""
+            placeholder="Artist"
+            autocomplete="off"
+            spellcheck="true"
+        />
+        <input
+            id="editor-song-album"
+            class="text-input"
+            name="album"
+            type="text"
+            value=""
+            placeholder="Album"
+            autocomplete="off"
+            spellcheck="true"
+        />
+        <input
+            id="editor-song-release-date"
+            class="text-input"
+            type="text"
+            value=""
+            placeholder="Release date, e.g. 2024 or 2025-06-15"
+            autocomplete="off"
+        />
+        <input id="editor-song-release-date-iso" name="release-date" type="hidden" value="" />
+        <input
+            id="editor-song-genre"
+            class="text-input"
+            name="genre"
+            type="text"
+            value=""
+            placeholder="Genre"
+            autocomplete="off"
+            spellcheck="true"
+        />
+    </div>
+
+    <div class="music-type-fields" data-music-type="album" hidden>
+        <input
+            id="editor-album-artist"
+            class="text-input"
+            name="artist"
+            type="text"
+            value=""
+            placeholder="Artist"
+            autocomplete="off"
+            spellcheck="true"
+            disabled
+        />
+        <input
+            id="editor-album-release-date"
+            class="text-input"
+            type="text"
+            value=""
+            placeholder="Release date, e.g. 2024 or 2025-06-15"
+            autocomplete="off"
+            disabled
+        />
+        <input id="editor-album-release-date-iso" name="release-date" type="hidden" value="" disabled />
+        <input
+            id="editor-album-genre"
+            class="text-input"
+            name="genre"
+            type="text"
+            value=""
+            placeholder="Genre"
+            autocomplete="off"
+            spellcheck="true"
+            disabled
+        />
+        <input id="editor-album-tracklist-json" type="hidden" name="tracklist-json" value="" disabled />
+    </div>
+
+    <div class="music-type-fields" data-music-type="playlist" hidden>
+        <textarea
+            id="editor-playlist-description"
+            class="text-input"
+            name="description"
+            placeholder="Description"
+            autocomplete="off"
+            spellcheck="true"
+            rows="3"
+            disabled
+        ></textarea>
+        <input id="editor-playlist-tracklist-json" type="hidden" name="tracklist-json" value="" disabled />
+    </div>
+    #endexport
+
+    #export("editor-image-picker"):
+    <figure id="artwork-placeholder" class="image-picker empty">
+        <img id="artwork-image" src="" alt="Artwork" />
+        <span>#extend("Icons/gallery")</span>
+        <button id="artwork-clear" type="button" class="icon">#extend("Icons/trash")</button>
+    </figure>
+    #endexport
+
+    #export("editor-preview-form"):
+    <form id="preview-form" method="post" action="/songs/preview" target="_blank" hidden>
+        <input type="hidden" name="title" id="preview-title" />
+        <input type="hidden" name="artist" id="preview-artist" />
+        <input type="hidden" name="album" id="preview-album" />
+        <input type="hidden" name="genre" id="preview-genre" />
+        <input type="hidden" name="releaseDate" id="preview-release-date" />
+        <input type="hidden" name="description" id="preview-description" />
+        <input type="hidden" name="artworkURL" id="preview-artwork-url" />
+        <input type="hidden" name="resourceURLs" id="preview-resource-urls" />
+        <input type="hidden" name="notes" id="preview-notes" />
     </form>
     #endexport
 
-    #export("scripts"):
-        <script src="/Scripts/Catalogue/Music/music-editor.js"></script>
+    #export("editor-type-script"):
+    <script src="/Scripts/Catalogue/Music/music-editor.js"></script>
     #endexport
+
 #endextend

--- a/tmbr/Resources/Views/Catalogue/editor.leaf
+++ b/tmbr/Resources/Views/Catalogue/editor.leaf
@@ -12,6 +12,8 @@
         #endif
 
         #import("editor-title-input")
+        
+        #import("editor-type-picker")
 
         #extend("Catalogue/resources-editor")
 

--- a/tmbr/Sources/App/Modules/Catalogue/Music/Routes/Web/MusicWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Music/Routes/Web/MusicWebController.swift
@@ -2,13 +2,21 @@ import Vapor
 import Core
 
 struct MusicMetadataResponse: Content, Sendable {
-    let musicType: String
-    let title: String?
+    
     let artist: String?
-    let description: String?
+    
     let artwork: String?
-    let releaseDate: String?
+    
+    let description: String?
+    
     let genre: String?
+    
+    let musicType: String
+    
+    let releaseDate: String?
+    
+    let title: String?
+    
     let tracks: [TrackMetadata]?
 }
 
@@ -36,51 +44,51 @@ struct MusicWebController: RouteCollection {
         if path.contains("/playlist/") || path.contains("/playlist") {
             let playlist = try await request.commands.playlists.metadata(url)
             return MusicMetadataResponse(
-                musicType: "playlist",
-                title: playlist.title,
                 artist: nil,
-                description: playlist.description,
                 artwork: playlist.artwork,
-                releaseDate: nil,
+                description: playlist.description,
                 genre: nil,
+                musicType: "playlist",
+                releaseDate: nil,
+                title: playlist.title,
                 tracks: playlist.tracks
             )
         } else if url.query?.contains("i=") == true {
             // Apple Music song link (?i=trackID)
             let song = try await request.commands.songs.metadata(url)
             return MusicMetadataResponse(
-                musicType: "song",
-                title: song.title,
                 artist: song.artist,
-                description: nil,
                 artwork: song.artwork,
-                releaseDate: song.releaseDate,
+                description: nil,
                 genre: nil,
+                musicType: "song",
+                releaseDate: song.releaseDate,
+                title: song.title,
                 tracks: nil
             )
         } else if path.contains("/album/") {
             let album = try await request.commands.albums.metadata(url)
             return MusicMetadataResponse(
-                musicType: "album",
-                title: album.title,
                 artist: album.artist,
-                description: nil,
                 artwork: album.artwork,
-                releaseDate: album.releaseDate,
+                description: nil,
                 genre: nil,
+                musicType: "album",
+                releaseDate: album.releaseDate,
+                title: album.title,
                 tracks: album.tracks
             )
         }
 
         // Unknown — return minimal response; frontend shows manual type selector
         return MusicMetadataResponse(
-            musicType: "unknown",
-            title: nil,
             artist: nil,
-            description: nil,
             artwork: nil,
-            releaseDate: nil,
+            description: nil,
             genre: nil,
+            musicType: "unknown",
+            releaseDate: nil,
+            title: nil,
             tracks: nil
         )
     }

--- a/tmbr/Sources/App/Modules/Catalogue/Music/Routes/Web/MusicWebController.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Music/Routes/Web/MusicWebController.swift
@@ -1,11 +1,87 @@
 import Vapor
 import Core
 
+struct MusicMetadataResponse: Content, Sendable {
+    let musicType: String
+    let title: String?
+    let artist: String?
+    let description: String?
+    let artwork: String?
+    let releaseDate: String?
+    let genre: String?
+    let tracks: [TrackMetadata]?
+}
+
 struct MusicWebController: RouteCollection {
 
     func boot(routes: RoutesBuilder) throws {
-        routes.grouped("music")
-            .grouped(RecoverMiddleware())
-            .get(page: .music)
+        let musicRoute = routes.grouped("music")
+        let recoveringRoute = musicRoute.grouped(RecoverMiddleware())
+
+        recoveringRoute.get(page: .music)
+        recoveringRoute.get("new", page: .newMusic)
+
+        musicRoute.get("metadata", use: metadata)
+    }
+
+    @Sendable
+    private func metadata(_ request: Request) async throws -> MusicMetadataResponse {
+        let urlString = try request.query.get(String.self, at: "url")
+        guard let url = URL(string: urlString) else {
+            throw Abort(.badRequest, reason: "Invalid URL")
+        }
+
+        // Detect type from URL path before fetching (avoids double network call)
+        let path = url.path
+        if path.contains("/playlist/") || path.contains("/playlist") {
+            let playlist = try await request.commands.playlists.metadata(url)
+            return MusicMetadataResponse(
+                musicType: "playlist",
+                title: playlist.title,
+                artist: nil,
+                description: playlist.description,
+                artwork: playlist.artwork,
+                releaseDate: nil,
+                genre: nil,
+                tracks: playlist.tracks
+            )
+        } else if url.query?.contains("i=") == true {
+            // Apple Music song link (?i=trackID)
+            let song = try await request.commands.songs.metadata(url)
+            return MusicMetadataResponse(
+                musicType: "song",
+                title: song.title,
+                artist: song.artist,
+                description: nil,
+                artwork: song.artwork,
+                releaseDate: song.releaseDate,
+                genre: nil,
+                tracks: nil
+            )
+        } else if path.contains("/album/") {
+            let album = try await request.commands.albums.metadata(url)
+            return MusicMetadataResponse(
+                musicType: "album",
+                title: album.title,
+                artist: album.artist,
+                description: nil,
+                artwork: album.artwork,
+                releaseDate: album.releaseDate,
+                genre: nil,
+                tracks: album.tracks
+            )
+        }
+
+        // Unknown — return minimal response; frontend shows manual type selector
+        return MusicMetadataResponse(
+            musicType: "unknown",
+            title: nil,
+            artist: nil,
+            description: nil,
+            artwork: nil,
+            releaseDate: nil,
+            genre: nil,
+            tracks: nil
+        )
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Music/Routes/Web/Pages/Page+MusicEditor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Music/Routes/Web/Pages/Page+MusicEditor.swift
@@ -3,8 +3,20 @@ import Core
 import Foundation
 
 struct MusicEditorViewModel: Encodable, Sendable {
+
+    struct NoteViewModel: Encodable, Sendable {
+        let id: String?
+        let body: String
+        let access: String
+    }
+
     let pageTitle: String
-    let composeAction: String
+    let id: Int? = nil
+    let resourceURLs: [String] = []
+    let notes: [NoteViewModel] = []
+    let submit: Form.Submit
+    let _csrf: String?
+    let error: String? = nil
 }
 
 extension Template where Model == MusicEditorViewModel {
@@ -14,15 +26,16 @@ extension Template where Model == MusicEditorViewModel {
 extension Page {
     static var newMusic: Self {
         Page(template: .musicEditor) { req in
-            let canSong = (try? await req.permissions.songs.create()) != nil
-            let canAlbum = (try? await req.permissions.albums.create()) != nil
-            let canPlaylist = (try? await req.permissions.playlists.create()) != nil
-            guard canSong || canAlbum || canPlaylist else {
+            let allowed: ComposeDefinition = req.permissions.compose(.music)
+            guard !allowed.sections.isEmpty else {
                 throw Abort(.unauthorized)
             }
+            let csrf = UUID().uuidString
+            req.session.data["csrf.editor"] = csrf
             return MusicEditorViewModel(
                 pageTitle: "New music",
-                composeAction: "/music/new"
+                submit: Form.Submit(action: "/songs/new", label: "Save"),
+                _csrf: csrf
             )
         }
     }

--- a/tmbr/Sources/App/Modules/Catalogue/Music/Routes/Web/Pages/Page+MusicEditor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Music/Routes/Web/Pages/Page+MusicEditor.swift
@@ -10,13 +10,20 @@ struct MusicEditorViewModel: Encodable, Sendable {
         let access: String
     }
 
-    let pageTitle: String
-    let id: Int? = nil
-    let resourceURLs: [String] = []
-    let notes: [NoteViewModel] = []
-    let submit: Form.Submit
+    
     let _csrf: String?
+    
     let error: String? = nil
+    
+    let id: Int? = nil
+    
+    let notes: [NoteViewModel] = []
+    
+    let pageTitle: String
+    
+    let resourceURLs: [String] = []
+    
+    let submit: Form.Submit
 }
 
 extension Template where Model == MusicEditorViewModel {
@@ -33,9 +40,9 @@ extension Page {
             let csrf = UUID().uuidString
             req.session.data["csrf.editor"] = csrf
             return MusicEditorViewModel(
+                _csrf: csrf,
                 pageTitle: "New music",
-                submit: Form.Submit(action: "/songs/new", label: "Save"),
-                _csrf: csrf
+                submit: Form.Submit(action: "/songs/new", label: "Save")
             )
         }
     }

--- a/tmbr/Sources/App/Modules/Catalogue/Music/Routes/Web/Pages/Page+MusicEditor.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Music/Routes/Web/Pages/Page+MusicEditor.swift
@@ -1,0 +1,29 @@
+import Vapor
+import Core
+import Foundation
+
+struct MusicEditorViewModel: Encodable, Sendable {
+    let pageTitle: String
+    let composeAction: String
+}
+
+extension Template where Model == MusicEditorViewModel {
+    static let musicEditor = Template(name: "Catalogue/Music/music-editor")
+}
+
+extension Page {
+    static var newMusic: Self {
+        Page(template: .musicEditor) { req in
+            let canSong = (try? await req.permissions.songs.create()) != nil
+            let canAlbum = (try? await req.permissions.albums.create()) != nil
+            let canPlaylist = (try? await req.permissions.playlists.create()) != nil
+            guard canSong || canAlbum || canPlaylist else {
+                throw Abort(.unauthorized)
+            }
+            return MusicEditorViewModel(
+                pageTitle: "New music",
+                composeAction: "/music/new"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /music/metadata?url=...` — detects music type from URL path (no double-fetch: `/playlist/` → playlist, `?i=` → song, `/album/` → album); returns `MusicMetadataResponse` with `musicType` field + all relevant metadata fields
- `GET /music/new` — landing page with a single URL input field
- `music-editor.js` — debounced fetch on URL input; on success redirects to the type-specific editor (`/songs/new`, `/albums/new`, `/playlists/new`) with metadata pre-filled as query params; on unknown type shows a manual type radio selector

## Test plan
- [ ] Paste an Apple Music album URL → redirects to `/albums/new` with title/artist/artwork/tracks pre-filled
- [ ] Paste an Apple Music song URL (`?i=`) → redirects to `/songs/new` with title/artist/artwork pre-filled
- [ ] Paste an Apple Music playlist URL → redirects to `/playlists/new` with title/description/artwork pre-filled
- [ ] Paste an unrecognised URL → manual type selector appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)