### PR TITLE
Make column-add migrations idempotent

### DIFF
--- a/tmbr-web/Sources/App/Modules/Notes/Models/Migrations/AddNoteLanguage.swift
+++ b/tmbr-web/Sources/App/Modules/Notes/Models/Migrations/AddNoteLanguage.swift
@@ -5,7 +5,7 @@ import SQLKit
 struct AddNoteLanguage: AsyncMigration {
     func prepare(on database: Database) async throws {
         guard let sqlDB = database as? SQLDatabase else { return }
-        try await sqlDB.raw("ALTER TABLE notes ADD COLUMN language TEXT NOT NULL DEFAULT 'en'").run()
+        try await sqlDB.raw("ALTER TABLE notes ADD COLUMN IF NOT EXISTS language TEXT NOT NULL DEFAULT 'en'").run()
     }
 
     func revert(on database: Database) async throws {

--- a/tmbr-web/Sources/App/Modules/Posts/Models/Migrations/AddPostLanguage.swift
+++ b/tmbr-web/Sources/App/Modules/Posts/Models/Migrations/AddPostLanguage.swift
@@ -5,7 +5,7 @@ import SQLKit
 struct AddPostLanguage: AsyncMigration {
     func prepare(on database: Database) async throws {
         guard let sqlDB = database as? SQLDatabase else { return }
-        try await sqlDB.raw("ALTER TABLE posts ADD COLUMN language TEXT NOT NULL DEFAULT 'en'").run()
+        try await sqlDB.raw("ALTER TABLE posts ADD COLUMN IF NOT EXISTS language TEXT NOT NULL DEFAULT 'en'").run()
     }
 
     func revert(on database: Database) async throws {

--- a/tmbr-web/Sources/App/Modules/Posts/Models/Migrations/AddPostPublishedAt.swift
+++ b/tmbr-web/Sources/App/Modules/Posts/Models/Migrations/AddPostPublishedAt.swift
@@ -6,7 +6,7 @@ struct AddPostPublishedAt: AsyncMigration {
     func prepare(on database: Database) async throws {
         guard let sqlDB = database as? SQLDatabase else { return }
 
-        try await sqlDB.raw("ALTER TABLE posts ADD COLUMN published_at TIMESTAMPTZ").run()
+        try await sqlDB.raw("ALTER TABLE posts ADD COLUMN IF NOT EXISTS published_at TIMESTAMPTZ").run()
 
         try await sqlDB.raw("""
             UPDATE posts


### PR DESCRIPTION
## Problem

The original combined migration (`AddPostPublishedAtAndLanguage`) is recorded in Fluent's `_fluent_migrations` table on existing installs. The three new split migrations (`AddPostPublishedAt`, `AddPostLanguage`, `AddNoteLanguage`) are unknown names — so Fluent tries to run them, finds the columns already there, and crashes.

## Fix

Add `IF NOT EXISTS` to every `ADD COLUMN` statement. The migration still runs (and gets recorded) on first encounter; it just skips the column creation silently when it already exists.

Safe to merge and deploy immediately — no data changes, only DDL guard clauses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)