### PR TITLE
Refine cross-platform navigation and toolbar layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Tests/LinuxMain.swift
 generate-package-api-docs.swift
 theme-settings.json
 tmbr.xcworkspace/xcuserdata/
+node_modules/

--- a/api-kit/Sources/ApiKit/AuthProvider.swift
+++ b/api-kit/Sources/ApiKit/AuthProvider.swift
@@ -10,7 +10,7 @@ public actor AuthProvider {
 
     public init(
         token: String? = nil,
-        refresher: @escaping @Sendable () async throws -> String
+        refresher: (@Sendable () async throws -> String)? = nil
     ) {
         self.token = token
         self.refresher = refresher
@@ -20,7 +20,8 @@ public actor AuthProvider {
 
     public func refreshedToken() async throws -> String {
         if let task = refreshTask { return try await task.value }
-        let task = Task { [refresher] in try await refresher() }
+        guard let refresher else { throw RefreshError.noRefresher }
+        let task = Task { try await refresher() }
         refreshTask = task
         do {
             let fresh = try await task.value
@@ -35,5 +36,9 @@ public actor AuthProvider {
 
     public func set(_ token: String?) {
         self.token = token
+    }
+
+    public enum RefreshError: Error {
+        case noRefresher
     }
 }

--- a/api-kit/Sources/ApiKit/RequestError.swift
+++ b/api-kit/Sources/ApiKit/RequestError.swift
@@ -1,5 +1,13 @@
 import Foundation
 
-public enum RequestError: Error {
+public enum RequestError: Error, LocalizedError {
     case httpError(statusCode: Int, data: Data)
+
+    public var errorDescription: String? {
+        switch self {
+        case .httpError(let statusCode, let data):
+            let body = String(data: data, encoding: .utf8) ?? "<non-UTF8 body>"
+            return "HTTP \(statusCode): \(body)"
+        }
+    }
 }

--- a/tmbr-app/tmbr/AccountSheet.swift
+++ b/tmbr-app/tmbr/AccountSheet.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct AccountSheet: View {
+    @Environment(AuthState.self) private var authState
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if authState.isSignedIn {
+                    VStack(spacing: 24) {
+                        Spacer()
+                        Button("Sign Out", role: .destructive) {
+                            Task { await authState.signOut() }
+                        }
+                        .padding(.bottom, 60)
+                    }
+                } else {
+                    SignInView()
+                }
+            }
+            .navigationTitle("Account")
+            .toolbarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+        }
+        .frame(minWidth: 320, minHeight: 380)
+        .onChange(of: authState.isSignedIn) { _, _ in
+            dismiss()
+        }
+    }
+}

--- a/tmbr-app/tmbr/BlogEditorView.swift
+++ b/tmbr-app/tmbr/BlogEditorView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct BlogEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Text("Blog Editor")
+                .foregroundStyle(.secondary)
+                .navigationTitle("New Post")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+        }
+    }
+}

--- a/tmbr-app/tmbr/BlogEditorView.swift
+++ b/tmbr-app/tmbr/BlogEditorView.swift
@@ -8,7 +8,7 @@ struct BlogEditorView: View {
             Text("Blog Editor")
                 .foregroundStyle(.secondary)
                 .navigationTitle("New Post")
-                .navigationBarTitleDisplayMode(.inline)
+                .toolbarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Cancel") { dismiss() }

--- a/tmbr-app/tmbr/BlogTab.swift
+++ b/tmbr-app/tmbr/BlogTab.swift
@@ -43,11 +43,9 @@ struct BlogTab: View {
             SignInView()
                 .environment(authState)
         }
-        #if os(iOS)
-        .fullScreenCover(isPresented: $showEditor) {
+        .sheet(isPresented: $showEditor) {
             BlogEditorView()
         }
-        #endif
         .onChange(of: authState.isSignedIn) { _, isSignedIn in
             if isSignedIn { showSignIn = false }
         }

--- a/tmbr-app/tmbr/BlogTab.swift
+++ b/tmbr-app/tmbr/BlogTab.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct BlogTab: View {
+    @Environment(AuthState.self) private var authState
+    @State private var searchText = ""
+    @State private var showSignIn = false
+    @State private var showEditor = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(0..<5) { i in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Post Title \(i + 1)")
+                            .font(.headline)
+                        Text("A short excerpt from the post...")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .navigationTitle("Blog")
+            .searchable(text: $searchText)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    if authState.isSignedIn {
+                        Button {
+                            showEditor = true
+                        } label: {
+                            Image(systemName: "square.and.pencil")
+                        }
+                    } else {
+                        Button("Sign In") {
+                            showSignIn = true
+                        }
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $showSignIn) {
+            SignInView()
+        }
+        .fullScreenCover(isPresented: $showEditor) {
+            BlogEditorView()
+        }
+        .tabItem {
+            Label("Blog", systemImage: "doc.text")
+        }
+    }
+}

--- a/tmbr-app/tmbr/BlogTab.swift
+++ b/tmbr-app/tmbr/BlogTab.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct BlogTab: View {
     @Environment(AuthState.self) private var authState
-    @State private var showSignIn = false
+    @State private var showAccount = false
     @State private var showEditor = false
 
     var body: some View {
@@ -13,41 +13,60 @@ struct BlogTab: View {
                         Text("\(index + 1).")
                             .foregroundStyle(.secondary)
                             .monospacedDigit()
+#if os(macOS)
+                        Text(title)
+                        Spacer()
+                        Text("May 28")
+                            .foregroundStyle(.secondary)
+#else
                         VStack(alignment: .leading, spacing: 2) {
                             Text(title)
                             Text("May 28")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                         }
+#endif
                     }
                 }
             }
             .navigationTitle("Blog")
             .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    if authState.isSignedIn {
+#if os(iOS)
+                if authState.isSignedIn {
+                    ToolbarItem(placement: .topBarLeading) {
                         Button {
                             showEditor = true
                         } label: {
                             Image(systemName: "square.and.pencil")
                         }
-                    } else {
-                        Button("Sign In") {
-                            showSignIn = true
+                    }
+                }
+#else
+                if authState.isSignedIn {
+                    ToolbarItem(placement: .automatic) {
+                        Button {
+                            showEditor = true
+                        } label: {
+                            Image(systemName: "square.and.pencil")
                         }
+                    }
+                }
+#endif
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showAccount = true
+                    } label: {
+                        Image(systemName: authState.isSignedIn ? "person.circle.fill" : "person.circle")
                     }
                 }
             }
         }
-        .sheet(isPresented: $showSignIn) {
-            SignInView()
+        .sheet(isPresented: $showAccount) {
+            AccountSheet()
                 .environment(authState)
         }
         .sheet(isPresented: $showEditor) {
             BlogEditorView()
-        }
-        .onChange(of: authState.isSignedIn) { _, isSignedIn in
-            if isSignedIn { showSignIn = false }
         }
     }
 

--- a/tmbr-app/tmbr/BlogTab.swift
+++ b/tmbr-app/tmbr/BlogTab.swift
@@ -9,17 +9,16 @@ struct BlogTab: View {
         NavigationStack {
             List {
                 ForEach(Array(placeholderPosts.enumerated()), id: \.offset) { index, title in
-                    HStack {
-                        HStack(spacing: 6) {
-                            Text("\(index + 1).")
-                                .foregroundStyle(.secondary)
-                                .monospacedDigit()
-                            Text(title)
-                        }
-                        Spacer()
-                        Text("May 28")
-                            .font(.subheadline)
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text("\(index + 1).")
                             .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(title)
+                            Text("May 28")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
             }
@@ -49,9 +48,6 @@ struct BlogTab: View {
         }
         .onChange(of: authState.isSignedIn) { _, isSignedIn in
             if isSignedIn { showSignIn = false }
-        }
-        .tabItem {
-            Label("Blog", systemImage: "doc.text")
         }
     }
 

--- a/tmbr-app/tmbr/BlogTab.swift
+++ b/tmbr-app/tmbr/BlogTab.swift
@@ -2,26 +2,28 @@ import SwiftUI
 
 struct BlogTab: View {
     @Environment(AuthState.self) private var authState
-    @State private var searchText = ""
     @State private var showSignIn = false
     @State private var showEditor = false
 
     var body: some View {
         NavigationStack {
             List {
-                ForEach(0..<5) { i in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Post Title \(i + 1)")
-                            .font(.headline)
-                        Text("A short excerpt from the post...")
+                ForEach(Array(placeholderPosts.enumerated()), id: \.offset) { index, title in
+                    HStack {
+                        HStack(spacing: 6) {
+                            Text("\(index + 1).")
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                            Text(title)
+                        }
+                        Spacer()
+                        Text("May 28")
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
                     }
-                    .padding(.vertical, 4)
                 }
             }
             .navigationTitle("Blog")
-            .searchable(text: $searchText)
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     if authState.isSignedIn {
@@ -40,12 +42,24 @@ struct BlogTab: View {
         }
         .sheet(isPresented: $showSignIn) {
             SignInView()
+                .environment(authState)
         }
         .fullScreenCover(isPresented: $showEditor) {
             BlogEditorView()
+        }
+        .onChange(of: authState.isSignedIn) { _, isSignedIn in
+            if isSignedIn { showSignIn = false }
         }
         .tabItem {
             Label("Blog", systemImage: "doc.text")
         }
     }
+
+    private let placeholderPosts = [
+        "On keeping a reading journal",
+        "Why I stopped using recommendations",
+        "Albums I return to every winter",
+        "Notes on Detransition, Baby",
+        "The case for private playlists",
+    ]
 }

--- a/tmbr-app/tmbr/BlogTab.swift
+++ b/tmbr-app/tmbr/BlogTab.swift
@@ -43,9 +43,11 @@ struct BlogTab: View {
             SignInView()
                 .environment(authState)
         }
+        #if os(iOS)
         .fullScreenCover(isPresented: $showEditor) {
             BlogEditorView()
         }
+        #endif
         .onChange(of: authState.isSignedIn) { _, isSignedIn in
             if isSignedIn { showSignIn = false }
         }

--- a/tmbr-app/tmbr/CatalogueFilterSheet.swift
+++ b/tmbr-app/tmbr/CatalogueFilterSheet.swift
@@ -28,6 +28,16 @@ struct CatalogueFilterSheet: View {
             .navigationTitle("Filter")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    let allSelected = selectedTypes.count == CatalogueItemType.allCases.count
+                    Button(allSelected ? "Deselect All" : "Select All") {
+                        if allSelected {
+                            selectedTypes.removeAll()
+                        } else {
+                            selectedTypes = Set(CatalogueItemType.allCases)
+                        }
+                    }
+                }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
                 }

--- a/tmbr-app/tmbr/CatalogueFilterSheet.swift
+++ b/tmbr-app/tmbr/CatalogueFilterSheet.swift
@@ -25,6 +25,7 @@ struct CatalogueFilterSheet: View {
                     }
                 }
             }
+            .listStyle(.plain)
             .navigationTitle("Filter")
             .toolbarTitleDisplayMode(.inline)
             .toolbar {
@@ -43,5 +44,6 @@ struct CatalogueFilterSheet: View {
                 }
             }
         }
+        .frame(minWidth: 320, minHeight: 380)
     }
 }

--- a/tmbr-app/tmbr/CatalogueFilterSheet.swift
+++ b/tmbr-app/tmbr/CatalogueFilterSheet.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct CatalogueFilterSheet: View {
+    @Binding var selectedTypes: Set<CatalogueItemType>
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List(CatalogueItemType.allCases) { type in
+                Button {
+                    if selectedTypes.contains(type) {
+                        selectedTypes.remove(type)
+                    } else {
+                        selectedTypes.insert(type)
+                    }
+                } label: {
+                    HStack {
+                        Label(type.label, systemImage: type.systemImage)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        if selectedTypes.contains(type) {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.tint)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Filter")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/tmbr-app/tmbr/CatalogueFilterSheet.swift
+++ b/tmbr-app/tmbr/CatalogueFilterSheet.swift
@@ -26,7 +26,7 @@ struct CatalogueFilterSheet: View {
                 }
             }
             .navigationTitle("Filter")
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     let allSelected = selectedTypes.count == CatalogueItemType.allCases.count

--- a/tmbr-app/tmbr/CatalogueItemType.swift
+++ b/tmbr-app/tmbr/CatalogueItemType.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum CatalogueItemType: String, CaseIterable, Identifiable {
+    case song, album, playlist, book, podcast, movie
+
+    var id: String { rawValue }
+
+    var label: String { rawValue.capitalized }
+
+    var systemImage: String {
+        switch self {
+        case .song: "music.note"
+        case .album: "music.note.list"
+        case .playlist: "list.bullet"
+        case .book: "book"
+        case .podcast: "mic"
+        case .movie: "film"
+        }
+    }
+}

--- a/tmbr-app/tmbr/CatalogueItemType.swift
+++ b/tmbr-app/tmbr/CatalogueItemType.swift
@@ -10,9 +10,9 @@ enum CatalogueItemType: String, CaseIterable, Identifiable {
     var systemImage: String {
         switch self {
         case .song: "music.note"
-        case .album: "music.note.list"
-        case .playlist: "list.bullet"
-        case .book: "book"
+        case .album: "music.note.square.stack"
+        case .playlist: "music.note.list"
+        case .book: "book.closed"
         case .podcast: "mic"
         case .movie: "film"
         }

--- a/tmbr-app/tmbr/CatalogueTab.swift
+++ b/tmbr-app/tmbr/CatalogueTab.swift
@@ -12,18 +12,9 @@ struct CatalogueTab: View {
     var body: some View {
         NavigationStack {
             List(placeholderItems) { item in
-                HStack(spacing: 12) {
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color.secondary.opacity(0.2))
-                        .frame(width: 44, height: 44)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(item.primaryInfo)
-                        Text(item.secondaryInfo)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    Text("May 28")
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.primaryInfo)
+                    Text(item.secondaryInfo)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
@@ -74,9 +65,6 @@ struct CatalogueTab: View {
         }
         .onChange(of: authState.isSignedIn) { _, isSignedIn in
             if isSignedIn { showSignIn = false }
-        }
-        .tabItem {
-            Label("Catalogue", systemImage: "square.grid.2x2")
         }
     }
 

--- a/tmbr-app/tmbr/CatalogueTab.swift
+++ b/tmbr-app/tmbr/CatalogueTab.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct CatalogueTab: View {
     @Environment(AuthState.self) private var authState
-    @State private var searchText = ""
     @State private var showSignIn = false
     @State private var showFilter = false
     @State private var showTypePicker = false
@@ -12,25 +11,24 @@ struct CatalogueTab: View {
 
     var body: some View {
         NavigationStack {
-            List {
-                ForEach(0..<8) { i in
-                    HStack(spacing: 12) {
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(Color.secondary.opacity(0.2))
-                            .frame(width: 48, height: 48)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Item Title \(i + 1)")
-                                .font(.headline)
-                            Text("Artist / Author")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                        }
+            List(placeholderItems) { item in
+                HStack(spacing: 12) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.secondary.opacity(0.2))
+                        .frame(width: 44, height: 44)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(item.primaryInfo)
+                        Text(item.secondaryInfo)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
                     }
-                    .padding(.vertical, 2)
+                    Spacer()
+                    Text("May 28")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
                 }
             }
             .navigationTitle("Catalogue")
-            .searchable(text: $searchText)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button {
@@ -56,6 +54,7 @@ struct CatalogueTab: View {
         }
         .sheet(isPresented: $showSignIn) {
             SignInView()
+                .environment(authState)
         }
         .sheet(isPresented: $showFilter) {
             CatalogueFilterSheet(selectedTypes: $filterTypes)
@@ -71,12 +70,30 @@ struct CatalogueTab: View {
             }
         }
         .onChange(of: selectedType) { _, type in
-            if type != nil {
-                showEditor = true
-            }
+            if type != nil { showEditor = true }
+        }
+        .onChange(of: authState.isSignedIn) { _, isSignedIn in
+            if isSignedIn { showSignIn = false }
         }
         .tabItem {
             Label("Catalogue", systemImage: "square.grid.2x2")
         }
     }
+
+    private struct PreviewItem: Identifiable {
+        let id = UUID()
+        let primaryInfo: String
+        let secondaryInfo: String
+    }
+
+    private let placeholderItems: [PreviewItem] = [
+        .init(primaryInfo: "The Glow Pt. 2", secondaryInfo: "The Microphones"),
+        .init(primaryInfo: "Parable of the Sower", secondaryInfo: "Octavia Butler"),
+        .init(primaryInfo: "Stranger in the Alps", secondaryInfo: "Phoebe Bridgers"),
+        .init(primaryInfo: "Arrival", secondaryInfo: "Denis Villeneuve"),
+        .init(primaryInfo: "Radiolab", secondaryInfo: "Season 22, Ep. 4"),
+        .init(primaryInfo: "Late Night Playlist", secondaryInfo: "Playlist"),
+        .init(primaryInfo: "Normal People", secondaryInfo: "Sally Rooney"),
+        .init(primaryInfo: "Javelin", secondaryInfo: "Sufjan Stevens"),
+    ]
 }

--- a/tmbr-app/tmbr/CatalogueTab.swift
+++ b/tmbr-app/tmbr/CatalogueTab.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct CatalogueTab: View {
+    @Environment(AuthState.self) private var authState
+    @State private var searchText = ""
+    @State private var showSignIn = false
+    @State private var showFilter = false
+    @State private var showTypePicker = false
+    @State private var selectedType: CatalogueItemType?
+    @State private var showEditor = false
+    @State private var filterTypes: Set<CatalogueItemType> = []
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(0..<8) { i in
+                    HStack(spacing: 12) {
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color.secondary.opacity(0.2))
+                            .frame(width: 48, height: 48)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Item Title \(i + 1)")
+                                .font(.headline)
+                            Text("Artist / Author")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+            .navigationTitle("Catalogue")
+            .searchable(text: $searchText)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        showFilter = true
+                    } label: {
+                        Image(systemName: "slider.horizontal.3")
+                    }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    if authState.isSignedIn {
+                        Button {
+                            showTypePicker = true
+                        } label: {
+                            Image(systemName: "square.and.pencil")
+                        }
+                    } else {
+                        Button("Sign In") {
+                            showSignIn = true
+                        }
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $showSignIn) {
+            SignInView()
+        }
+        .sheet(isPresented: $showFilter) {
+            CatalogueFilterSheet(selectedTypes: $filterTypes)
+        }
+        .sheet(isPresented: $showTypePicker) {
+            MediaTypePickerSheet { type in
+                selectedType = type
+            }
+        }
+        .fullScreenCover(isPresented: $showEditor) {
+            if let type = selectedType {
+                MediaEditorView(type: type)
+            }
+        }
+        .onChange(of: selectedType) { _, type in
+            if type != nil {
+                showEditor = true
+            }
+        }
+        .tabItem {
+            Label("Catalogue", systemImage: "square.grid.2x2")
+        }
+    }
+}

--- a/tmbr-app/tmbr/CatalogueTab.swift
+++ b/tmbr-app/tmbr/CatalogueTab.swift
@@ -25,7 +25,7 @@ struct CatalogueTab: View {
                     Button {
                         showFilter = true
                     } label: {
-                        Image(systemName: "slider.horizontal.3")
+                        Image(systemName: "line.3.horizontal.decrease")
                     }
                 }
                 ToolbarItem(placement: .primaryAction) {

--- a/tmbr-app/tmbr/CatalogueTab.swift
+++ b/tmbr-app/tmbr/CatalogueTab.swift
@@ -21,15 +21,13 @@ struct CatalogueTab: View {
             }
             .navigationTitle("Catalogue")
             .toolbar {
-                #if os(iOS)
-                ToolbarItem(placement: .topBarLeading) {
+                ToolbarItem(placement: .automatic) {
                     Button {
                         showFilter = true
                     } label: {
                         Image(systemName: "line.3.horizontal.decrease")
                     }
                 }
-                #endif
                 ToolbarItem(placement: .primaryAction) {
                     if authState.isSignedIn {
                         Button {
@@ -57,13 +55,11 @@ struct CatalogueTab: View {
                 selectedType = type
             }
         }
-        #if os(iOS)
-        .fullScreenCover(isPresented: $showEditor) {
+        .sheet(isPresented: $showEditor) {
             if let type = selectedType {
                 MediaEditorView(type: type)
             }
         }
-        #endif
         .onChange(of: selectedType) { _, type in
             if type != nil { showEditor = true }
         }

--- a/tmbr-app/tmbr/CatalogueTab.swift
+++ b/tmbr-app/tmbr/CatalogueTab.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct CatalogueTab: View {
     @Environment(AuthState.self) private var authState
-    @State private var showSignIn = false
+    @State private var showAccount = false
     @State private var showFilter = false
     @State private var showTypePicker = false
     @State private var selectedType: CatalogueItemType?
@@ -21,6 +21,25 @@ struct CatalogueTab: View {
             }
             .navigationTitle("Catalogue")
             .toolbar {
+#if os(iOS)
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        showFilter = true
+                    } label: {
+                        Image(systemName: "line.3.horizontal.decrease")
+                    }
+                }
+                if authState.isSignedIn {
+                    ToolbarSpacer(.fixed, placement: .topBarLeading)
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button {
+                            showTypePicker = true
+                        } label: {
+                            Image(systemName: "square.and.pencil")
+                        }
+                    }
+                }
+#else
                 ToolbarItem(placement: .automatic) {
                     Button {
                         showFilter = true
@@ -28,23 +47,27 @@ struct CatalogueTab: View {
                         Image(systemName: "line.3.horizontal.decrease")
                     }
                 }
-                ToolbarItem(placement: .primaryAction) {
-                    if authState.isSignedIn {
+                if authState.isSignedIn {
+                    ToolbarItem(placement: .primaryAction) {
                         Button {
                             showTypePicker = true
                         } label: {
                             Image(systemName: "square.and.pencil")
                         }
-                    } else {
-                        Button("Sign In") {
-                            showSignIn = true
-                        }
+                    }
+                }
+#endif
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showAccount = true
+                    } label: {
+                        Image(systemName: authState.isSignedIn ? "person.circle.fill" : "person.circle")
                     }
                 }
             }
         }
-        .sheet(isPresented: $showSignIn) {
-            SignInView()
+        .sheet(isPresented: $showAccount) {
+            AccountSheet()
                 .environment(authState)
         }
         .sheet(isPresented: $showFilter) {
@@ -62,9 +85,6 @@ struct CatalogueTab: View {
         }
         .onChange(of: selectedType) { _, type in
             if type != nil { showEditor = true }
-        }
-        .onChange(of: authState.isSignedIn) { _, isSignedIn in
-            if isSignedIn { showSignIn = false }
         }
     }
 

--- a/tmbr-app/tmbr/CatalogueTab.swift
+++ b/tmbr-app/tmbr/CatalogueTab.swift
@@ -21,6 +21,7 @@ struct CatalogueTab: View {
             }
             .navigationTitle("Catalogue")
             .toolbar {
+                #if os(iOS)
                 ToolbarItem(placement: .topBarLeading) {
                     Button {
                         showFilter = true
@@ -28,6 +29,7 @@ struct CatalogueTab: View {
                         Image(systemName: "line.3.horizontal.decrease")
                     }
                 }
+                #endif
                 ToolbarItem(placement: .primaryAction) {
                     if authState.isSignedIn {
                         Button {
@@ -55,11 +57,13 @@ struct CatalogueTab: View {
                 selectedType = type
             }
         }
+        #if os(iOS)
         .fullScreenCover(isPresented: $showEditor) {
             if let type = selectedType {
                 MediaEditorView(type: type)
             }
         }
+        #endif
         .onChange(of: selectedType) { _, type in
             if type != nil { showEditor = true }
         }

--- a/tmbr-app/tmbr/ContentView.swift
+++ b/tmbr-app/tmbr/ContentView.swift
@@ -1,29 +1,10 @@
 import SwiftUI
 
 struct ContentView: View {
-    @Environment(AuthState.self) private var authState
-
     var body: some View {
-        if authState.isSignedIn {
-            HomeView()
-        } else {
-            SignInView()
-        }
-    }
-}
-
-private struct HomeView: View {
-    @Environment(AuthState.self) private var authState
-
-    var body: some View {
-        NavigationStack {
-            Text("Welcome to tmbr")
-                .navigationTitle("tmbr")
-                .toolbar {
-                    ToolbarItem(placement: .primaryAction) {
-                        Button("Sign Out") { Task { await authState.signOut() } }
-                    }
-                }
+        TabView {
+            BlogTab()
+            CatalogueTab()
         }
     }
 }

--- a/tmbr-app/tmbr/ContentView.swift
+++ b/tmbr-app/tmbr/ContentView.swift
@@ -13,5 +13,6 @@ struct ContentView: View {
                 SearchTab()
             }
         }
+        .tabViewStyle(.sidebarAdaptable)
     }
 }

--- a/tmbr-app/tmbr/ContentView.swift
+++ b/tmbr-app/tmbr/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
         TabView {
             BlogTab()
             CatalogueTab()
+            SearchTab()
         }
     }
 }

--- a/tmbr-app/tmbr/ContentView.swift
+++ b/tmbr-app/tmbr/ContentView.swift
@@ -3,9 +3,15 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         TabView {
-            BlogTab()
-            CatalogueTab()
-            SearchTab()
+            Tab("Blog", systemImage: "doc.text") {
+                BlogTab()
+            }
+            Tab("Catalogue", systemImage: "square.grid.2x2") {
+                CatalogueTab()
+            }
+            Tab(role: .search) {
+                SearchTab()
+            }
         }
     }
 }

--- a/tmbr-app/tmbr/ContentView.swift
+++ b/tmbr-app/tmbr/ContentView.swift
@@ -3,15 +3,22 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         TabView {
+#if os(macOS)
+            Tab(role: .search) {
+                SearchTab()
+            }
+#endif
             Tab("Blog", systemImage: "doc.text") {
                 BlogTab()
             }
             Tab("Catalogue", systemImage: "square.grid.2x2") {
                 CatalogueTab()
             }
+#if !os(macOS)
             Tab(role: .search) {
                 SearchTab()
             }
+#endif
         }
         .tabViewStyle(.sidebarAdaptable)
     }

--- a/tmbr-app/tmbr/MediaEditorView.swift
+++ b/tmbr-app/tmbr/MediaEditorView.swift
@@ -9,7 +9,7 @@ struct MediaEditorView: View {
             Text("\(type.label) Editor")
                 .foregroundStyle(.secondary)
                 .navigationTitle(type.label)
-                .navigationBarTitleDisplayMode(.inline)
+                .toolbarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("Cancel") { dismiss() }

--- a/tmbr-app/tmbr/MediaEditorView.swift
+++ b/tmbr-app/tmbr/MediaEditorView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct MediaEditorView: View {
+    let type: CatalogueItemType
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Text("\(type.label) Editor")
+                .foregroundStyle(.secondary)
+                .navigationTitle(type.label)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+        }
+    }
+}

--- a/tmbr-app/tmbr/MediaTypePickerSheet.swift
+++ b/tmbr-app/tmbr/MediaTypePickerSheet.swift
@@ -16,7 +16,7 @@ struct MediaTypePickerSheet: View {
                 }
             }
             .navigationTitle("New Item")
-            .navigationBarTitleDisplayMode(.inline)
+            .toolbarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }

--- a/tmbr-app/tmbr/MediaTypePickerSheet.swift
+++ b/tmbr-app/tmbr/MediaTypePickerSheet.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct MediaTypePickerSheet: View {
+    let onSelect: (CatalogueItemType) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List(CatalogueItemType.allCases) { type in
+                Button {
+                    onSelect(type)
+                    dismiss()
+                } label: {
+                    Label(type.label, systemImage: type.systemImage)
+                        .foregroundStyle(.primary)
+                }
+            }
+            .navigationTitle("New Item")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/tmbr-app/tmbr/SearchTab.swift
+++ b/tmbr-app/tmbr/SearchTab.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct SearchTab: View {
+    @State private var searchText = ""
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if searchText.isEmpty {
+                    ContentUnavailableView(
+                        "Search",
+                        systemImage: "magnifyingglass",
+                        description: Text("Search across all posts and catalogue items.")
+                    )
+                } else {
+                    List(placeholderResults(for: searchText)) { result in
+                        HStack(spacing: 12) {
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Color.secondary.opacity(0.2))
+                                .frame(width: 44, height: 44)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(result.primaryInfo)
+                                if let secondary = result.secondaryInfo {
+                                    Text(secondary)
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Search")
+            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
+        }
+        .tabItem {
+            Label("Search", systemImage: "magnifyingglass")
+        }
+    }
+
+    private struct SearchResult: Identifiable {
+        let id = UUID()
+        let primaryInfo: String
+        let secondaryInfo: String?
+    }
+
+    private func placeholderResults(for query: String) -> [SearchResult] {
+        [
+            .init(primaryInfo: "The Glow Pt. 2", secondaryInfo: "The Microphones · Album"),
+            .init(primaryInfo: "On keeping a reading journal", secondaryInfo: "Post"),
+            .init(primaryInfo: "Stranger in the Alps", secondaryInfo: "Phoebe Bridgers · Album"),
+            .init(primaryInfo: "Normal People", secondaryInfo: "Sally Rooney · Book"),
+        ]
+    }
+}

--- a/tmbr-app/tmbr/SearchTab.swift
+++ b/tmbr-app/tmbr/SearchTab.swift
@@ -4,27 +4,30 @@ struct SearchTab: View {
     @State private var searchText = ""
 
     var body: some View {
-        Group {
-            if searchText.isEmpty {
-                ContentUnavailableView(
-                    "Search",
-                    systemImage: "magnifyingglass",
-                    description: Text("Posts, songs, books, movies, and more.")
-                )
-            } else {
-                List(placeholderResults(for: searchText)) { result in
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(result.primaryInfo)
-                        if let secondary = result.secondaryInfo {
-                            Text(secondary)
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
+        NavigationStack {
+            Group {
+                if searchText.isEmpty {
+                    ContentUnavailableView(
+                        "Search",
+                        systemImage: "magnifyingglass",
+                        description: Text("Posts, songs, books, movies, and more.")
+                    )
+                } else {
+                    List(placeholderResults(for: searchText)) { result in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(result.primaryInfo)
+                            if let secondary = result.secondaryInfo {
+                                Text(secondary)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                     }
                 }
             }
+            .navigationTitle("Search")
+            .searchable(text: $searchText, prompt: "Posts, songs, books…")
         }
-        .searchable(text: $searchText, prompt: "Posts, songs, books…")
     }
 
     private struct SearchResult: Identifiable {

--- a/tmbr-app/tmbr/SearchTab.swift
+++ b/tmbr-app/tmbr/SearchTab.swift
@@ -4,38 +4,27 @@ struct SearchTab: View {
     @State private var searchText = ""
 
     var body: some View {
-        NavigationStack {
-            Group {
-                if searchText.isEmpty {
-                    ContentUnavailableView(
-                        "Search",
-                        systemImage: "magnifyingglass",
-                        description: Text("Search across all posts and catalogue items.")
-                    )
-                } else {
-                    List(placeholderResults(for: searchText)) { result in
-                        HStack(spacing: 12) {
-                            RoundedRectangle(cornerRadius: 4)
-                                .fill(Color.secondary.opacity(0.2))
-                                .frame(width: 44, height: 44)
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(result.primaryInfo)
-                                if let secondary = result.secondaryInfo {
-                                    Text(secondary)
-                                        .font(.subheadline)
-                                        .foregroundStyle(.secondary)
-                                }
-                            }
+        Group {
+            if searchText.isEmpty {
+                ContentUnavailableView(
+                    "Search",
+                    systemImage: "magnifyingglass",
+                    description: Text("Posts, songs, books, movies, and more.")
+                )
+            } else {
+                List(placeholderResults(for: searchText)) { result in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(result.primaryInfo)
+                        if let secondary = result.secondaryInfo {
+                            Text(secondary)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }
             }
-            .navigationTitle("Search")
-            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
         }
-        .tabItem {
-            Label("Search", systemImage: "magnifyingglass")
-        }
+        .searchable(text: $searchText, prompt: "Posts, songs, books…")
     }
 
     private struct SearchResult: Identifiable {

--- a/tmbr-app/tmbr/SignInView.swift
+++ b/tmbr-app/tmbr/SignInView.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import AuthenticationServices
 import CryptoKit
+import OSLog
+
+private let logger = Logger(subsystem: "me.tmbr", category: "auth")
 
 struct SignInView: View {
     @Environment(AuthState.self) private var authState
     @State private var currentNonce: String = ""
-    @State private var error: Error?
 
     var body: some View {
         VStack(spacing: 24) {
@@ -17,11 +19,6 @@ struct SignInView: View {
                 .frame(height: 50)
                 .padding(.horizontal, 40)
                 .padding(.bottom, 60)
-        }
-        .alert("Sign In Failed", isPresented: .constant(error != nil), presenting: error) { _ in
-            Button("OK") { error = nil }
-        } message: { err in
-            Text(err.localizedDescription)
         }
     }
 
@@ -40,13 +37,13 @@ struct SignInView: View {
                 do {
                     try await authState.signIn(authorization: authorization, nonce: nonce)
                 } catch {
-                    self.error = error
+                    logger.error("Sign in failed: \(error)")
                 }
             }
         case .failure(let err):
             let asErr = err as? ASAuthorizationError
             if asErr?.code == .canceled { return }
-            error = err
+            logger.error("Apple credential error: \(err)")
         }
     }
 


### PR DESCRIPTION
## Summary

- **Search tab** appears first in the macOS sidebar, last in the iOS tab bar
- **Profile button** replaces the per-tab sign-in/compose toggle — always visible as `person.circle`, opens `AccountSheet` (sign-in when logged out, sign-out when logged in)
- **iOS Catalogue toolbar**: filter on leading edge, compose as a separate leading group (`ToolbarSpacer` between them), profile on trailing
- **macOS Catalogue toolbar**: filter stays `.automatic`, compose promoted to `.primaryAction` to land in a different toolbar zone than the filter
- **Sheet sizing**: `CatalogueFilterSheet` and `AccountSheet` get a `320×380` minimum frame so content is visible on macOS
- **AccountSheet**: wrapped in `NavigationStack` with a Close button; auto-dismisses on auth state change
- **CatalogueFilterSheet**: `.listStyle(.plain)` removes the macOS 26 rounded card-cell appearance
- **Blog list**: date on the trailing edge on macOS, stacked subtitle on iOS
- **CatalogueItemType icons**: album → `music.note.square.stack`, playlist → `music.note.list`, book → `book.closed`

## Test plan

- [ ] macOS: Search is first item in sidebar
- [ ] macOS: Filter and compose buttons are in separate toolbar groups in Catalogue
- [ ] macOS: Blog list rows show title + trailing date
- [ ] macOS: Filter sheet opens with full list visible and a working Done button
- [ ] macOS: Account sheet opens with Close button; sign-out works
- [ ] iOS: Filter and compose are two distinct pills on the leading side of Catalogue
- [ ] iOS: Profile button always visible on trailing edge; opens correct sheet based on auth state
- [ ] iOS: Blog list rows show title + subtitle date
- [ ] Both: Updated SF Symbols appear correctly in the filter sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)