### PR TITLE
Apple Sign In with ApiKit

### DIFF
--- a/api-kit/Sources/ApiKit/AuthProvider.swift
+++ b/api-kit/Sources/ApiKit/AuthProvider.swift
@@ -1,9 +1,12 @@
 import Foundation
 
 public actor AuthProvider {
+    
     private var token: String?
+    
     private var refreshTask: Task<String, Error>?
-    private let refresher: @Sendable () async throws -> String
+    
+    private let refresher: (@Sendable () async throws -> String)?
 
     public init(
         token: String? = nil,
@@ -30,5 +33,7 @@ public actor AuthProvider {
         }
     }
 
-    public func set(_ token: String?) { self.token = token }
+    public func set(_ token: String?) {
+        self.token = token
+    }
 }

--- a/tmbr-app/tmbr/APIConfig.swift
+++ b/tmbr-app/tmbr/APIConfig.swift
@@ -1,0 +1,22 @@
+import Foundation
+import ApiKit
+
+struct APIConfig: Sendable {
+    let baseURL: URL
+    let session: URLSession
+    let auth: AuthToken
+
+    func loader<R: Request>(for request: R) -> RequestLoader<R> {
+        RequestLoader(request: request, session: session, auth: auth)
+    }
+}
+
+extension APIConfig {
+    static func fromInfoPlist(session: URLSession = .shared) -> APIConfig {
+        let raw = Bundle.main.object(forInfoDictionaryKey: "APIBaseURL") as? String ?? ""
+        guard let url = URL(string: raw), !raw.isEmpty else {
+            fatalError("APIBaseURL missing or invalid in Info.plist — check the API_BASE_URL build setting")
+        }
+        return APIConfig(baseURL: url, session: session, auth: AuthToken())
+    }
+}

--- a/tmbr-app/tmbr/APIConfig.swift
+++ b/tmbr-app/tmbr/APIConfig.swift
@@ -4,7 +4,7 @@ import ApiKit
 struct APIConfig: Sendable {
     let baseURL: URL
     let session: URLSession
-    let auth: AuthToken
+    let auth: AuthProvider
 
     func loader<R: Request>(for request: R) -> RequestLoader<R> {
         RequestLoader(request: request, session: session, auth: auth)
@@ -17,6 +17,6 @@ extension APIConfig {
         guard let url = URL(string: raw), !raw.isEmpty else {
             fatalError("APIBaseURL missing or invalid in Info.plist — check the API_BASE_URL build setting")
         }
-        return APIConfig(baseURL: url, session: session, auth: AuthToken())
+        return APIConfig(baseURL: url, session: session, auth: AuthProvider())
     }
 }

--- a/tmbr-app/tmbr/APIConfig.swift
+++ b/tmbr-app/tmbr/APIConfig.swift
@@ -12,11 +12,11 @@ struct APIConfig: Sendable {
 }
 
 extension APIConfig {
-    static func fromInfoPlist(session: URLSession = .shared) -> APIConfig {
+    static func fromInfoPlist(token: String? = nil, session: URLSession = .shared) -> APIConfig {
         let raw = Bundle.main.object(forInfoDictionaryKey: "APIBaseURL") as? String ?? ""
         guard let url = URL(string: raw), !raw.isEmpty else {
             fatalError("APIBaseURL missing or invalid in Info.plist — check the API_BASE_URL build setting")
         }
-        return APIConfig(baseURL: url, session: session, auth: AuthProvider())
+        return APIConfig(baseURL: url, session: session, auth: AuthProvider(token: token))
     }
 }

--- a/tmbr-app/tmbr/APIConfig.swift
+++ b/tmbr-app/tmbr/APIConfig.swift
@@ -2,21 +2,22 @@ import Foundation
 import ApiKit
 
 struct APIConfig: Sendable {
+
     let baseURL: URL
+
     let session: URLSession
-    let auth: AuthProvider
 
     func loader<R: Request>(for request: R) -> RequestLoader<R> {
-        RequestLoader(request: request, session: session, auth: auth)
+        RequestLoader(request: request, session: session)
     }
 }
 
 extension APIConfig {
-    static func fromInfoPlist(token: String? = nil, session: URLSession = .shared) -> APIConfig {
+    static func fromInfoPlist(session: URLSession = .shared) -> APIConfig {
         let raw = Bundle.main.object(forInfoDictionaryKey: "APIBaseURL") as? String ?? ""
         guard let url = URL(string: raw), !raw.isEmpty else {
             fatalError("APIBaseURL missing or invalid in Info.plist — check the API_BASE_URL build setting")
         }
-        return APIConfig(baseURL: url, session: session, auth: AuthProvider(token: token))
+        return APIConfig(baseURL: url, session: session)
     }
 }

--- a/tmbr-app/tmbr/AppleSignInRequest.swift
+++ b/tmbr-app/tmbr/AppleSignInRequest.swift
@@ -1,32 +1,11 @@
 import ApiKit
+import Foundation
 import TmbrCore
 
-typealias AppleSignInRequest = BasicRequest<AppleSignInInput, AuthResponse>
+typealias AppleSignInRequest = BasicRequest<AppleCallbackData, AuthResponse>
 
 extension Request where Self == AppleSignInRequest {
     static func signIn(baseURL: URL) -> Self {
         .post(baseURL: baseURL, path: "/api/apple/auth")
-    }
-}
-
-struct AppleSignInInput: Encodable, Sendable {
-    let identityToken: String
-    let authCode: String
-    let nonce: String
-    let userPayload: String?
-
-    nonisolated func encode(to encoder: any Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(identityToken, forKey: .identityToken)
-        try container.encode(authCode, forKey: .authCode)
-        try container.encode(nonce, forKey: .nonce)
-        try container.encodeIfPresent(userPayload, forKey: .userPayload)
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case identityToken = "id_token"
-        case authCode = "code"
-        case nonce
-        case userPayload = "user"
     }
 }

--- a/tmbr-app/tmbr/AppleSignInRequest.swift
+++ b/tmbr-app/tmbr/AppleSignInRequest.swift
@@ -2,7 +2,7 @@ import ApiKit
 import Foundation
 import TmbrCore
 
-typealias AppleSignInRequest = BasicRequest<AppleCallbackData, AuthResponse>
+typealias AppleSignInRequest = BasicRequest<AppleSignInData, AuthResponse>
 
 extension Request where Self == AppleSignInRequest {
     static func signIn(baseURL: URL) -> Self {

--- a/tmbr-app/tmbr/AppleSignInRequest.swift
+++ b/tmbr-app/tmbr/AppleSignInRequest.swift
@@ -1,0 +1,39 @@
+import Foundation
+import ApiKit
+import TmbrCore
+
+struct AppleSignInRequest: Request {
+    struct Input: Sendable {
+        let identityToken: String
+        let authCode: String
+        let nonce: String
+        let userPayload: String?
+    }
+
+    typealias Response = AuthResponse
+
+    private let baseURL: URL
+
+    init(baseURL: URL) {
+        self.baseURL = baseURL
+    }
+
+    func makeRequest(from input: Input, encoder: JSONEncoder) throws -> URLRequest {
+        struct Body: Encodable {
+            let code: String
+            let id_token: String
+            let nonce: String
+            let user: String?
+        }
+        var req = URLRequest(url: baseURL.appending(path: "/api/apple/auth"))
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try encoder.encode(Body(
+            code: input.authCode,
+            id_token: input.identityToken,
+            nonce: input.nonce,
+            user: input.userPayload
+        ))
+        return req
+    }
+}

--- a/tmbr-app/tmbr/AppleSignInRequest.swift
+++ b/tmbr-app/tmbr/AppleSignInRequest.swift
@@ -15,7 +15,15 @@ struct AppleSignInInput: Encodable, Sendable {
     let nonce: String
     let userPayload: String?
 
-    enum CodingKeys: String, CodingKey {
+    nonisolated func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(identityToken, forKey: .identityToken)
+        try container.encode(authCode, forKey: .authCode)
+        try container.encode(nonce, forKey: .nonce)
+        try container.encodeIfPresent(userPayload, forKey: .userPayload)
+    }
+
+    private enum CodingKeys: String, CodingKey {
         case identityToken = "id_token"
         case authCode = "code"
         case nonce

--- a/tmbr-app/tmbr/AppleSignInRequest.swift
+++ b/tmbr-app/tmbr/AppleSignInRequest.swift
@@ -18,7 +18,7 @@ struct AppleSignInRequest: Request {
         self.baseURL = baseURL
     }
 
-    func makeRequest(from input: Input, encoder: JSONEncoder) throws -> URLRequest {
+    func makeRequest(from input: Input, token _: String?, using encoder: JSONEncoder) throws -> URLRequest {
         struct Body: Encodable {
             let code: String
             let id_token: String

--- a/tmbr-app/tmbr/AppleSignInRequest.swift
+++ b/tmbr-app/tmbr/AppleSignInRequest.swift
@@ -1,3 +1,14 @@
+import ApiKit
+import TmbrCore
+
+typealias AppleSignInRequest = BasicRequest<AppleSignInInput, AuthResponse>
+
+extension Request where Self == AppleSignInRequest {
+    static func signIn(baseURL: URL) -> Self {
+        .post(baseURL: baseURL, path: "/api/apple/auth")
+    }
+}
+
 struct AppleSignInInput: Encodable, Sendable {
     let identityToken: String
     let authCode: String

--- a/tmbr-app/tmbr/AppleSignInRequest.swift
+++ b/tmbr-app/tmbr/AppleSignInRequest.swift
@@ -1,39 +1,13 @@
-import Foundation
-import ApiKit
-import TmbrCore
+struct AppleSignInInput: Encodable, Sendable {
+    let identityToken: String
+    let authCode: String
+    let nonce: String
+    let userPayload: String?
 
-struct AppleSignInRequest: Request {
-    struct Input: Sendable {
-        let identityToken: String
-        let authCode: String
-        let nonce: String
-        let userPayload: String?
-    }
-
-    typealias Response = AuthResponse
-
-    private let baseURL: URL
-
-    init(baseURL: URL) {
-        self.baseURL = baseURL
-    }
-
-    func makeRequest(from input: Input, token _: String?, using encoder: JSONEncoder) throws -> URLRequest {
-        struct Body: Encodable {
-            let code: String
-            let id_token: String
-            let nonce: String
-            let user: String?
-        }
-        var req = URLRequest(url: baseURL.appending(path: "/api/apple/auth"))
-        req.httpMethod = "POST"
-        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try encoder.encode(Body(
-            code: input.authCode,
-            id_token: input.identityToken,
-            nonce: input.nonce,
-            user: input.userPayload
-        ))
-        return req
+    enum CodingKeys: String, CodingKey {
+        case identityToken = "id_token"
+        case authCode = "code"
+        case nonce
+        case userPayload = "user"
     }
 }

--- a/tmbr-app/tmbr/AuthState.swift
+++ b/tmbr-app/tmbr/AuthState.swift
@@ -8,25 +8,25 @@ final class AuthState {
 
     private(set) var isSignedIn: Bool
 
-    private let config: APIConfig
+    private let session: URLSession
 
     private let keychain: Keychain
 
     private let auth: AuthProvider
 
-    private let signInLoader: RequestLoader<BasicRequest<AppleSignInInput, AuthResponse>>
+    private let signInLoader: RequestLoader<AppleSignInRequest>
 
-    init(config: APIConfig, keychain: Keychain) {
+    init(session: URLSession, keychain: Keychain, signInLoader: RequestLoader<AppleSignInRequest>) {
         let savedToken = keychain.loadToken()
-        self.config = config
+        self.session = session
         self.keychain = keychain
         self.auth = AuthProvider(token: savedToken)
         self.isSignedIn = savedToken != nil
-        self.signInLoader = config.loader(for: .signIn(baseURL: config.baseURL))
+        self.signInLoader = signInLoader
     }
 
     func loader<R: Request>(for request: R) -> RequestLoader<R> {
-        RequestLoader(request: request, session: config.session, auth: auth)
+        RequestLoader(request: request, session: session, auth: auth)
     }
 
     func signIn(authorization: ASAuthorization, nonce: String) async throws {

--- a/tmbr-app/tmbr/AuthState.swift
+++ b/tmbr-app/tmbr/AuthState.swift
@@ -14,7 +14,7 @@ final class AuthState {
 
     private let auth: AuthProvider
 
-    private let signInLoader: RequestLoader<AppleSignInRequest>
+    private let signInLoader: RequestLoader<BasicRequest<AppleSignInInput, AuthResponse>>
 
     init(config: APIConfig, keychain: Keychain) {
         let savedToken = keychain.loadToken()
@@ -22,7 +22,7 @@ final class AuthState {
         self.keychain = keychain
         self.auth = AuthProvider(token: savedToken)
         self.isSignedIn = savedToken != nil
-        self.signInLoader = config.loader(for: AppleSignInRequest(baseURL: config.baseURL))
+        self.signInLoader = config.loader(for: .post(baseURL: config.baseURL, path: "/api/apple/auth"))
     }
 
     func loader<R: Request>(for request: R) -> RequestLoader<R> {

--- a/tmbr-app/tmbr/AuthState.swift
+++ b/tmbr-app/tmbr/AuthState.swift
@@ -39,7 +39,7 @@ final class AuthState {
             throw AuthError.invalidCredential
         }
 
-        let response = try await signInLoader.load(from: AppleCallbackData(
+        let response = try await signInLoader.load(from: AppleSignInData(
             code: authCode,
             idToken: identityToken,
             nonce: nonce,
@@ -58,11 +58,11 @@ final class AuthState {
     }
 
     // Apple only sends name/email on first sign-in
-    private func appleUser(from credential: ASAuthorizationAppleIDCredential) -> AppleCallbackData.User? {
+    private func appleUser(from credential: ASAuthorizationAppleIDCredential) -> AppleSignInData.User? {
         let components = credential.fullName
         let hasName = components?.givenName != nil || components?.familyName != nil
         guard credential.email != nil || hasName else { return nil }
-        let name: AppleCallbackData.User.Name? = hasName
+        let name: AppleSignInData.User.Name? = hasName
             ? .init(firstName: components?.givenName ?? "", lastName: components?.familyName ?? "")
             : nil
         return .init(email: credential.email, name: name)

--- a/tmbr-app/tmbr/AuthState.swift
+++ b/tmbr-app/tmbr/AuthState.swift
@@ -39,11 +39,11 @@ final class AuthState {
             throw AuthError.invalidCredential
         }
 
-        let response = try await signInLoader.load(from: .init(
-            identityToken: identityToken,
-            authCode: authCode,
+        let response = try await signInLoader.load(from: AppleCallbackData(
+            code: authCode,
+            idToken: identityToken,
             nonce: nonce,
-            userPayload: encodeUserPayload(credential: credential)
+            user: appleUser(from: credential)
         ))
 
         keychain.saveToken(response.token)
@@ -57,19 +57,15 @@ final class AuthState {
         isSignedIn = false
     }
 
-    // Apple only sends name/email on first sign-in; encode as JSON string to match backend's AppleCallbackData
-    private func encodeUserPayload(credential: ASAuthorizationAppleIDCredential) -> String? {
-        struct Name: Encodable { let firstName: String; let lastName: String }
-        struct UserInfo: Encodable { let email: String?; let name: Name? }
-
+    // Apple only sends name/email on first sign-in
+    private func appleUser(from credential: ASAuthorizationAppleIDCredential) -> AppleCallbackData.User? {
         let components = credential.fullName
-        let name: Name? = (components?.givenName != nil || components?.familyName != nil)
-            ? Name(firstName: components?.givenName ?? "", lastName: components?.familyName ?? "")
+        let hasName = components?.givenName != nil || components?.familyName != nil
+        guard credential.email != nil || hasName else { return nil }
+        let name: AppleCallbackData.User.Name? = hasName
+            ? .init(firstName: components?.givenName ?? "", lastName: components?.familyName ?? "")
             : nil
-
-        guard credential.email != nil || name != nil else { return nil }
-        let info = UserInfo(email: credential.email, name: name)
-        return try? String(data: JSONEncoder().encode(info), encoding: .utf8)
+        return .init(email: credential.email, name: name)
     }
 
     enum AuthError: LocalizedError {

--- a/tmbr-app/tmbr/AuthState.swift
+++ b/tmbr-app/tmbr/AuthState.swift
@@ -9,13 +9,13 @@ final class AuthState {
     private let config: APIConfig
     private let signInLoader: RequestLoader<AppleSignInRequest>
 
-    init(config: APIConfig) {
+    init(config: APIConfig, isSignedIn: Bool = false) {
         self.config = config
         self.signInLoader = RequestLoader(
             request: AppleSignInRequest(baseURL: config.baseURL),
             session: config.session
         )
-        self.isSignedIn = Keychain.loadToken() != nil
+        self.isSignedIn = isSignedIn
     }
 
     func signIn(authorization: ASAuthorization, nonce: String) async throws {
@@ -40,9 +40,9 @@ final class AuthState {
         isSignedIn = true
     }
 
-    func signOut() {
+    func signOut() async {
+        await config.auth.set(nil)
         Keychain.deleteToken()
-        Task { await config.auth.set(nil) }
         isSignedIn = false
     }
 

--- a/tmbr-app/tmbr/AuthState.swift
+++ b/tmbr-app/tmbr/AuthState.swift
@@ -22,7 +22,7 @@ final class AuthState {
         self.keychain = keychain
         self.auth = AuthProvider(token: savedToken)
         self.isSignedIn = savedToken != nil
-        self.signInLoader = config.loader(for: .post(baseURL: config.baseURL, path: "/api/apple/auth"))
+        self.signInLoader = config.loader(for: .signIn(baseURL: config.baseURL))
     }
 
     func loader<R: Request>(for request: R) -> RequestLoader<R> {

--- a/tmbr-app/tmbr/AuthState.swift
+++ b/tmbr-app/tmbr/AuthState.swift
@@ -5,17 +5,28 @@ import TmbrCore
 
 @Observable
 final class AuthState {
+
     private(set) var isSignedIn: Bool
+
     private let config: APIConfig
+
+    private let keychain: Keychain
+
+    private let auth: AuthProvider
+
     private let signInLoader: RequestLoader<AppleSignInRequest>
 
-    init(config: APIConfig, isSignedIn: Bool = false) {
+    init(config: APIConfig, keychain: Keychain) {
+        let savedToken = keychain.loadToken()
         self.config = config
-        self.signInLoader = RequestLoader(
-            request: AppleSignInRequest(baseURL: config.baseURL),
-            session: config.session
-        )
-        self.isSignedIn = isSignedIn
+        self.keychain = keychain
+        self.auth = AuthProvider(token: savedToken)
+        self.isSignedIn = savedToken != nil
+        self.signInLoader = config.loader(for: AppleSignInRequest(baseURL: config.baseURL))
+    }
+
+    func loader<R: Request>(for request: R) -> RequestLoader<R> {
+        RequestLoader(request: request, session: config.session, auth: auth)
     }
 
     func signIn(authorization: ASAuthorization, nonce: String) async throws {
@@ -35,14 +46,14 @@ final class AuthState {
             userPayload: encodeUserPayload(credential: credential)
         ))
 
-        Keychain.saveToken(response.token)
-        await config.auth.set(response.token)
+        keychain.saveToken(response.token)
+        await auth.set(response.token)
         isSignedIn = true
     }
 
     func signOut() async {
-        await config.auth.set(nil)
-        Keychain.deleteToken()
+        await auth.set(nil)
+        keychain.deleteToken()
         isSignedIn = false
     }
 

--- a/tmbr-app/tmbr/AuthState.swift
+++ b/tmbr-app/tmbr/AuthState.swift
@@ -1,0 +1,68 @@
+import Foundation
+import AuthenticationServices
+import ApiKit
+import TmbrCore
+
+@Observable
+final class AuthState {
+    private(set) var isSignedIn: Bool
+    private let config: APIConfig
+    private let signInLoader: RequestLoader<AppleSignInRequest>
+
+    init(config: APIConfig) {
+        self.config = config
+        self.signInLoader = RequestLoader(
+            request: AppleSignInRequest(baseURL: config.baseURL),
+            session: config.session
+        )
+        self.isSignedIn = Keychain.loadToken() != nil
+    }
+
+    func signIn(authorization: ASAuthorization, nonce: String) async throws {
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+              let tokenData = credential.identityToken,
+              let identityToken = String(data: tokenData, encoding: .utf8),
+              let codeData = credential.authorizationCode,
+              let authCode = String(data: codeData, encoding: .utf8)
+        else {
+            throw AuthError.invalidCredential
+        }
+
+        let response = try await signInLoader.load(from: .init(
+            identityToken: identityToken,
+            authCode: authCode,
+            nonce: nonce,
+            userPayload: encodeUserPayload(credential: credential)
+        ))
+
+        Keychain.saveToken(response.token)
+        await config.auth.set(response.token)
+        isSignedIn = true
+    }
+
+    func signOut() {
+        Keychain.deleteToken()
+        Task { await config.auth.set(nil) }
+        isSignedIn = false
+    }
+
+    // Apple only sends name/email on first sign-in; encode as JSON string to match backend's AppleCallbackData
+    private func encodeUserPayload(credential: ASAuthorizationAppleIDCredential) -> String? {
+        struct Name: Encodable { let firstName: String; let lastName: String }
+        struct UserInfo: Encodable { let email: String?; let name: Name? }
+
+        let components = credential.fullName
+        let name: Name? = (components?.givenName != nil || components?.familyName != nil)
+            ? Name(firstName: components?.givenName ?? "", lastName: components?.familyName ?? "")
+            : nil
+
+        guard credential.email != nil || name != nil else { return nil }
+        let info = UserInfo(email: credential.email, name: name)
+        return try? String(data: JSONEncoder().encode(info), encoding: .utf8)
+    }
+
+    enum AuthError: LocalizedError {
+        case invalidCredential
+        var errorDescription: String? { "Could not read Apple Sign In credential." }
+    }
+}

--- a/tmbr-app/tmbr/ContentView.swift
+++ b/tmbr-app/tmbr/ContentView.swift
@@ -21,7 +21,7 @@ private struct HomeView: View {
                 .navigationTitle("tmbr")
                 .toolbar {
                     ToolbarItem(placement: .primaryAction) {
-                        Button("Sign Out") { authState.signOut() }
+                        Button("Sign Out") { Task { await authState.signOut() } }
                     }
                 }
         }

--- a/tmbr-app/tmbr/ContentView.swift
+++ b/tmbr-app/tmbr/ContentView.swift
@@ -1,7 +1,29 @@
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(AuthState.self) private var authState
+
     var body: some View {
-        Text("tmbr")
+        if authState.isSignedIn {
+            HomeView()
+        } else {
+            SignInView()
+        }
+    }
+}
+
+private struct HomeView: View {
+    @Environment(AuthState.self) private var authState
+
+    var body: some View {
+        NavigationStack {
+            Text("Welcome to tmbr")
+                .navigationTitle("tmbr")
+                .toolbar {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button("Sign Out") { authState.signOut() }
+                    }
+                }
+        }
     }
 }

--- a/tmbr-app/tmbr/Keychain.swift
+++ b/tmbr-app/tmbr/Keychain.swift
@@ -1,11 +1,13 @@
 import Foundation
 import Security
 
-enum Keychain {
-    private static let service = "me.tmbr.app"
-    private static let account = "auth-token"
+struct Keychain {
 
-    static func saveToken(_ token: String) {
+    private let service = "me.tmbr"
+
+    private let account = "auth-token"
+
+    func saveToken(_ token: String) {
         guard let data = token.data(using: .utf8) else { return }
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
@@ -18,7 +20,7 @@ enum Keychain {
         SecItemAdd(attributes as CFDictionary, nil)
     }
 
-    static func loadToken() -> String? {
+    func loadToken() -> String? {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
@@ -33,7 +35,7 @@ enum Keychain {
         return String(data: data, encoding: .utf8)
     }
 
-    static func deleteToken() {
+    func deleteToken() {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,

--- a/tmbr-app/tmbr/Keychain.swift
+++ b/tmbr-app/tmbr/Keychain.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Security
+
+enum Keychain {
+    private static let service = "me.tmbr.app"
+    private static let account = "auth-token"
+
+    static func saveToken(_ token: String) {
+        guard let data = token.data(using: .utf8) else { return }
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+        var attributes = query
+        attributes[kSecValueData] = data
+        SecItemAdd(attributes as CFDictionary, nil)
+    }
+
+    static func loadToken() -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data
+        else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func deleteToken() {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/tmbr-app/tmbr/SignInView.swift
+++ b/tmbr-app/tmbr/SignInView.swift
@@ -45,7 +45,6 @@ struct SignInView: View {
             }
         case .failure(let err):
             let asErr = err as? ASAuthorizationError
-            print("SIWA error: \(err.localizedDescription), code: \(asErr?.code.rawValue ?? -1)")
             if asErr?.code == .canceled { return }
             error = err
         }

--- a/tmbr-app/tmbr/SignInView.swift
+++ b/tmbr-app/tmbr/SignInView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import AuthenticationServices
+import CryptoKit
+
+struct SignInView: View {
+    @Environment(AuthState.self) private var authState
+    @State private var currentNonce: String = ""
+    @State private var error: Error?
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+            Text("tmbr")
+                .font(.largeTitle.bold())
+            Spacer()
+            SignInWithAppleButton(.signIn, onRequest: configure, onCompletion: handle)
+                .frame(height: 50)
+                .padding(.horizontal, 40)
+                .padding(.bottom, 60)
+        }
+        .alert("Sign In Failed", isPresented: .constant(error != nil), presenting: error) { _ in
+            Button("OK") { error = nil }
+        } message: { err in
+            Text(err.localizedDescription)
+        }
+    }
+
+    private func configure(_ request: ASAuthorizationAppleIDRequest) {
+        let nonce = randomNonce()
+        currentNonce = nonce
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+    }
+
+    private func handle(_ result: Result<ASAuthorization, Error>) {
+        switch result {
+        case .success(let authorization):
+            let nonce = currentNonce
+            Task {
+                do {
+                    try await authState.signIn(authorization: authorization, nonce: nonce)
+                } catch {
+                    self.error = error
+                }
+            }
+        case .failure(let err):
+            let asErr = err as? ASAuthorizationError
+            print("SIWA error: \(err.localizedDescription), code: \(asErr?.code.rawValue ?? -1)")
+            if asErr?.code == .canceled { return }
+            error = err
+        }
+    }
+
+    private func randomNonce(length: Int = 32) -> String {
+        var bytes = [UInt8](repeating: 0, count: length)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func sha256(_ input: String) -> String {
+        let data = Data(input.utf8)
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/tmbr-app/tmbr/tmbr.entitlements
+++ b/tmbr-app/tmbr/tmbr.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:$(WEB_CREDENTIALS_DOMAIN)</string>
+	</array>
+</dict>
+</plist>

--- a/tmbr-app/tmbr/tmbr.swift
+++ b/tmbr-app/tmbr/tmbr.swift
@@ -1,10 +1,24 @@
 import SwiftUI
+import ApiKit
 
 @main
 struct tmbr: App {
+    private let config: APIConfig
+    private let authState: AuthState
+
+    init() {
+        print("Bundle ID: \(Bundle.main.bundleIdentifier ?? "nil")")
+        config = .fromInfoPlist()
+        if let saved = Keychain.loadToken() {
+            Task { await config.auth.set(saved) }
+        }
+        authState = AuthState(config: config)
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(authState)
         }
     }
 }

--- a/tmbr-app/tmbr/tmbr.swift
+++ b/tmbr-app/tmbr/tmbr.swift
@@ -8,11 +8,9 @@ struct tmbr: App {
 
     init() {
         print("Bundle ID: \(Bundle.main.bundleIdentifier ?? "nil")")
-        config = .fromInfoPlist()
-        if let saved = Keychain.loadToken() {
-            Task { await config.auth.set(saved) }
-        }
-        authState = AuthState(config: config)
+        let token = Keychain.loadToken()
+        config = .fromInfoPlist(token: token)
+        authState = AuthState(config: config, isSignedIn: token != nil)
     }
 
     var body: some Scene {

--- a/tmbr-app/tmbr/tmbr.swift
+++ b/tmbr-app/tmbr/tmbr.swift
@@ -1,16 +1,12 @@
 import SwiftUI
-import ApiKit
 
 @main
 struct tmbr: App {
-    private let config: APIConfig
+
     private let authState: AuthState
 
     init() {
-        print("Bundle ID: \(Bundle.main.bundleIdentifier ?? "nil")")
-        let token = Keychain.loadToken()
-        config = .fromInfoPlist(token: token)
-        authState = AuthState(config: config, isSignedIn: token != nil)
+        authState = AuthState(config: .fromInfoPlist(), keychain: Keychain())
     }
 
     var body: some Scene {

--- a/tmbr-app/tmbr/tmbr.swift
+++ b/tmbr-app/tmbr/tmbr.swift
@@ -6,7 +6,12 @@ struct tmbr: App {
     private let authState: AuthState
 
     init() {
-        authState = AuthState(config: .fromInfoPlist(), keychain: Keychain())
+        let config = APIConfig.fromInfoPlist()
+        authState = AuthState(
+            session: config.session,
+            keychain: Keychain(),
+            signInLoader: config.loader(for: .signIn(baseURL: config.baseURL))
+        )
     }
 
     var body: some Scene {

--- a/tmbr-core/Sources/TmbrCore/Requests/AppleCallbackData.swift
+++ b/tmbr-core/Sources/TmbrCore/Requests/AppleCallbackData.swift
@@ -1,0 +1,42 @@
+public struct AppleCallbackData: Codable, Sendable {
+
+    public struct User: Codable, Sendable {
+
+        public struct Name: Codable, Sendable {
+            public let firstName: String
+            public let lastName: String
+
+            public init(firstName: String, lastName: String) {
+                self.firstName = firstName
+                self.lastName = lastName
+            }
+        }
+
+        public let email: String?
+        public let name: Name?
+
+        public init(email: String?, name: Name?) {
+            self.email = email
+            self.name = name
+        }
+    }
+
+    public let code: String
+    public let idToken: String
+    public let nonce: String?
+    public let user: User?
+
+    public init(code: String, idToken: String, nonce: String?, user: User?) {
+        self.code = code
+        self.idToken = idToken
+        self.nonce = nonce
+        self.user = user
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case code
+        case idToken = "id_token"
+        case nonce
+        case user
+    }
+}

--- a/tmbr-core/Sources/TmbrCore/Requests/AppleSignInData.swift
+++ b/tmbr-core/Sources/TmbrCore/Requests/AppleSignInData.swift
@@ -1,4 +1,4 @@
-public struct AppleCallbackData: Codable, Sendable {
+public struct AppleSignInData: Codable, Sendable {
 
     public struct User: Codable, Sendable {
 

--- a/tmbr-core/Sources/TmbrCore/Responses/AuthResponse.swift
+++ b/tmbr-core/Sources/TmbrCore/Responses/AuthResponse.swift
@@ -1,0 +1,7 @@
+public struct AuthResponse: Codable, Sendable {
+    public let token: String
+
+    public init(token: String) {
+        self.token = token
+    }
+}

--- a/tmbr-web/Sources/App/Modules/Authentication/Authentication.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Authentication.swift
@@ -55,9 +55,7 @@ struct Authentication: Module {
     }
     
     func boot(_ routes: RoutesBuilder) async throws {
-        try routes
-            .grouped(APITokenAuthenticator())
-            .register(collection: AuthAPIController())
+        try routes.register(collection: AuthAPIController())
         try routes
             .grouped(RecoverMiddleware())
             .register(collection: AuthWebController())

--- a/tmbr-web/Sources/App/Modules/Authentication/Authentication.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Authentication.swift
@@ -55,7 +55,9 @@ struct Authentication: Module {
     }
     
     func boot(_ routes: RoutesBuilder) async throws {
-        try routes.register(collection: AuthAPIController())
+        try routes
+            .grouped(APITokenAuthenticator())
+            .register(collection: AuthAPIController())
         try routes
             .grouped(RecoverMiddleware())
             .register(collection: AuthWebController())

--- a/tmbr-web/Sources/App/Modules/Authentication/Environment+SignIn.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Environment+SignIn.swift
@@ -2,8 +2,11 @@ import Vapor
 
 extension Environment {
     struct SignIn: Sendable {
-        /// Service bundle identifier
+        /// Services ID used by the web sign-in flow
         let appID = Environment.get("SIWA_APP_ID")!
+
+        /// Bundle ID used by the native app sign-in flow
+        let nativeAppID = Environment.get("SIWA_NATIVE_APP_ID")!
         
         /// Registered redirect url
         let redirectUrl = Environment.get("SIWA_REDIRECT_URL")!

--- a/tmbr-web/Sources/App/Modules/Authentication/Environment+SignIn.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Environment+SignIn.swift
@@ -6,7 +6,7 @@ extension Environment {
         let appID = Environment.get("SIWA_APP_ID")!
 
         /// Bundle ID used by the native app sign-in flow
-        let nativeAppID = Environment.get("SIWA_NATIVE_APP_ID")!
+        let nativeAppID = Environment.get("SIWA_NATIVE_APP_ID") ?? { fatalError("SIWA_NATIVE_APP_ID missing — set the bundle ID of the native app in your environment") }()
         
         /// Registered redirect url
         let redirectUrl = Environment.get("SIWA_REDIRECT_URL")!

--- a/tmbr-web/Sources/App/Modules/Authentication/Environment+SignIn.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Environment+SignIn.swift
@@ -6,7 +6,7 @@ extension Environment {
         let appID = Environment.get("SIWA_APP_ID")!
 
         /// Bundle ID used by the native app sign-in flow
-        let nativeAppID = Environment.get("SIWA_NATIVE_APP_ID") ?? { fatalError("SIWA_NATIVE_APP_ID missing — set the bundle ID of the native app in your environment") }()
+        let nativeAppID = Environment.get("SIWA_NATIVE_APP_ID")!
         
         /// Registered redirect url
         let redirectUrl = Environment.get("SIWA_REDIRECT_URL")!

--- a/tmbr-web/Sources/App/Modules/Authentication/Routes/API/AuthAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Routes/API/AuthAPIController.swift
@@ -25,7 +25,7 @@ struct AuthAPIController: RouteCollection {
 
     private func authorizedUser(from request: Request) async throws -> User {
         let callbackData = try request.content.decode(AppleCallbackData.self)
-        let appleIdentity = try await request.jwt.apple.verify(callbackData.id_token, applicationIdentifier: Environment.signIn.nativeAppID)
+        let appleIdentity = try await request.jwt.apple.verify(callbackData.idToken, applicationIdentifier: Environment.signIn.nativeAppID)
 
         guard let tokenNonce = appleIdentity.nonce else {
             throw Abort(.unauthorized, reason: "Token missing nonce")

--- a/tmbr-web/Sources/App/Modules/Authentication/Routes/API/AuthAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Routes/API/AuthAPIController.swift
@@ -4,25 +4,29 @@ import Crypto
 import JWT
 import Foundation
 import Core
+import TmbrCore
 
 struct AuthAPIController: RouteCollection {
-    
+
     func boot(routes: RoutesBuilder) throws {
-        // TODO: Implement oroper SignIn + SignOut
-        routes.post("api", "apple", "auth") { req async throws -> Response in
-            _ = try await authorizedUser(from: req)
-            // TODO: Return token
-            let response = Response(status: .ok)
-            try response.content.encode(["redirect": "/"]) // or any post-auth URL
-            return response
-        }
+        routes.post("api", "apple", "auth", use: signIn)
     }
-    
+
+    @Sendable
+    private func signIn(_ req: Request) async throws -> AuthResponse {
+        let user = try await authorizedUser(from: req)
+        guard let userID = user.id else {
+            throw Abort(.internalServerError, reason: "User has no ID")
+        }
+        let payload = AppTokenPayload(userID: userID)
+        let token = try await req.jwt.sign(payload)
+        return AuthResponse(token: token)
+    }
+
     private func authorizedUser(from request: Request) async throws -> User {
         let callbackData = try request.content.decode(AppleCallbackData.self)
-        let appleIdentity = try await request.jwt.apple.verify(callbackData.id_token)
-        
-        // API flow: require nonce, no session/state
+        let appleIdentity = try await request.jwt.apple.verify(callbackData.id_token, applicationIdentifier: Environment.signIn.nativeAppID)
+
         guard let tokenNonce = appleIdentity.nonce else {
             throw Abort(.unauthorized, reason: "Token missing nonce")
         }
@@ -33,11 +37,11 @@ struct AuthAPIController: RouteCollection {
         guard tokenNonce == hashedProvided || tokenNonce == providedNonce else {
             throw Abort(.unauthorized, reason: "Invalid nonce")
         }
-        
+
         let appleID = appleIdentity.subject.value
         let email = appleIdentity.email
         let name = callbackData.user?.name
-        
+
         return try await User.findOrCreate(
             in: request.db,
             appleID: appleID,
@@ -46,7 +50,7 @@ struct AuthAPIController: RouteCollection {
             lastName: name?.lastName
         )
     }
-    
+
     private func sha256Hex(_ string: String) -> String {
         let data = Data(string.utf8)
         let digest = SHA256.hash(data: data)

--- a/tmbr-web/Sources/App/Modules/Authentication/Routes/API/AuthAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Routes/API/AuthAPIController.swift
@@ -24,7 +24,7 @@ struct AuthAPIController: RouteCollection {
     }
 
     private func authorizedUser(from request: Request) async throws -> User {
-        let callbackData = try request.content.decode(AppleCallbackData.self)
+        let callbackData = try request.content.decode(AppleSignInData.self)
         let appleIdentity = try await request.jwt.apple.verify(callbackData.idToken, applicationIdentifier: Environment.signIn.nativeAppID)
 
         guard let tokenNonce = appleIdentity.nonce else {

--- a/tmbr-web/Sources/App/Modules/Authentication/Routes/API/Responses/AuthResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Routes/API/Responses/AuthResponse+Vapor.swift
@@ -1,5 +1,5 @@
 import TmbrCore
 import Vapor
 
-extension AuthResponse: Content {}
-extension AuthResponse: AsyncResponseEncodable {}
+extension AuthResponse: @retroactive Content {}
+extension AuthResponse: @retroactive AsyncResponseEncodable {}

--- a/tmbr-web/Sources/App/Modules/Authentication/Routes/API/Responses/AuthResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Routes/API/Responses/AuthResponse+Vapor.swift
@@ -1,0 +1,5 @@
+import TmbrCore
+import Vapor
+
+extension AuthResponse: Content {}
+extension AuthResponse: AsyncResponseEncodable {}

--- a/tmbr-web/Sources/App/Modules/Authentication/Routes/Payloads/AppleCallbackData.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Routes/Payloads/AppleCallbackData.swift
@@ -1,44 +1,38 @@
 import Foundation
 import Vapor
 
-struct AppleCallbackData: Decodable, Sendable {
+// Decodes Apple's web sign-in callback, where `user` is a JSON-encoded string
+struct AppleWebCallbackData: Decodable, Sendable {
     struct User: Decodable, Sendable {
-        
+
         struct Name: Decodable, Sendable {
-            
             let firstName: String
-            
             let lastName: String
         }
-        
+
         let email: String?
-        
         let name: Name?
     }
-    
+
     enum Keys: String, CodingKey {
         case code, id_token, state, nonce, user
     }
-    
+
     let code: String
-    
     let id_token: String
-    
     let state: String?
-    
     let nonce: String?
-    
     let user: User?
-    
+
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: Keys.self)
         self.code = try container.decode(String.self, forKey: .code)
         self.id_token = try container.decode(String.self, forKey: .id_token)
         self.state = try container.decodeIfPresent(String.self, forKey: .state)
         self.nonce = try container.decodeIfPresent(String.self, forKey: .nonce)
-        
+
         let userString = try container.decodeIfPresent(String.self, forKey: .user)
-        if let userString = userString, let data = userString.data(using: .utf8) {
+        if let userString, let data = userString.data(using: .utf8) {
             self.user = try JSONDecoder().decode(User.self, from: data)
         } else {
             self.user = nil

--- a/tmbr-web/Sources/App/Modules/Authentication/Routes/Web/AuthWebController.swift
+++ b/tmbr-web/Sources/App/Modules/Authentication/Routes/Web/AuthWebController.swift
@@ -18,7 +18,7 @@ struct AuthWebController: RouteCollection {
     
     @Sendable
     private func signIn(_ req: Request) async throws -> Response {
-        let callbackData = try req.content.decode(AppleCallbackData.self)
+        let callbackData = try req.content.decode(AppleWebCallbackData.self)
         let appleIdentity = try await req.jwt.apple.verify(callbackData.id_token)
         
         guard let returnedState = callbackData.state else {

--- a/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/API/Responses/AlbumResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/API/Responses/AlbumResponse+Vapor.swift
@@ -1,5 +1,5 @@
 import TmbrCore
 import Vapor
 
-extension AlbumResponse: Content {}
-extension AlbumResponse: AsyncResponseEncodable {}
+extension AlbumResponse: @retroactive Content {}
+extension AlbumResponse: @retroactive AsyncResponseEncodable {}

--- a/tmbr-web/Sources/App/Modules/Catalogue/Books/Routes/API/Responses/BookResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Books/Routes/API/Responses/BookResponse+Vapor.swift
@@ -1,5 +1,5 @@
 import TmbrCore
 import Vapor
 
-extension BookResponse: Content {}
-extension BookResponse: AsyncResponseEncodable {}
+extension BookResponse: @retroactive Content {}
+extension BookResponse: @retroactive AsyncResponseEncodable {}

--- a/tmbr-web/Sources/App/Modules/Catalogue/Movies/Routes/API/Responses/MovieResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Movies/Routes/API/Responses/MovieResponse+Vapor.swift
@@ -1,5 +1,5 @@
 import TmbrCore
 import Vapor
 
-extension MovieResponse: Content {}
-extension MovieResponse: AsyncResponseEncodable {}
+extension MovieResponse: @retroactive Content {}
+extension MovieResponse: @retroactive AsyncResponseEncodable {}

--- a/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/API/Responses/PlaylistResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/API/Responses/PlaylistResponse+Vapor.swift
@@ -1,5 +1,5 @@
 import TmbrCore
 import Vapor
 
-extension PlaylistResponse: Content {}
-extension PlaylistResponse: AsyncResponseEncodable {}
+extension PlaylistResponse: @retroactive Content {}
+extension PlaylistResponse: @retroactive AsyncResponseEncodable {}

--- a/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Routes/API/Responses/PodcastResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Routes/API/Responses/PodcastResponse+Vapor.swift
@@ -1,5 +1,5 @@
 import TmbrCore
 import Vapor
 
-extension PodcastResponse: Content {}
-extension PodcastResponse: AsyncResponseEncodable {}
+extension PodcastResponse: @retroactive Content {}
+extension PodcastResponse: @retroactive AsyncResponseEncodable {}

--- a/tmbr-web/Sources/App/Modules/Catalogue/Songs/Routes/API/Responses/SongResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Songs/Routes/API/Responses/SongResponse+Vapor.swift
@@ -1,5 +1,5 @@
 import TmbrCore
 import Vapor
 
-extension SongResponse: Content {}
-extension SongResponse: AsyncResponseEncodable {}
+extension SongResponse: @retroactive Content {}
+extension SongResponse: @retroactive AsyncResponseEncodable {}

--- a/tmbr-web/Sources/App/Modules/Gallery/Routes/API/Responses/ImageResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Gallery/Routes/API/Responses/ImageResponse+Vapor.swift
@@ -1,4 +1,4 @@
 import TmbrCore
 import Vapor
 
-extension ImageResponse: Content {}
+extension ImageResponse: @retroactive Content {}

--- a/tmbr-web/Sources/App/Modules/Notes/Routes/API/Responses/NoteResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Notes/Routes/API/Responses/NoteResponse+Vapor.swift
@@ -1,5 +1,5 @@
 import TmbrCore
 import Vapor
 
-extension NoteResponse: Content {}
-extension NoteResponse: AsyncResponseEncodable {}
+extension NoteResponse: @retroactive Content {}
+extension NoteResponse: @retroactive AsyncResponseEncodable {}

--- a/tmbr-web/Sources/App/Modules/Notes/Routes/API/Responses/QuoteResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Notes/Routes/API/Responses/QuoteResponse+Vapor.swift
@@ -1,4 +1,4 @@
 import TmbrCore
 import Vapor
 
-extension QuoteResponse: Content {}
+extension QuoteResponse: @retroactive Content {}

--- a/tmbr-web/Sources/App/Modules/Previews/Routes/API/Responses/PreviewResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Previews/Routes/API/Responses/PreviewResponse+Vapor.swift
@@ -1,4 +1,4 @@
 import TmbrCore
 import Vapor
 
-extension PreviewResponse: Content {}
+extension PreviewResponse: @retroactive Content {}

--- a/tmbr-web/Sources/AuthKit/Middlewares/APITokenAuthenticator.swift
+++ b/tmbr-web/Sources/AuthKit/Middlewares/APITokenAuthenticator.swift
@@ -1,0 +1,17 @@
+import Vapor
+import Fluent
+import JWT
+
+public struct APITokenAuthenticator: AsyncRequestAuthenticator {
+
+    public init() {}
+
+    public func authenticate(request: Request) async throws {
+        guard let bearer = request.headers.bearerAuthorization else { return }
+        let payload = try await request.jwt.verify(bearer.token, as: AppTokenPayload.self)
+        guard let userID = Int(payload.sub.value),
+              let user = try await User.find(userID, on: request.db)
+        else { return }
+        request.auth.login(user)
+    }
+}

--- a/tmbr-web/Sources/AuthKit/Models/AppTokenPayload.swift
+++ b/tmbr-web/Sources/AuthKit/Models/AppTokenPayload.swift
@@ -1,0 +1,21 @@
+import JWT
+import Foundation
+
+public struct AppTokenPayload: JWTPayload {
+    public var sub: SubjectClaim
+    public var exp: ExpirationClaim
+    public var iat: IssuedAtClaim
+
+    public static let expiry: TimeInterval = 60 * 60 * 24 * 30 // 30 days
+
+    public init(userID: Int) {
+        let now = Date()
+        self.sub = .init(value: String(userID))
+        self.exp = .init(value: now.addingTimeInterval(Self.expiry))
+        self.iat = .init(value: now)
+    }
+
+    public func verify(using algorithm: some JWTAlgorithm) async throws {
+        try exp.verifyNotExpired()
+    }
+}


### PR DESCRIPTION
## Summary

Implements Sign in with Apple end-to-end, using the `ApiKit` loader-per-endpoint pattern throughout. Replaces the PoC `APIClient` class.

**Native app (`tmbr-app`):**
- `APIConfig` — app-level Sendable context struct; bundles `baseURL`, `URLSession`, and `AuthToken`; exposes `loader(for:)` factory so features create their own typed loaders
- `AppleSignInRequest` — typed `Request` for `POST /api/apple/auth`; uses snake_case `id_token` field to match the backend's `AppleCallbackData`
- `AuthState` — `@Observable`; holds a `RequestLoader<AppleSignInRequest>` as a stored dependency; reads `AuthToken` at call time so token refreshes are transparent
- `Keychain` — secure token persistence across launches
- `SignInView` — Sign in with Apple button with nonce generation
- `ContentView` — routes to `SignInView` or main content based on `authState.isSignedIn`

**Backend (`tmbr-web`):**
- `APITokenAuthenticator` — Bearer token middleware using `AppTokenPayload`
- `AppTokenPayload` — JWT payload struct for app-issued tokens
- `AuthAPIController` — Apple OAuth callback → JWT exchange endpoint
- `AuthResponse+Vapor` — Vapor `Content` conformance for the shared DTO

**Shared (`tmbr-core`):**
- `AuthResponse` DTO (`token: String`) added

## Test plan

- [ ] Fresh launch: Sign In with Apple sheet appears
- [ ] Complete sign in: token persisted to Keychain, main content shown
- [ ] Force-quit and relaunch: stays signed in (token restored from Keychain)
- [ ] Sign out: returns to sign-in screen, Keychain cleared
- [ ] `POST /api/apple/auth` with a valid Apple identity token returns `{"token": "..."}`
- [ ] Authenticated requests include `Authorization: Bearer <token>` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)