### PR TITLE
Stage 8: Music virtual filter chip in catalogue

### DIFF
--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Routes/CatalogueQueryMapper.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Routes/CatalogueQueryMapper.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct CatalogueQueryMapper: Sendable {
-    
+
     private static let catalogueTypes: Set<String> = [
         Album.previewType,
         Book.previewType,
@@ -10,27 +10,33 @@ struct CatalogueQueryMapper: Sendable {
         Podcast.previewType,
         Song.previewType,
     ]
-    
+
+    // Virtual type chips that expand to multiple concrete previewTypes
+    private static let virtualTypes: [String: Set<String>] = [
+        "music": [Album.previewType, Playlist.previewType, Song.previewType],
+    ]
+
     private let allowedTypes: Set<String>
-    
+
     init(allowedTypes: Set<String> = Self.catalogueTypes) {
         self.allowedTypes = allowedTypes
     }
-    
+
     func toPreviewQuery(from payload: CatalogueQueryPayload) -> PreviewQueryInput {
         PreviewQueryInput(term: payload.term, types: filter(types: payload.types))
     }
-    
+
     func toNotesQuery(from payload: CatalogueQueryPayload) -> NoteQueryPayload {
         NoteQueryPayload(term: payload.term, types: filter(types: payload.types))
     }
-    
+
     func toQuoteQuery(from payload: CatalogueQueryPayload) -> QuoteQueryPayload {
         QuoteQueryPayload(term: payload.term, types: filter(types: payload.types))
     }
-    
+
     private func filter(types: Set<String>?) -> Set<String> {
         guard let types else { return allowedTypes }
-        return allowedTypes.filter { types.contains($0) }
+        let expanded = types.flatMap { Self.virtualTypes[$0] ?? [$0] }
+        return allowedTypes.filter { expanded.contains($0) }
     }
 }

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Routes/Web/Pages/CatalogueListViewModel.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Routes/Web/Pages/CatalogueListViewModel.swift
@@ -2,9 +2,13 @@ import Vapor
 import Core
 
 struct CatalogueListViewModel: Encodable, Sendable {
+    
     let compose: ComposePopupViewModel?
+    
     let filterItems: [FilterItemViewModel]
+    
     let term: String?
+    
     let previews: [PreviewViewModel]
 
     init(

--- a/tmbr/Sources/App/Modules/Catalogue/Catalogue/Routes/Web/Pages/Page+Catalogue.swift
+++ b/tmbr/Sources/App/Modules/Catalogue/Catalogue/Routes/Web/Pages/Page+Catalogue.swift
@@ -13,19 +13,37 @@ struct CatalogueViewModel: Encodable, Sendable {
 }
 
 extension FilterItemViewModel {
-    
+
+    static let album = FilterItemViewModel(
+        icon: "album",
+        label: "Albums",
+        value: Album.previewType
+    )
+
     static let book = FilterItemViewModel(
         icon: "book",
         label: "Books",
         value: Book.previewType
     )
-    
+
     static let movie = FilterItemViewModel(
         icon: "movie",
         label: "Movies",
         value: Movie.previewType
     )
-    
+
+    static let music = FilterItemViewModel(
+        icon: "music",
+        label: "Music",
+        value: "music"
+    )
+
+    static let playlist = FilterItemViewModel(
+        icon: "playlist",
+        label: "Playlists",
+        value: Playlist.previewType
+    )
+
     static let podcast = FilterItemViewModel(
         icon: "podcast",
         label: "Podcasts",
@@ -37,23 +55,11 @@ extension FilterItemViewModel {
         label: "Songs",
         value: Song.previewType
     )
-    
-    static let album = FilterItemViewModel(
-        icon: "album",
-        label: "Albums",
-        value: Album.previewType
-    )
-    
-    static let playlist = FilterItemViewModel(
-        icon: "playlist",
-        label: "Playlists",
-        value: Playlist.previewType
-    )
 }
 
 extension [FilterItemViewModel] {
     static let catalogue: Self = [
-        .book, .movie, .podcast, .song
+        .book, .movie, .music, .podcast,
     ]
     
     static let music: Self = [


### PR DESCRIPTION
## Summary
- `CatalogueQueryMapper` gains a `virtualTypes` map: `"music"` expands to `["song", "album", "playlist"]` before intersecting with `allowedTypes`
- The Song filter chip is replaced with a single **Music** chip (`value: "music"`) in `Page+Catalogue.swift`; selecting it returns songs, albums, and playlists in one feed

## Test plan
- [ ] Catalogue filter shows Book / Movie / Music / Podcasts chips (no separate Song chip)
- [ ] Selecting "Music" returns songs, albums, and playlists
- [ ] Other chips (Books, Movies, Podcasts) still filter correctly
- [ ] No filter selected shows all types

🤖 Generated with [Claude Code](https://claude.com/claude-code)