### PR TITLE
Fix language picker regressions from PR #176

### DIFF
--- a/.claude/docs/plans/injectable-web-controllers.md
+++ b/.claude/docs/plans/injectable-web-controllers.md
@@ -1,0 +1,56 @@
+# Plan: Injectable Web Controllers (`request.controllers.*`)
+
+## Motivation
+
+Commands (`request.commands.*`) and permissions (`request.permissions.*`) are injected, swappable closure-based types — they encapsulate a single unit of business logic and can be composed or replaced without touching callers.
+
+The web layer currently has no equivalent. Self-contained HTTP features (decode request → run commands → render response) end up either duplicated across controllers or consolidated as hardcoded static helpers (e.g. `NotesWebController.createNote(attachmentID:on:)`). These helpers are better than duplication but they are not injectable, not composable, and don't signal clearly whether they're infrastructure or one-off utilities.
+
+## Proposed Pattern
+
+A `request.controllers` registry, following the same closure-based struct pattern as `CommandFactory` / `AuthPermissionResolver`:
+
+```swift
+request.controllers.notes.create(attachmentID: id)  // → Response
+request.controllers.notes.edit(noteID: id)           // → Response
+```
+
+Each controller is a struct wrapping a closure, built from the request context (commands, view renderer, etc.) and registered the same way commands are — via a `ControllerFactory` and a computed property extension on `Request`.
+
+## Sketch
+
+```swift
+struct WebController<Input, Output> {
+    private let resolve: @Sendable (Input) async throws -> Output
+    func callAsFunction(_ input: Input) async throws -> Output {
+        try await resolve(input)
+    }
+}
+
+struct NoteWebControllers {
+    let create: WebController<UUID, Response>   // attachmentID → Response
+    let edit:   WebController<NoteID, Response> // noteID → Response
+}
+
+extension Request {
+    var controllers: WebControllerRegistry { ... }
+}
+```
+
+Factories are defined close to the feature they own (e.g. `Notes/Routes/Web/`) and wired up in the module's `boot`.
+
+## Benefits
+
+- Same injection/composability story as commands and permissions
+- Testable: swap in a stub factory in tests
+- Removes the conceptual ambiguity of "is this a static helper or infrastructure?"
+- Makes the call site (`request.controllers.notes.create(attachmentID: id)`) read like the existing layers
+
+## Current workaround
+
+`NotesWebController.createNote(attachmentID:on:)` — a static method, honest about being a concrete utility but not injectable. Fine for now; replace when this pattern is adopted.
+
+## Prior art in the codebase
+
+- `CommandFactory` + `Commands+Notes.swift` — exact same struct-wrapping-closure pattern
+- `AuthPermissionResolver` + `PermissionScopes+Notes.swift` — same, for auth

--- a/.claude/incidents/003-language-picker-regressions.md
+++ b/.claude/incidents/003-language-picker-regressions.md
@@ -1,0 +1,37 @@
+# Incident: Language picker regressions after PR #176
+
+**Date**: 2026-06-06
+**Severity**: Medium
+**Status**: Resolved
+
+## What happened
+
+After merging PR #176 (language picker UI + push notification filtering), three regressions were found:
+
+1. Creating a new note on a catalogue item detail page always saved `language = en`, even when the user had selected `hu` in the picker.
+2. The post editor language select defaulted to `hu` for new posts instead of `en`.
+3. Clicking the globe/language button in the toolbar on detail pages and editor pages did nothing — the language filter panel never opened.
+
+## Root cause
+
+**Bug 1 — note language not saved:** Every `createNote` handler in the six catalogue web controllers (`Songs`, `Books`, `Podcasts`, `Movies`, `Albums`, `Playlists`) decoded the `language` field from the payload but never forwarded it to `CreateNoteInput`. The struct's default of `.en` was always used.
+
+**Bug 2 — post editor wrong default:** `post-editor.leaf` used `#if(language=="hu"){ selected }` without spaces around `==`. Leaf evaluates this as a truthiness check on `language` rather than a string comparison, so both `en` and `hu` options rendered with the `selected` attribute simultaneously. The browser picks the last one, so `hu` always won.
+
+**Bug 3 — language panel not wired up:** `filter.js` (which initialises `FilterController` for all `[data-filter-panel]` elements) was only loaded on list/catalogue pages. The global language panel button in `page.leaf` is present on every page, but without `filter.js` the click handler was never attached on detail and editor pages.
+
+## How it was fixed
+
+- Added `language: payload.language ?? .en` to `CreateNoteInput(...)` in all six catalogue web controllers.
+- Changed the post editor Leaf syntax from `#if(language=="hu"){ selected }` to `#if(language == "hu"):selected#endif`, matching the convention used in all other templates.
+- Moved `<script src="/Scripts/Shared/filter.js"></script>` into `scripts.leaf` (loaded globally), and removed the now-redundant conditional loads from `catalogue.leaf`, `list.leaf`, and `posts.leaf`.
+
+## Prevention
+
+- [x] New test: `AlbumTests/createNote_withNonDefaultLanguage_savesLanguage` — POSTs a note with `language=hu` to `/albums/:id/notes` and asserts the persisted note has `language == .hu`.
+- [ ] Process change: when a `createNote`-style handler is added for a new catalogue type, the test suite should include a note-language round-trip test for that type.
+- [ ] Leaf convention: prefer `:...#endif` syntax with spaces around operators; document this in `.claude/docs/frontend.md` to avoid silent comparison failures.
+
+## Tests added
+
+`Tests/AppTests/Catalogue/AlbumTests.swift` — `createNote_withNonDefaultLanguage_savesLanguage`

--- a/tmbr-web/Resources/Views/Catalogue/catalogue.leaf
+++ b/tmbr-web/Resources/Views/Catalogue/catalogue.leaf
@@ -30,7 +30,6 @@
     #export("scripts"):
         <script src="/Scripts/Shared/toolbar.js"></script>
         <script src="/Scripts/Shared/search.js"></script>
-        <script src="/Scripts/Shared/filter.js"></script>
         <script>document.addEventListener('DOMContentLoaded', () => new ShortcutsController([ShortcutsController.login]).init());</script>
     #endexport
 

--- a/tmbr-web/Resources/Views/Catalogue/list.leaf
+++ b/tmbr-web/Resources/Views/Catalogue/list.leaf
@@ -29,7 +29,6 @@
         #if(compose):
             #if(compose.directURL):#else:<script src="/Scripts/Shared/toolbar.js"></script>#endif
         #endif
-        #if(panels):<script src="/Scripts/Shared/filter.js"></script>#endif
         <script src="/Scripts/Shared/search.js"></script>
         <script>document.addEventListener('DOMContentLoaded', () => new ShortcutsController([ShortcutsController.login]).init());</script>
     #endexport

--- a/tmbr-web/Resources/Views/Posts/post-editor.leaf
+++ b/tmbr-web/Resources/Views/Posts/post-editor.leaf
@@ -62,8 +62,8 @@
                 <label class="language-picker">
                     #extend("Icons/globe")
                     <select id="editor-post-language" name="language">
-                        <option value="en" #if(language=="en"){ selected }>en</option>
-                        <option value="hu" #if(language=="hu"){ selected }>hu</option>
+                        <option value="en" #if(language == "en"):selected#endif>en</option>
+                        <option value="hu" #if(language == "hu"):selected#endif>hu</option>
                     </select>
                 </label>
 

--- a/tmbr-web/Resources/Views/Posts/posts.leaf
+++ b/tmbr-web/Resources/Views/Posts/posts.leaf
@@ -35,7 +35,6 @@
 
     #export("scripts"):
         <script src="/Scripts/Shared/toolbar.js"></script>
-        #if(panels):<script src="/Scripts/Shared/filter.js"></script>#endif
         <script src="/Scripts/Shared/search.js"></script>
         <script>document.addEventListener('DOMContentLoaded', () => new ShortcutsController([ShortcutsController.login]).init());</script>
     #endexport

--- a/tmbr-web/Resources/Views/Shared/scripts.leaf
+++ b/tmbr-web/Resources/Views/Shared/scripts.leaf
@@ -1,3 +1,4 @@
 <script src="/Scripts/Notifications/notifications.js"></script>
 <script src="/Scripts/Shortcuts/shortcuts.js"></script>
+<script src="/Scripts/Shared/filter.js"></script>
 #import("scripts")

--- a/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/Web/AlbumsWebController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/Web/AlbumsWebController.swift
@@ -206,20 +206,9 @@ struct AlbumsWebController: RouteCollection {
         guard let albumID = request.parameters.get("albumID", as: Int.self) else {
             return Response(status: .badRequest)
         }
-        guard let payload = try? request.content.decode(NotePayload.self) else {
-            return Response(status: .badRequest)
-        }
         do {
             let album = try await request.commands.albums.fetch(albumID, for: .write)
-            let input = CreateNoteInput(
-                body: payload.body,
-                access: payload.access,
-                attachmentID: album.$preview.id
-            )
-            let note = try await request.commands.notes.create(input)
-            let model = try NoteViewModel(note: note, isEditable: true)
-            let view = try await Template.noteItem.render(NoteItemContext(note: model), with: request.view)
-            return try await view.encodeResponse(for: request)
+            return try await NotesWebController.createNote(attachmentID: album.$preview.id, on: request)
         } catch {
             return Response(status: .unprocessableEntity)
         }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Books/Routes/Web/BooksWebController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Books/Routes/Web/BooksWebController.swift
@@ -193,20 +193,9 @@ struct BooksWebController: RouteCollection {
         guard let bookID = request.parameters.get("bookID", as: Int.self) else {
             return Response(status: .badRequest)
         }
-        guard let payload = try? request.content.decode(NotePayload.self) else {
-            return Response(status: .badRequest)
-        }
         do {
             let book = try await request.commands.books.fetch(bookID, for: .write)
-            let input = CreateNoteInput(
-                body: payload.body,
-                access: payload.access,
-                attachmentID: book.$preview.id
-            )
-            let note = try await request.commands.notes.create(input)
-            let model = try NoteViewModel(note: note, isEditable: true)
-            let view = try await Template.noteItem.render(NoteItemContext(note: model), with: request.view)
-            return try await view.encodeResponse(for: request)
+            return try await NotesWebController.createNote(attachmentID: book.$preview.id, on: request)
         } catch {
             return Response(status: .unprocessableEntity)
         }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Movies/Routes/Web/MoviesWebController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Movies/Routes/Web/MoviesWebController.swift
@@ -194,20 +194,9 @@ struct MoviesWebController: RouteCollection {
         guard let movieID = request.parameters.get("movieID", as: Int.self) else {
             return Response(status: .badRequest)
         }
-        guard let payload = try? request.content.decode(NotePayload.self) else {
-            return Response(status: .badRequest)
-        }
         do {
             let movie = try await request.commands.movies.fetch(movieID, for: .write)
-            let input = CreateNoteInput(
-                body: payload.body,
-                access: payload.access,
-                attachmentID: movie.$preview.id
-            )
-            let note = try await request.commands.notes.create(input)
-            let model = try NoteViewModel(note: note, isEditable: true)
-            let view = try await Template.noteItem.render(NoteItemContext(note: model), with: request.view)
-            return try await view.encodeResponse(for: request)
+            return try await NotesWebController.createNote(attachmentID: movie.$preview.id, on: request)
         } catch {
             return Response(status: .unprocessableEntity)
         }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/Web/PlaylistsWebController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/Web/PlaylistsWebController.swift
@@ -184,20 +184,9 @@ struct PlaylistsWebController: RouteCollection {
         guard let playlistID = request.parameters.get("playlistID", as: Int.self) else {
             return Response(status: .badRequest)
         }
-        guard let payload = try? request.content.decode(NotePayload.self) else {
-            return Response(status: .badRequest)
-        }
         do {
             let playlist = try await request.commands.playlists.fetch(playlistID, for: .write)
-            let input = CreateNoteInput(
-                body: payload.body,
-                access: payload.access,
-                attachmentID: playlist.$preview.id
-            )
-            let note = try await request.commands.notes.create(input)
-            let model = try NoteViewModel(note: note, isEditable: true)
-            let view = try await Template.noteItem.render(NoteItemContext(note: model), with: request.view)
-            return try await view.encodeResponse(for: request)
+            return try await NotesWebController.createNote(attachmentID: playlist.$preview.id, on: request)
         } catch {
             return Response(status: .unprocessableEntity)
         }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/PodcastsWebController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Routes/Web/PodcastsWebController.swift
@@ -195,20 +195,9 @@ struct PodcastsWebController: RouteCollection {
         guard let podcastID = request.parameters.get("podcastID", as: Int.self) else {
             return Response(status: .badRequest)
         }
-        guard let payload = try? request.content.decode(NotePayload.self) else {
-            return Response(status: .badRequest)
-        }
         do {
             let podcast = try await request.commands.podcasts.fetch(podcastID, for: .write)
-            let input = CreateNoteInput(
-                body: payload.body,
-                access: payload.access,
-                attachmentID: podcast.$preview.id
-            )
-            let note = try await request.commands.notes.create(input)
-            let model = try NoteViewModel(note: note, isEditable: true)
-            let view = try await Template.noteItem.render(NoteItemContext(note: model), with: request.view)
-            return try await view.encodeResponse(for: request)
+            return try await NotesWebController.createNote(attachmentID: podcast.$preview.id, on: request)
         } catch {
             return Response(status: .unprocessableEntity)
         }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Songs/Routes/Web/SongsWebController.swift
@@ -203,20 +203,9 @@ struct SongsWebController: RouteCollection {
         guard let songID = request.parameters.get("songID", as: Int.self) else {
             return Response(status: .badRequest)
         }
-        guard let payload = try? request.content.decode(NotePayload.self) else {
-            return Response(status: .badRequest)
-        }
         do {
             let song = try await request.commands.songs.fetch(songID, for: .write)
-            let input = CreateNoteInput(
-                body: payload.body,
-                access: payload.access,
-                attachmentID: song.$preview.id
-            )
-            let note = try await request.commands.notes.create(input)
-            let model = try NoteViewModel(note: note, isEditable: true)
-            let view = try await Template.noteItem.render(NoteItemContext(note: model), with: request.view)
-            return try await view.encodeResponse(for: request)
+            return try await NotesWebController.createNote(attachmentID: song.$preview.id, on: request)
         } catch {
             return Response(status: .unprocessableEntity)
         }

--- a/tmbr-web/Sources/App/Modules/Notes/Routes/Web/NotesWebController.swift
+++ b/tmbr-web/Sources/App/Modules/Notes/Routes/Web/NotesWebController.swift
@@ -11,6 +11,25 @@ struct NotesWebController: RouteCollection {
         notes.put(":noteID", use: edit)
     }
 
+    static func createNote(attachmentID: UUID, on request: Request) async throws -> Response {
+        guard let payload = try? request.content.decode(NotePayload.self) else {
+            return Response(status: .badRequest)
+        }
+        do {
+            let note = try await request.commands.notes.create(CreateNoteInput(
+                body: payload.body,
+                access: payload.access,
+                attachmentID: attachmentID,
+                language: payload.language ?? .en
+            ))
+            let model = try NoteViewModel(note: note, isEditable: true)
+            let view = try await Template.noteItem.render(NoteItemContext(note: model), with: request.view)
+            return try await view.encodeResponse(for: request)
+        } catch {
+            return Response(status: .unprocessableEntity)
+        }
+    }
+
     @Sendable
     private func edit(request: Request) async throws -> Response {
         guard let noteID = request.parameters.get("noteID", as: NoteID.self) else {

--- a/tmbr-web/Tests/AppTests/Catalogue/AlbumTests.swift
+++ b/tmbr-web/Tests/AppTests/Catalogue/AlbumTests.swift
@@ -167,6 +167,52 @@ struct AlbumTests {
         }
     }
 
+    @Test("POST /albums/:id/notes preserves submitted language")
+    func createNote_withNonDefaultLanguage_savesLanguage() async throws {
+        try await withAuthenticatedApp { app, headers in
+            var csrf = ""
+            try await app.testing().test(.GET, "/albums/new", headers: headers) { res async in
+                let body = res.body.string
+                if let range = body.range(of: "name=\"_csrf\" value=\"") {
+                    let start = body.index(range.upperBound, offsetBy: 0)
+                    let end = body[start...].firstIndex(of: "\"") ?? body.endIndex
+                    csrf = String(body[start..<end])
+                }
+            }
+            var albumLocation = ""
+            try await app.testing().test(
+                .POST, "/albums/new",
+                headers: headers,
+                beforeRequest: { req in
+                    struct AlbumForm: Content {
+                        let _csrf: String; let title: String; let artist: String; let access: String
+                    }
+                    try req.content.encode(AlbumForm(_csrf: csrf, title: "Test Album", artist: "Tester", access: "private"))
+                },
+                afterResponse: { res async in albumLocation = res.headers.first(name: "Location") ?? "" }
+            )
+            let albumID = albumLocation.components(separatedBy: "/").last ?? ""
+            #expect(!albumID.isEmpty)
+
+            struct NoteForm: Content {
+                let body: String; let access: String; let language: String
+            }
+            try await app.testing().test(
+                .POST, "/albums/\(albumID)/notes",
+                headers: headers,
+                beforeRequest: { req in
+                    try req.content.encode(NoteForm(body: "Teszt megjegyzés", access: "private", language: "hu"))
+                },
+                afterResponse: { res async in
+                    #expect(res.status == .ok)
+                }
+            )
+
+            let note = try await Note.query(on: app.db).first()
+            #expect(note?.language == .hu)
+        }
+    }
+
     @Test("GET /albums/:id detail page returns 200")
     func getAlbumDetail_returnsOK() async throws {
         try await withAuthenticatedApp { app, headers in


### PR DESCRIPTION
## Summary

Three regressions introduced in #176 (language picker + push notifications):

- **New notes ignored selected language** — all six catalogue `createNote` handlers constructed `CreateNoteInput` without forwarding `language` from the payload, so notes always saved as `en`. Consolidated the shared decode→create→render logic into `NotesWebController.createNote(attachmentID:on:)` and each controller now delegates to it after fetching its item.
- **Post editor defaulted to `hu`** — `#if(language=="hu"){ selected }` without spaces around `==` caused Leaf to evaluate the condition as a truthiness check rather than a string comparison, making both options render as selected (last one wins). Fixed by switching to `:selected#endif` syntax with spaces, matching the convention used in all other templates.
- **Language filter panel didn't open on detail/editor pages** — `filter.js` was only loaded on list and catalogue pages, but the globe button that triggers it lives in `page.leaf` (shared layout). Moved `filter.js` to `scripts.leaf` so it loads on every page.

## Test plan

- [ ] On any catalogue item detail page, create a note with language set to `hu` → confirm `language = hu` in DB
- [ ] Open the post editor for a new post → confirm `en` is selected by default
- [ ] On a catalogue item detail page, click the globe button in the toolbar → confirm the language panel opens
- [ ] On a post detail page, click the globe button → confirm the language panel opens
- [ ] Existing language filter behaviour on list/catalogue pages still works

## Notes

`NotesWebController.createNote(attachmentID:on:)` is a static helper, not a new injection point. A plan for an injectable `request.controllers.*` layer (the natural evolution of this) is documented in `.claude/docs/plans/injectable-web-controllers.md`. Incident post-mortem at `.claude/incidents/003-language-picker-regressions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)