### PR TITLE
Rename CatalogueCategory.Kind: .catalogue→.entry, .collection→.virtual

### DIFF
--- a/tmbr-web/.claude/docs/database.md
+++ b/tmbr-web/.claude/docs/database.md
@@ -75,19 +75,19 @@ Some catalogue entries are **shallow placeholders** — they have a Preview reco
 
 | Kind | Description | `parentID` | Can have Notes? | Example |
 |------|-------------|------------|-----------------|---------|
-| `.catalogue` | Model-backed, appears in feed | non-nil | Yes | Song, Album, Book, Movie, Playlist, Podcast |
+| `.entry` | Model-backed, appears in feed | non-nil | Yes | Song, Album, Book, Movie, Playlist, Podcast |
 | `.promotable` | Shallow placeholder awaiting promotion | nil → non-nil after promotion | No → Yes after promotion | Track |
 | `.orphan` | User-defined, no backing model | nil | Yes | Recipe, Guide, Link |
-| `.collection` | Display-only grouping | nil | Yes (no use case yet) | Music |
+| `.virtual` | Display-only grouping | nil | Yes (no use case yet) | Music |
 
-**Key rule: use `catalogueCategory?.kind.isShallow` (not `parentID == nil`) to test whether an item can have notes.** Orphan and collection items also have `parentID == nil` but are not shallow and can accept Notes.
+**Key rule: use `catalogueCategory?.kind.isShallow` (not `parentID == nil`) to test whether an item can have notes.** Orphan and virtual items also have `parentID == nil` but are not shallow and can accept Notes.
 
 #### Promotable Lifecycle (Track → Song)
 
 1. **Import**: A `Preview` is created with `parentID = nil` and `kind = .promotable`. No Song model exists yet.
 2. **User accesses track**: The app prompts to promote. `POST /api/songs/promote` is called.
-3. **Promotion**: A `Song` model is created with `adoptingPreviewID` set to the track's Preview UUID. `PreviewModelMiddleware` calls `preview.adopt(parentID: songID, categoryID: songCategoryID, ...)` — setting `parentID` to the Song's Int ID and changing the category to "song" (kind = `.catalogue`).
-4. **After promotion**: The same Preview UUID now has a non-nil `parentID` and a `.catalogue` kind. Notes can now be attached.
+3. **Promotion**: A `Song` model is created with `adoptingPreviewID` set to the track's Preview UUID. `PreviewModelMiddleware` calls `preview.adopt(parentID: songID, categoryID: songCategoryID, ...)` — setting `parentID` to the Song's Int ID and changing the category to "song" (kind = `.entry`).
+4. **After promotion**: The same Preview UUID now has a non-nil `parentID` and a `.entry` kind. Notes can now be attached.
 
 The `ContainerEntry` for an album/playlist tracklist always points to the same Preview UUID regardless of whether it has been promoted.
 

--- a/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Models/CatalogueCategory.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Models/CatalogueCategory.swift
@@ -27,10 +27,10 @@ final class CatalogueCategory: Model, @unchecked Sendable {
     var parentSlug: String?
 
     enum Kind: String, Codable, CaseIterable {
-        case catalogue   // model-backed items visible in the feed: song, album, book, movie, playlist, podcast
+        case entry       // model-backed items visible in the feed: song, album, book, movie, playlist, podcast
         case promotable  // shallow placeholder awaiting promotion: track
         case orphan      // user-defined, no backing model: recipe, guide, link, …
-        case collection  // display-only grouping of related catalogue types, e.g. music → song/album/playlist
+        case virtual     // display-only grouping of related catalogue types, e.g. music → song/album/playlist
     }
 
     init() {}
@@ -55,7 +55,7 @@ final class CatalogueCategory: Model, @unchecked Sendable {
 extension CatalogueCategory.Kind {
     /// True for shallow placeholder items (currently: track) that cannot own Notes
     /// and are expected to be promoted to a first-class catalogue item.
-    /// Use this instead of checking `preview.parentID != nil` — orphan and collection items
+    /// Use this instead of checking `preview.parentID != nil` — orphan and virtual items
     /// also have a nil parentID but are not shallow and can have notes.
     var isShallow: Bool { self == .promotable }
 }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/CatalogueQueryMapper.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/CatalogueQueryMapper.swift
@@ -32,8 +32,8 @@ struct CatalogueQueryMapper: Sendable {
 
     private func selectedCategoryIDs(from slugs: Set<String>?) -> Set<Int>? {
         guard let slugs else {
-            // nil = all selected: exclude collection categories (they have no direct preview assignments)
-            let leafIDs = Set(categories.filter { $0.kind != .collection }.compactMap(\.id))
+            // nil = all selected: exclude virtual categories (they have no direct preview assignments)
+            let leafIDs = Set(categories.filter { $0.kind != .virtual }.compactMap(\.id))
             return leafIDs.isEmpty ? nil : leafIDs
         }
         // Expand collection slugs to their child category slugs

--- a/tmbr-web/Sources/App/Modules/Notifications/Routes/Web/NotificationsWebController.swift
+++ b/tmbr-web/Sources/App/Modules/Notifications/Routes/Web/NotificationsWebController.swift
@@ -9,12 +9,12 @@ struct NotificationsWebController: RouteCollection {
 
     private func panel(req: Request) async throws -> View {
         let categories = try await CatalogueCategory.query(on: req.db)
-            .filter(\.$kind ~~ [.collection, .catalogue, .orphan])
+            .filter(\.$kind ~~ [.virtual, .entry, .orphan])
             .sort(\.$name)
             .all()
 
         let noteChildren: [PanelOption] = categories
-            .filter { $0.kind == .orphan || $0.kind == .collection || ($0.kind == .catalogue && $0.parentSlug == nil) }
+            .filter { $0.kind == .orphan || $0.kind == .virtual || ($0.kind == .entry && $0.parentSlug == nil) }
             .map { PanelOption(value: "note:\($0.slug)", label: $0.name, icon: $0.icon ?? $0.slug, hasChildren: false, children: []) }
 
         let options: [PanelOption] = [

--- a/tmbr-web/Sources/App/Modules/Previews/Models/Migrations/RenameCatalogueKinds.swift
+++ b/tmbr-web/Sources/App/Modules/Previews/Models/Migrations/RenameCatalogueKinds.swift
@@ -1,0 +1,18 @@
+import Fluent
+import Foundation
+import SQLKit
+
+struct RenameCatalogueKinds: AsyncMigration {
+
+    func prepare(on database: Database) async throws {
+        guard let sqlDB = database as? SQLDatabase else { return }
+        try await sqlDB.raw("UPDATE catalogue_categories SET kind = 'entry' WHERE kind = 'catalogue'").run()
+        try await sqlDB.raw("UPDATE catalogue_categories SET kind = 'virtual' WHERE kind = 'collection'").run()
+    }
+
+    func revert(on database: Database) async throws {
+        guard let sqlDB = database as? SQLDatabase else { return }
+        try await sqlDB.raw("UPDATE catalogue_categories SET kind = 'catalogue' WHERE kind = 'entry'").run()
+        try await sqlDB.raw("UPDATE catalogue_categories SET kind = 'collection' WHERE kind = 'virtual'").run()
+    }
+}

--- a/tmbr-web/Sources/App/Modules/Previews/Previews.swift
+++ b/tmbr-web/Sources/App/Modules/Previews/Previews.swift
@@ -27,6 +27,7 @@ struct Previews: Module {
         app.migrations.add(AddRouteAndIconToCatalogueCategories())
         app.migrations.add(MigrateCategoryIDToInteger())
         app.migrations.add(AddCollectionKindAndParentSlug())
+        app.migrations.add(RenameCatalogueKinds())
 
         try await app.permissions.add(scope: permissions)
         try await app.commands.add(collection: commands)


### PR DESCRIPTION
## Summary

- `.catalogue` renamed to `.entry` — removes the overloaded term that also names the entire module/feature
- `.collection` renamed to `.virtual` — disambiguates from album/playlist which are colloquially "collections"
- New `RenameCatalogueKinds` migration updates stored string values in `catalogue_categories` so existing rows decode correctly against the renamed enum cases

## Files changed

| File | Change |
|------|--------|
| `CatalogueCategory.swift` | Enum cases renamed; `isShallow` comment updated |
| `NotificationsWebController.swift` | Filter updated to `.entry` / `.virtual` |
| `CatalogueQueryMapper.swift` | Filter updated to `.virtual` |
| `RenameCatalogueKinds.swift` | New migration (prepare + revert) |
| `Previews.swift` | Migration registered after `AddCollectionKindAndParentSlug` |
| `database.md` | Docs updated |

## Test plan

- [ ] `swift build` passes (already verified locally — no errors, only a pre-existing `Sendable` warning)
- [ ] `swift run Backend migrate` applies `RenameCatalogueKinds` without error on a local DB
- [ ] Load `/notifications/panel` — categories render correctly
- [ ] `swift test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)