### PR TITLE
Stage 4: Offline writes for notes and posts

### DIFF
--- a/tmbr-app/tmbr/Blog/Actions/CreatePostAction.swift
+++ b/tmbr-app/tmbr/Blog/Actions/CreatePostAction.swift
@@ -1,0 +1,31 @@
+import Foundation
+import SwiftData
+import TmbrCore
+
+@MainActor
+public struct CreatePostAction: Sendable {
+
+    private let body: @MainActor (String, String, ModelContext) async -> Void
+
+    nonisolated public init(_ body: @escaping @MainActor (String, String, ModelContext) async -> Void = { _, _, _ in }) {
+        self.body = body
+    }
+
+    @MainActor public init(syncEngine: SyncEngine) {
+        self.init { title, content, context in
+            let record = PostRecord(
+                title: title,
+                content: content,
+                stateRaw: PostState.draft.rawValue,
+                languageRaw: Language.en.rawValue,
+                syncState: .pendingCreate
+            )
+            context.insert(record)
+            Task { try? await syncEngine.pushPendingPosts() }
+        }
+    }
+
+    @MainActor public func callAsFunction(title: String, content: String, context: ModelContext) async {
+        await body(title, content, context)
+    }
+}

--- a/tmbr-app/tmbr/Blog/Actions/DeletePostAction.swift
+++ b/tmbr-app/tmbr/Blog/Actions/DeletePostAction.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftData
+
+@MainActor
+public struct DeletePostAction: Sendable {
+
+    private let body: @MainActor (PostRecord, ModelContext) async -> Void
+
+    nonisolated public init(_ body: @escaping @MainActor (PostRecord, ModelContext) async -> Void = { _, _ in }) {
+        self.body = body
+    }
+
+    @MainActor public init(syncEngine: SyncEngine) {
+        self.init { record, context in
+            if record.serverID != nil {
+                record.syncState = .pendingDelete
+                Task { try? await syncEngine.pushPendingPosts() }
+            } else {
+                context.delete(record)
+            }
+        }
+    }
+
+    @MainActor public func callAsFunction(record: PostRecord, context: ModelContext) async {
+        await body(record, context)
+    }
+}

--- a/tmbr-app/tmbr/Blog/Actions/UpdatePostAction.swift
+++ b/tmbr-app/tmbr/Blog/Actions/UpdatePostAction.swift
@@ -1,0 +1,26 @@
+import Foundation
+import TmbrCore
+
+@MainActor
+public struct UpdatePostAction: Sendable {
+
+    private let body: @MainActor (PostRecord, String, String, PostState) async -> Void
+
+    nonisolated public init(_ body: @escaping @MainActor (PostRecord, String, String, PostState) async -> Void = { _, _, _, _ in }) {
+        self.body = body
+    }
+
+    @MainActor public init(syncEngine: SyncEngine) {
+        self.init { record, title, content, state in
+            record.title = title
+            record.content = content
+            record.stateRaw = state.rawValue
+            if record.syncState == .synced { record.syncState = .pendingUpdate }
+            Task { try? await syncEngine.pushPendingPosts() }
+        }
+    }
+
+    @MainActor public func callAsFunction(record: PostRecord, title: String, content: String, state: PostState) async {
+        await body(record, title, content, state)
+    }
+}

--- a/tmbr-app/tmbr/Blog/BlogEnvironment.swift
+++ b/tmbr-app/tmbr/Blog/BlogEnvironment.swift
@@ -2,4 +2,7 @@ import SwiftUI
 
 extension EnvironmentValues {
     @Entry var syncBlog: SyncBlogAction = SyncBlogAction()
+    @Entry var createPost: CreatePostAction = CreatePostAction()
+    @Entry var updatePost: UpdatePostAction = UpdatePostAction()
+    @Entry var deletePost: DeletePostAction = DeletePostAction()
 }

--- a/tmbr-app/tmbr/Blog/BlogModel.swift
+++ b/tmbr-app/tmbr/Blog/BlogModel.swift
@@ -8,7 +8,7 @@ final class BlogModel {
     private(set) var isSyncing = false
     private(set) var syncError: Error?
 
-    private let syncEngine: SyncEngine
+    let syncEngine: SyncEngine
 
     init(syncEngine: SyncEngine) {
         self.syncEngine = syncEngine
@@ -20,7 +20,7 @@ final class BlogModel {
         syncError = nil
         defer { isSyncing = false }
         do {
-            try await syncEngine.syncDelta()
+            try await syncEngine.runSync()
         } catch {
             syncError = error
         }

--- a/tmbr-app/tmbr/Blog/View+Blog.swift
+++ b/tmbr-app/tmbr/Blog/View+Blog.swift
@@ -4,5 +4,8 @@ extension View {
     func blog(_ model: BlogModel) -> some View {
         environment(model)
             .environment(\.syncBlog, SyncBlogAction(model: model))
+            .environment(\.createPost, CreatePostAction(syncEngine: model.syncEngine))
+            .environment(\.updatePost, UpdatePostAction(syncEngine: model.syncEngine))
+            .environment(\.deletePost, DeletePostAction(syncEngine: model.syncEngine))
     }
 }

--- a/tmbr-app/tmbr/BlogEditorView.swift
+++ b/tmbr-app/tmbr/BlogEditorView.swift
@@ -1,19 +1,70 @@
 import SwiftUI
+import SwiftData
+import TmbrCore
 
 struct BlogEditorView: View {
+
+    var post: PostRecord? = nil   // nil = create, non-nil = edit
+
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.createPost) private var createPost
+    @Environment(\.updatePost) private var updatePost
+
+    @State private var title: String = ""
+    @State private var content: String = ""
+    @State private var state: PostState = .draft
+    @State private var isSaving = false
 
     var body: some View {
         NavigationStack {
-            Text("Blog Editor")
-                .foregroundStyle(.secondary)
-                .navigationTitle("New Post")
-                .toolbarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel") { dismiss() }
+            Form {
+                Section("Title") {
+                    TextField("Title", text: $title, axis: .vertical)
+                        .lineLimit(1...3)
+                }
+                Section("Content") {
+                    TextEditor(text: $content)
+                        .frame(minHeight: 200)
+                }
+                Section {
+                    Picker("Status", selection: $state) {
+                        Text("Draft").tag(PostState.draft)
+                        Text("Published").tag(PostState.published)
                     }
                 }
+            }
+            .navigationTitle(post == nil ? "New Post" : "Edit Post")
+            .toolbarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task { await save() }
+                    }
+                    .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty || isSaving)
+                }
+            }
         }
+        .onAppear {
+            if let post {
+                title = post.title
+                content = post.content
+                state = PostState(rawValue: post.stateRaw) ?? .draft
+            }
+        }
+    }
+
+    private func save() async {
+        isSaving = true
+        let trimmedTitle = title.trimmingCharacters(in: .whitespaces)
+        if let post {
+            await updatePost(record: post, title: trimmedTitle, content: content, state: state)
+        } else {
+            await createPost(title: trimmedTitle, content: content, context: modelContext)
+        }
+        dismiss()
     }
 }

--- a/tmbr-app/tmbr/BlogTab.swift
+++ b/tmbr-app/tmbr/BlogTab.swift
@@ -12,11 +12,18 @@ struct BlogTab: View {
     @Environment(\.syncBlog)
     private var syncBlog
 
+    @Environment(\.deletePost)
+    private var deletePost
+
     @Environment(AuthState.self)
     private var authState
 
+    @Environment(\.modelContext)
+    private var modelContext
+
     @State private var showAccount = false
     @State private var showEditor = false
+    @State private var postToEdit: PostRecord? = nil
 
     var body: some View {
         NavigationStack {
@@ -26,6 +33,19 @@ struct BlogTab: View {
                 } else {
                     ForEach(posts) { post in
                         PostRow(post: post)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) {
+                                    Task { await deletePost(record: post, context: modelContext) }
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                                Button {
+                                    postToEdit = post
+                                } label: {
+                                    Label("Edit", systemImage: "pencil")
+                                }
+                                .tint(.blue)
+                            }
                     }
                 }
             }
@@ -63,6 +83,9 @@ struct BlogTab: View {
         .sheet(isPresented: $showEditor) {
             BlogEditorView()
         }
+        .sheet(item: $postToEdit) { post in
+            BlogEditorView(post: post)
+        }
     }
 }
 
@@ -73,6 +96,11 @@ private struct PostRow: View {
         VStack(alignment: .leading, spacing: 2) {
             Text(post.title.isEmpty ? "Untitled" : post.title)
             HStack {
+                if post.syncState != .synced {
+                    Image(systemName: "arrow.trianglehead.2.clockwise")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
                 Text(post.stateRaw.capitalized)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)

--- a/tmbr-app/tmbr/Catalogue/Actions/CreateNoteAction.swift
+++ b/tmbr-app/tmbr/Catalogue/Actions/CreateNoteAction.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SwiftData
+import TmbrCore
+
+@MainActor
+public struct CreateNoteAction: Sendable {
+
+    private let body: @MainActor (String, Access, CatalogueItemRecord, ModelContext) async -> Void
+
+    nonisolated public init(_ body: @escaping @MainActor (String, Access, CatalogueItemRecord, ModelContext) async -> Void = { _, _, _, _ in }) {
+        self.body = body
+    }
+
+    @MainActor public init(syncEngine: SyncEngine, context: ModelContext) {
+        self.init { noteBody, access, item, ctx in
+            let record = NoteRecord(
+                body: noteBody,
+                accessRaw: access.rawValue,
+                languageRaw: Language.en.rawValue,
+                syncState: .pendingCreate,
+                attachmentPreviewID: item.id,
+                attachmentTitle: item.title,
+                attachmentSubtitle: item.subtitle,
+                attachmentCategoryType: item.categoryType,
+                attachmentSourceID: item.sourceID
+            )
+            ctx.insert(record)
+            Task { try? await syncEngine.pushPendingNotes() }
+        }
+    }
+
+    @MainActor public func callAsFunction(body: String, access: Access = .private, item: CatalogueItemRecord, context: ModelContext) async {
+        await self.body(body, access, item, context)
+    }
+}

--- a/tmbr-app/tmbr/Catalogue/Actions/DeleteNoteAction.swift
+++ b/tmbr-app/tmbr/Catalogue/Actions/DeleteNoteAction.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftData
+
+@MainActor
+public struct DeleteNoteAction: Sendable {
+
+    private let body: @MainActor (NoteRecord, ModelContext) async -> Void
+
+    nonisolated public init(_ body: @escaping @MainActor (NoteRecord, ModelContext) async -> Void = { _, _ in }) {
+        self.body = body
+    }
+
+    @MainActor public init(syncEngine: SyncEngine) {
+        self.init { record, context in
+            if record.serverID != nil {
+                record.syncState = .pendingDelete
+                Task { try? await syncEngine.pushPendingNotes() }
+            } else {
+                // Not yet on the server — safe to delete immediately without a server call.
+                context.delete(record)
+            }
+        }
+    }
+
+    @MainActor public func callAsFunction(record: NoteRecord, context: ModelContext) async {
+        await body(record, context)
+    }
+}

--- a/tmbr-app/tmbr/Catalogue/Actions/UpdateNoteAction.swift
+++ b/tmbr-app/tmbr/Catalogue/Actions/UpdateNoteAction.swift
@@ -1,0 +1,25 @@
+import Foundation
+import TmbrCore
+
+@MainActor
+public struct UpdateNoteAction: Sendable {
+
+    private let body: @MainActor (NoteRecord, String, Access) async -> Void
+
+    nonisolated public init(_ body: @escaping @MainActor (NoteRecord, String, Access) async -> Void = { _, _, _ in }) {
+        self.body = body
+    }
+
+    @MainActor public init(syncEngine: SyncEngine) {
+        self.init { record, newBody, access in
+            record.body = newBody
+            record.accessRaw = access.rawValue
+            if record.syncState == .synced { record.syncState = .pendingUpdate }
+            Task { try? await syncEngine.pushPendingNotes() }
+        }
+    }
+
+    @MainActor public func callAsFunction(record: NoteRecord, body: String, access: Access) async {
+        await self.body(record, body, access)
+    }
+}

--- a/tmbr-app/tmbr/Catalogue/CatalogueEnvironment.swift
+++ b/tmbr-app/tmbr/Catalogue/CatalogueEnvironment.swift
@@ -2,4 +2,7 @@ import SwiftUI
 
 extension EnvironmentValues {
     @Entry var syncCatalogue: SyncCatalogueAction = SyncCatalogueAction()
+    @Entry var createNote: CreateNoteAction = CreateNoteAction()
+    @Entry var updateNote: UpdateNoteAction = UpdateNoteAction()
+    @Entry var deleteNote: DeleteNoteAction = DeleteNoteAction()
 }

--- a/tmbr-app/tmbr/Catalogue/CatalogueItemDetailView.swift
+++ b/tmbr-app/tmbr/Catalogue/CatalogueItemDetailView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import SwiftData
+import TmbrCore
+
+struct CatalogueItemDetailView: View {
+
+    let item: CatalogueItemRecord
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.deleteNote) private var deleteNote
+
+    @State private var showNoteEditor = false
+    @State private var noteToEdit: NoteRecord? = nil
+
+    private var notes: [NoteRecord] {
+        let sourceID = item.sourceID
+        let categoryType = item.categoryType
+        let all = (try? modelContext.fetch(FetchDescriptor<NoteRecord>())) ?? []
+        return all.filter { $0.attachmentSourceID == sourceID && $0.attachmentCategoryType == categoryType }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    var body: some View {
+        List {
+            Section {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.title)
+                        .font(.headline)
+                    if let subtitle = item.subtitle {
+                        Text(subtitle)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(item.categoryType.capitalized)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(.vertical, 4)
+            }
+
+            Section("Notes") {
+                if notes.isEmpty {
+                    Text("No notes yet")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(notes) { note in
+                        NoteRow(note: note)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                Button(role: .destructive) {
+                                    Task { await deleteNote(record: note, context: modelContext) }
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                            .onTapGesture {
+                                noteToEdit = note
+                            }
+                    }
+                }
+            }
+        }
+        .navigationTitle(item.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    noteToEdit = nil
+                    showNoteEditor = true
+                } label: {
+                    Image(systemName: "square.and.pencil")
+                }
+            }
+        }
+        .sheet(isPresented: $showNoteEditor) {
+            NoteEditorView(item: item)
+        }
+        .sheet(item: $noteToEdit) { note in
+            NoteEditorView(item: item, note: note)
+        }
+    }
+}
+
+private struct NoteRow: View {
+    let note: NoteRecord
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(note.body)
+                .lineLimit(3)
+            HStack {
+                if note.syncState != .synced {
+                    Image(systemName: "arrow.trianglehead.2.clockwise")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+                Text(note.createdAt.formatted(date: .abbreviated, time: .omitted))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(note.accessRaw)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/tmbr-app/tmbr/Catalogue/CatalogueModel.swift
+++ b/tmbr-app/tmbr/Catalogue/CatalogueModel.swift
@@ -8,7 +8,7 @@ final class CatalogueModel {
     private(set) var isSyncing = false
     private(set) var syncError: Error?
 
-    private let syncEngine: SyncEngine
+    let syncEngine: SyncEngine
 
     init(syncEngine: SyncEngine) {
         self.syncEngine = syncEngine
@@ -20,7 +20,7 @@ final class CatalogueModel {
         syncError = nil
         defer { isSyncing = false }
         do {
-            try await syncEngine.syncDelta()
+            try await syncEngine.runSync()
         } catch {
             syncError = error
         }

--- a/tmbr-app/tmbr/Catalogue/NoteEditorView.swift
+++ b/tmbr-app/tmbr/Catalogue/NoteEditorView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import SwiftData
+import TmbrCore
+
+struct NoteEditorView: View {
+
+    let item: CatalogueItemRecord
+    var note: NoteRecord? = nil   // nil = create, non-nil = edit
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.createNote) private var createNote
+    @Environment(\.updateNote) private var updateNote
+
+    @State private var noteText: String = ""
+    @State private var access: Access = .private
+    @State private var isSaving = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Note") {
+                    TextEditor(text: $noteText)
+                        .frame(minHeight: 120)
+                }
+                Section {
+                    Picker("Access", selection: $access) {
+                        Text("Private").tag(Access.private)
+                        Text("Public").tag(Access.public)
+                    }
+                }
+            }
+            .navigationTitle(note == nil ? "New Note" : "Edit Note")
+            .toolbarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Task { await save() }
+                    }
+                    .disabled(noteText.trimmingCharacters(in: .whitespaces).isEmpty || isSaving)
+                }
+            }
+        }
+        .onAppear {
+            if let note {
+                noteText = note.body
+                access = Access(rawValue: note.accessRaw) ?? .private
+            }
+        }
+    }
+
+    private func save() async {
+        isSaving = true
+        let trimmed = noteText.trimmingCharacters(in: .whitespaces)
+        if let note {
+            await updateNote(record: note, body: trimmed, access: access)
+        } else {
+            await createNote(body: trimmed, access: access, item: item, context: modelContext)
+        }
+        dismiss()
+    }
+}

--- a/tmbr-app/tmbr/Catalogue/View+Catalogue.swift
+++ b/tmbr-app/tmbr/Catalogue/View+Catalogue.swift
@@ -4,5 +4,8 @@ extension View {
     func catalogue(_ model: CatalogueModel) -> some View {
         environment(model)
             .environment(\.syncCatalogue, SyncCatalogueAction(model: model))
+            .environment(\.createNote, CreateNoteAction(syncEngine: model.syncEngine))
+            .environment(\.updateNote, UpdateNoteAction(syncEngine: model.syncEngine))
+            .environment(\.deleteNote, DeleteNoteAction(syncEngine: model.syncEngine))
     }
 }

--- a/tmbr-app/tmbr/CatalogueTab.swift
+++ b/tmbr-app/tmbr/CatalogueTab.swift
@@ -29,7 +29,9 @@ struct CatalogueTab: View {
                     ContentUnavailableView("Loading…", systemImage: "arrow.trianglehead.2.clockwise")
                 } else {
                     ForEach(items) { item in
-                        CatalogueItemRow(item: item)
+                        NavigationLink(destination: CatalogueItemDetailView(item: item)) {
+                            CatalogueItemRow(item: item)
+                        }
                     }
                 }
             }

--- a/tmbr-app/tmbr/Sync/SyncEngine.swift
+++ b/tmbr-app/tmbr/Sync/SyncEngine.swift
@@ -3,12 +3,10 @@ import SwiftData
 import TmbrCore
 import ApiKit
 
-/// Orchestrates delta sync between the backend API and the local SwiftData store.
+/// Orchestrates sync between the backend API and the local SwiftData store.
 ///
-/// Data flow: network response → upsert into ModelContext → @Query in views auto-updates.
-/// Nothing goes to the UI directly from the network.
-///
-/// Push logic (Stage 4) is scaffolded here as no-ops so the model compiles.
+/// Data flow (pull): network response → upsert into ModelContext → @Query in views auto-updates.
+/// Data flow (push): SwiftData record (.pendingCreate/.pendingUpdate/.pendingDelete) → HTTP call → mark .synced.
 @MainActor
 final class SyncEngine {
 
@@ -30,25 +28,117 @@ final class SyncEngine {
 
     // MARK: - Public interface
 
-    /// Fast path: called on every launch and `scenePhase → .active`.
-    /// Pushes pending local changes first, then fetches only items newer than `lastSyncAt`.
+    /// Full cycle: push pending local changes, then delta-pull from server.
+    /// Called on every foreground activation and explicit refresh.
+    func runSync() async throws {
+        try await pushPendingPosts()
+        try await pushPendingNotes()
+        try await syncDelta()
+    }
+
+    /// Pull-only delta sync. Fetches items newer than `lastSyncAt`.
     func syncDelta() async throws {
         let since = lastSyncAt
-        // Stage 4: try await pushPending()
         try await fetchAll(since: since)
         lastSyncAt = .now
     }
 
-    /// Slow path: fetches all history regardless of last sync. Used for full sync from Settings.
+    /// Pull-only full sync. Fetches all history regardless of last sync.
     func syncFull() async throws {
         try await fetchAll(since: nil)
         lastSyncAt = .now
     }
 
-    // MARK: - Stage 4 scaffolding
+    // MARK: - Push
 
-    func pushPending() async throws {
-        // Implemented in Stage 4
+    func pushPendingNotes() async throws {
+        let descriptor = FetchDescriptor<NoteRecord>(
+            predicate: #Predicate { $0.syncStateRaw != "synced" }
+        )
+        let pending = (try? modelContext.fetch(descriptor)) ?? []
+        for record in pending {
+            try await pushNote(record)
+        }
+    }
+
+    func pushPendingPosts() async throws {
+        let descriptor = FetchDescriptor<PostRecord>(
+            predicate: #Predicate { $0.syncStateRaw != "synced" }
+        )
+        let pending = (try? modelContext.fetch(descriptor)) ?? []
+        for record in pending {
+            try await pushPost(record)
+        }
+    }
+
+    private func pushNote(_ record: NoteRecord) async throws {
+        let input = NoteInput(
+            body: record.body,
+            access: Access(rawValue: record.accessRaw) ?? .private,
+            language: Language(rawValue: record.languageRaw) ?? .en
+        )
+        switch record.syncState {
+        case .pendingCreate:
+            guard let previewID = record.attachmentPreviewID else { return }
+            let loader = authState.loader(for: BasicRequest<NoteInput, NoteResponse>.post(
+                baseURL: baseURL, path: "/api/catalogue/item/\(previewID)/notes"
+            ))
+            let response = try await loader.load(from: input)
+            record.serverID = response.id
+            record.syncState = .synced
+        case .pendingUpdate:
+            guard let serverID = record.serverID else { return }
+            let loader = authState.loader(for: BasicRequest<NoteInput, NoteResponse>.put(
+                baseURL: baseURL, path: "/api/notes/\(serverID)"
+            ))
+            _ = try await loader.load(from: input)
+            record.syncState = .synced
+        case .pendingDelete:
+            if let serverID = record.serverID {
+                let loader = authState.loader(for: BasicRequest<Void, NoContent>.delete(
+                    baseURL: baseURL, path: "/api/notes/\(serverID)"
+                ))
+                _ = try await loader.load()
+            }
+            modelContext.delete(record)
+        case .synced:
+            break
+        }
+    }
+
+    private func pushPost(_ record: PostRecord) async throws {
+        let input = PostInput(
+            title: record.title,
+            body: record.content,
+            state: PostState(rawValue: record.stateRaw) ?? .draft,
+            language: Language(rawValue: record.languageRaw) ?? .en
+        )
+        switch record.syncState {
+        case .pendingCreate:
+            let loader = authState.loader(for: BasicRequest<PostInput, PostResponse>.post(
+                baseURL: baseURL, path: "/api/posts"
+            ))
+            let response = try await loader.load(from: input)
+            record.serverID = response.id
+            record.syncState = .synced
+        case .pendingUpdate:
+            guard let serverID = record.serverID else { return }
+            let loader = authState.loader(for: BasicRequest<PostInput, PostResponse>.put(
+                baseURL: baseURL, path: "/api/posts/\(serverID)"
+            ))
+            _ = try await loader.load(from: input)
+            record.syncState = .synced
+        case .pendingDelete:
+            if let serverID = record.serverID {
+                let loader = authState.loader(for: BasicRequest<Void, NoContent>.delete(
+                    baseURL: baseURL, path: "/api/posts/\(serverID)"
+                ))
+                _ = try await loader.load()
+            }
+            modelContext.delete(record)
+        case .synced:
+            break
+        }
     }
 
     // MARK: - Parallel fetch
@@ -460,4 +550,24 @@ private extension PlaylistRecord {
         self.playlistDescription = playlist.description
         self.accessRaw = playlist.access.rawValue; self.detailFetchedAt = .now
     }
+}
+
+// MARK: - Push payload types
+
+private struct NoteInput: Encodable, Sendable {
+    let body: String
+    let access: Access
+    let language: Language
+}
+
+private struct PostInput: Encodable, Sendable {
+    let title: String
+    let body: String       // "body" matches the backend PostPayload field name
+    let state: PostState
+    let language: Language
+}
+
+/// Response type for endpoints that return HTTP 204 No Content.
+private struct NoContent: Decodable, Sendable {
+    init(from decoder: any Decoder) throws {}
 }

--- a/tmbr-app/tmbr/tmbr.swift
+++ b/tmbr-app/tmbr/tmbr.swift
@@ -59,7 +59,7 @@ struct tmbr: App {
         }
         .onChange(of: scenePhase) { _, newPhase in
             guard newPhase == .active, authState.isSignedIn else { return }
-            Task { try? await syncEngine.syncDelta() }
+            Task { try? await syncEngine.runSync() }
         }
     }
 }


### PR DESCRIPTION
## Summary

- `CreateNoteAction`, `UpdateNoteAction`, `DeleteNoteAction` — write to SwiftData first, sync silently after
- `CreatePostAction`, `UpdatePostAction`, `DeletePostAction` — same pattern
- `SyncEngine.pushPendingNotes()` + `pushPendingPosts()` — flush `.pendingCreate`, `.pendingUpdate`, `.pendingDelete` records
- `SyncEngine.runSync()` — push first, then `syncDelta()` (preserves offline writes)
- `BlogEditorView` and `NoteEditorView` wired to create/update actions
- Pending sync indicator on list rows (`syncState != "synced"`)
- `CatalogueEnvironment` and `BlogEnvironment` updated with new action keys

## Depends on
- #186 (Stage 3: Delta sync engine)

## Test plan
- [ ] Create note in app → kill app → relaunch → note visible
- [ ] Create note offline → restore connectivity → syncs to web
- [ ] Delete note → removed from SwiftData immediately → server delete syncs
- [ ] Edit note offline → persists after relaunch → syncs when online

🤖 Generated with [Claude Code](https://claude.com/claude-code)