### PR TITLE
docs: three-app native architecture (Reader / Author / Personal)

### DIFF
--- a/.claude/docs/native-apps-architecture.md
+++ b/.claude/docs/native-apps-architecture.md
@@ -1,0 +1,229 @@
+# Native Apps Architecture: Three Apps, One Shared Core
+
+## Why this document exists
+
+The native app effort went through three rounds of foundation work. The current branch shipped a
+single monolithic offline-first app backed by the Vapor website, documented as a **two-product**
+vision (the now-superseded `two-product-architecture.md`). Building it clarified the real product
+shape: it is **three** distinct apps, not two. This document is the canonical record of that pivot,
+the target architecture, and the rationale — so later work follows a designed path rather than
+rediscovering it.
+
+Companion: `.claude/docs/plans/offline-first-native-app.md` (the staged roadmap).
+
+---
+
+## The three apps
+
+| | **Reader** (App 1) | **Author** (App 2) | **Personal** (App 3) |
+|---|---|---|---|
+| **Who** | Public consumers | The owner (you) | Each consumer (private) |
+| **Content** | The owner's *public* blog + catalogue | The owner's *full* blog + catalogue + notes | The user's *own* private catalogue + notes |
+| **Read/Write** | Read-only | Read + author | Read + author |
+| **Local store** | SwiftData as **cache** | SwiftData as **full mirror** | SwiftData as **full mirror** |
+| **Freshness** | On-demand, lazy: cache only what's viewed; conditional GET (ETag) refresh | Eager full delta sync; push-then-pull; tombstones; offline writes | CloudKit auto-mirror across the user's Apple devices |
+| **Backend** | Vapor public read API (new, additive) | Vapor sync API (built) | **None** — iCloud private DB only |
+| **Auth** | None / optional | Sign in with Apple | iCloud account (implicit) |
+
+**Reader's data-flow** (the genuinely new piece): open UI → `@Query` renders cached SwiftData
+instantly → background conditional fetch (`If-None-Match` with stored ETag) → on `200`, upsert into
+SwiftData (UI refreshes); on `304`, do nothing. Detail pages are cached when first opened. There is
+**no** `syncState`, no tombstones, no push — it is a stale-while-revalidate cache, not a sync engine.
+
+---
+
+## The pivot (from two products to three apps)
+
+The prior vision was "two products from one core": Product 1 = owner app + future guest read-mode,
+backed by the website; Product 2 = future CloudKit-only consumer app. The pivot splits Product 1's
+two audiences into two apps and keeps Product 2 as the third:
+
+**Why Reader is its own app, not a config of Author.** They share the schema and the `@Query`-driven
+presentation, but their data-flow is nearly opposite: Reader is read-only, lazy/on-demand ETag
+caching of just-viewed items for a *public* audience; Author is read-write, eager full-mirror with
+delta sync + tombstones + offline writes for *one* author. A single configurable binary would carry
+two incompatible sync subsystems and two entitlement profiles. They share *presentation*, not
+*plumbing* — so they share a **core**, not a binary. This also retires the old `offlineSyncEnabled`
+"guest read-mode" toggle (a two-product compromise, never built): Reader replaces it with a
+purpose-built app.
+
+**Why Author and Personal are the symmetric pair.** They are identical code: offline-first, full
+local mirror, the same write actions. The *only* difference is the `ModelContainer` and the sync
+composition — Author has a `SyncEngine`; Personal has a `.private` CloudKit container and no engine.
+This is exactly the "composition, not protocol" seam from the prior doc; the pivot keeps it intact.
+
+**Why CloudKit (not the backend) for Personal.** Unchanged: zero backend cost, no UGC App Store
+review, no GDPR/account-deletion duty, no moderation/support burden. Each user's data lives in their
+own iCloud. Apple-only reach for other users was explicitly judged acceptable.
+
+---
+
+## Target architecture
+
+### Shared core + three compositions
+
+```
+        ┌────────────────────────── shared local SPM package ──────────────────────────┐
+        │  AppCore   (no networking, no CloudKit, no sync engine)                       │
+        │    • SwiftData @Model records + SyncState   (CloudKit-constrained schema)     │
+        │    • @Query-driven views (Blog/Catalogue/detail/editors), capability-gated    │
+        │    • @Observable models (BlogModel, CatalogueModel, per-screen detail models) │
+        │    • property wrappers (@Blog, @Catalogue, @Post …), environment keys         │
+        │    • write Actions (Create/Update/Delete) → SwiftData + injected requestSync() │
+        │                                                                              │
+        │  AppBackend  (api-kit requests + shared pull/push helpers)  ← Reader + Author │
+        └──────────────────────────────────────────────────────────────────────────────┘
+                  ▲                        ▲                          ▲
+        ┌─────────┘            ┌───────────┘             ┌────────────┘
+ ┌──────┴───────┐     ┌────────┴────────┐       ┌────────┴────────┐
+ │ Reader (1)   │     │  Author (2)     │       │  Personal (3)   │
+ │ CacheLoader  │     │  SyncEngine     │       │ .private CloudKit│
+ │ (ETag, lazy) │     │ (delta/push/pull)│      │  ModelContainer  │
+ │ plain container│   │ plain container │       │ requestSync = {} │
+ │ read-only UI │     │ auth + bg sync  │       │ no networking    │
+ └──────────────┘     └─────────────────┘       └──────────────────┘
+```
+
+**The invariant that makes one core serve three apps:** `AppCore` depends on **SwiftData + closures
+only** — never on `SyncEngine`, `CacheLoader`, `URLSession`, `api-kit`, or CloudKit. Each app injects
+its own composition.
+
+### The seam is the existing Action pattern — no new protocol
+
+The house style (`swift-patterns.md`, `swiftui-architecture.md`) is closures-wrapped-in-structs over
+protocols. The seam reuses it. A `SyncCoordinator` protocol was rejected because its CloudKit body
+would be all no-ops — a fake abstraction.
+
+**Write path.** Actions write to SwiftData and call an injected `requestSync` closure:
+- Author: `requestSync = { try? await syncEngine.runSync() }`
+- Personal: `requestSync = {}` (CloudKit mirrors automatically)
+- Reader: no write actions surfaced (read-only)
+
+The current `BlogModel`/`CatalogueModel` and write actions capture `SyncEngine` directly; the one
+real refactor of the extraction is replacing that capture with the injected `requestSync`.
+
+### Read/refresh seam: a per-object `@Observable` detail model
+
+Detail-screen data + refresh lives in a small `@MainActor @Observable` model
+(`PostDetailModel`, `CatalogueItemDetailModel`) — the RunKit `RunLibrary`/`RunPlayer` shape, which
+puts async on an observable **source**, not inside a `DynamicProperty`. (An earlier
+`Resource`-DynamicProperty sketch that hosted async lifecycle in a wrapper was dropped — the one
+risky deviation from that reference.)
+
+The model owns: the observed record, the refresh `Task` lifecycle, and a `phase` enum
+(empty/loading/loaded/error — subsumes `isUpdating`, last-updated, and Reader's not-yet-cached case).
+It holds an **injected refresh strategy closure** — never ApiKit/SyncEngine/CloudKit — so `AppCore`
+stays clean. Injected scoped to the detail subtree at navigation time.
+
+Access uses the full house pattern; each layer earns its place:
+- **`@[Subject]` property wrapper** (`@Post(\.phase)`) — scoped reactivity (a view re-renders only
+  for the keypath it reads) + mandated by `tmbr-app/CLAUDE.md`. ~20 lines; the pattern already
+  exists twice (`@Blog`, `@Catalogue`).
+- **Refresh as an action** (`RefreshPostAction`) — **this is the three-app seam.** One env key,
+  a different body per app (Author → `syncEngine`; Reader → `cacheLoader` ETag GET; Personal →
+  no-op). `EnvironmentValues` can't be generic, so use one concrete key per entity type
+  (`refreshPost`, `refreshCatalogueItem`) — matching the existing "one key per action" convention.
+- **Atomic controls** (phase indicator, refresh button) — built **lazily**, only when a second
+  consumer appears (YAGNI, per `networking.md`'s "add on concrete need").
+
+Heterogeneous catalogue is not a problem: the list observes `PreviewRecord`; a detail model takes the
+typed record (e.g. `SongRecord`, fetched by `previewID`) + a refresh strategy that dispatches on
+`categoryType` to the right `RequestLoader`. (See the normalized schema section below.)
+
+---
+
+## Schema: normalized, mirroring the backend
+
+Because Author **and** Personal must author catalogue items **offline** (full per-type metadata +
+album/playlist track lists), the app needs the typed structure — and the heterogeneous-list problem
+is already solved on the backend by the `Preview` projection, so the app mirrors that exactly. (An
+earlier flat `CatalogueItemRecord` was considered and **dropped** for this reason.)
+
+- **`PreviewRecord`** — the unified projection (mirrors backend `Preview`): `id` = server PreviewID
+  (UUID), `categoryType`, `primaryInfo`/`secondaryInfo`, `imageURL`, `externalLinks`, `accessRaw`,
+  `createdAt`/`updatedAt`, `syncStateRaw`. **Drives the heterogeneous list** via one
+  `@Query<PreviewRecord>`, and is the **note anchor**. An **orphan** is a `PreviewRecord` with no
+  backing typed record (`sourceID == nil` / `isOrphan`).
+- **Per-type records** — `SongRecord`, `AlbumRecord`, `BookRecord`, `MovieRecord`, `PodcastRecord`,
+  `PlaylistRecord` — rich typed fields for detail + offline authoring, each linked to its Preview by
+  `previewID: UUID` (a plain UUID link, **not** a `@Relationship` — matches backend `preview_id`,
+  keeps CloudKit mirroring trivial).
+- **`ContainerEntryRecord`** — album/playlist member ordering (mirrors backend `ContainerEntry`).
+  Track-removal honors promotion: only `.promotable` members are removed when a container is deleted.
+- `NoteRecord` (anchored to a Preview by PreviewID), `PostRecord`, `QuoteRecord`, `UserRecord`.
+- `AppSchema.models` is the single shared model list; each app builds its own `ModelContainer` from it.
+
+**Reads:** list = `@Query<PreviewRecord>`; detail/edit = fetch the typed record by `previewID`.
+**Per app:** Author + Personal author into typed records + Preview; **Reader** stays thin — fills
+`PreviewRecord` for the list, lazily caches the typed record when a detail is opened.
+
+**CloudKit constraints still hold** (made now because schema is costly to change post-ship; justified
+by Personal) and are unaffected by normalization:
+
+1. **No `@Attribute(.unique)`** — uniqueness lives in the upsert (fetch-by-identity before insert).
+2. **Every stored attribute optional or defaulted** (e.g. `var title = ""`). The `@Model` macro needs
+   the fully-qualified `Date.now`, not a bare `.now`.
+3. **Link by UUID, not `@Relationship`** — `previewID`/`memberPreviewID`/`attachmentPreviewID`. Keeps
+   mirroring trivial and lets records exist before their Preview is synced.
+4. **`nonisolated` payload structs** — so `NoteInput`/`PostInput`/`NoContent` `Codable` conformances
+   are usable as `Sendable` generic arguments to `RequestLoader`.
+
+`syncState`/`serverID`/tombstone fields are used fully by Author, set-but-ignored by Personal, and
+effectively always-`.synced` in Reader. One shared schema across all three.
+
+**Status:** the `AppCore` package + this schema are **built and compiling** (`swift build`).
+**Still to validate at runtime (before Personal ships):** that the schema round-trips to a `.private`
+CloudKit database.
+
+---
+
+## Project structure
+
+One local SPM package + three app targets, inside `tmbr-app/`:
+
+```
+tmbr-app/
+  AppCore/                      ← local SPM package
+    Package.swift               ← products: AppCore (all 3 apps), AppBackend (Reader + Author)
+    Sources/AppCore/            ← Persistence/, Blog/, Catalogue/, shared views, property wrappers,
+                                   environments, actions, detail models, NetworkMonitor
+    Sources/AppBackend/         ← api-kit request structs; shared pull/push helpers (PageLoader)
+  Author/                       ← @main, ModelContainer, SyncEngine, AuthState, background sync
+  Reader/                       ← @main, plain container, read-only UI, CacheLoader, public APIConfig
+  Personal/                     ← @main, .private CloudKit container, CloudKit entitlement, no engine
+  Configs/                      ← shared base .xcconfig + per-app overrides (bundle id, entitlements,
+                                   APIBaseURL, CloudKit container id)
+```
+
+Names are provisional. `AppKit` is avoided (clashes with Apple's framework). The `AppBackend` split
+exists so Personal carries **no** networking code; it may fold back into `AppCore` later if it proves
+to be overhead, but keeping Personal backend-free is a deliberate guard.
+
+---
+
+## Backend: kept, not redesigned
+
+The branch's backend is, field-for-field, Author's backend — fully aligned, not a two-product
+compromise. Keep as-is: the `tmbr-core` pagination contract; `tmbr-web` Core pagination infra;
+per-type list endpoints; `GET /api/posts` pagination; `GET /api/catalogue/orphans?notes=true`;
+embedded-notes design; deletion tombstones; `PreviewResponse.id`; the `NoteModelMiddleware`
+`updatedAt` bump.
+
+- **Personal needs:** nothing.
+- **Reader needs (new, additive, built later):** a *public* read API (browse/feed + detail JSON) and
+  ETag / `If-None-Match` → `304` support. Does not exist yet; does not conflict with the branch.
+
+The optional/soft auth on the list + deletions endpoints (added during the earlier guest-sync
+experiment) is **safe and reusable**, not dead weight: the previewable `query` permission scopes
+unauthenticated callers to `access == .public` only (authenticated owner → own + public), so guests
+never receive private data — which is exactly the access model the Reader app needs.
+
+---
+
+## Deferred (designed here, not built now)
+
+- **Reader app**: `CacheLoader` (stale-while-revalidate, lazy detail caching), read-only UI, and its
+  backend (public read API + ETags).
+- **Personal app**: the `.private` CloudKit container wiring and runtime mirror validation.
+- **Atomic controls** for the read/refresh detail models — added when a second consumer appears.
+- Whether `AppBackend` stays separate or folds into `AppCore`.

--- a/.claude/docs/plans/offline-first-native-app.md
+++ b/.claude/docs/plans/offline-first-native-app.md
@@ -1,15 +1,66 @@
-# Offline-First Native App: Multi-Stage Roadmap
+# Native App: Multi-Stage Roadmap (three apps, one shared core)
+
+> **Architecture:** `.claude/docs/native-apps-architecture.md` is the canonical design (three apps —
+> Reader, Author, Personal — over a shared `AppCore` package). This file is the **staged roadmap**.
 
 ## Vision
 
-The end state is a native app that feels fast and reliable regardless of connectivity:
-
+Each app feels fast and reliable regardless of connectivity, driven by SwiftData via `@Query`:
 - **Instant startup**: cached SwiftData renders before any network request completes
-- **Invisible sync**: delta sync runs in the background; `@Query` in views auto-updates as records arrive
-- **Offline writes**: notes and posts saved locally first, pushed silently when online
-- **No spinners on launch**: the user always sees their data, never a loading screen
+- **No spinners on launch**: the user always sees their data
+- **Author/Personal**: offline writes saved locally first; **Reader**: stale-while-revalidate cache
 
-Each stage below is a self-contained PR that ships a working increment. Later stages depend on earlier ones but each leaves the app in a releasable state.
+## Roadmap structure
+
+| Phase | App | Status |
+|---|---|---|
+| **Stages 1–5** (below) | **Author** (offline-first, backend sync) | **Built** — the original monolithic app *is* the Author app |
+| **Restructure** | Extract `AppCore`/`AppBackend`; re-home app as Author; Reader + Personal target skeletons | Next |
+| **Reader backend** | Public read API (browse/feed + detail JSON) + ETag/`304` in `tmbr-web` | Later |
+| **Reader app** | `CacheLoader` (lazy ETag cache), read-only UI | Later |
+| **Personal app** | `.private` CloudKit container + runtime mirror validation | Later |
+
+The **Stages 1–5 below are the Author app, already built.** They are retained as the reference
+implementation and regression checklist for the extraction. The Domain Primer and Notes Sync Design
+sections that follow are still accurate and apply to all backend-wired apps (Reader + Author).
+
+### Seam & schema (see architecture doc for full rationale)
+
+- **Composition, not a protocol.** Write actions call an injected `requestSync` closure
+  (`syncEngine.runSync()` for Author, `{}` for Personal); read/refresh uses a per-screen
+  `@Observable` detail model holding an injected refresh-strategy closure (`SyncEngine` / `CacheLoader`
+  ETag GET / no-op). `AppCore` imports no networking, no CloudKit.
+- **Normalized schema mirroring the backend** (Author + Personal author catalogue items offline):
+  `PreviewRecord` (unified list driver + note anchor, keyed by server PreviewID) + typed
+  `SongRecord`/etc. linked by `previewID` + `ContainerEntryRecord` for tracks. CloudKit-constrained
+  (decided now, justified by Personal): no `@Attribute(.unique)`, every attribute optional-or-defaulted,
+  link by UUID not `@Relationship`. See `.claude/docs/native-apps-architecture.md` for the full schema.
+  The Stage 2 code blocks below show an earlier flat/subclass shape for historical context only.
+
+---
+
+## Notes Sync Design (updated post-implementation)
+
+This supersedes the "dedicated notes sync" described in Stages 1 and 3 below.
+
+Notes are **never** synced via a standalone endpoint — they are always attached to a catalogue item,
+so they sync **embedded in that item's response**:
+
+- **Typed items** (song/album/…): each per-type response already carries `.notes`.
+- **Orphans**: `GET /api/catalogue/orphans?notes=true` embeds notes. `PreviewResponse` gained an
+  optional `notes` field; the endpoint batch-loads them via the existing `grouped` notes command.
+
+There is **no `GET /api/notes`**. The app upserts notes **per item, scoped by PreviewID**, replacing
+that item's full note set each sync — which also handles note edits and deletes (a removed note is
+simply absent from the embedded array; no note tombstones needed).
+
+**PreviewID reaches the app.** `PreviewResponse.id: PreviewID?` was added so the app uses the server
+PreviewID as `CatalogueItemRecord.id` and can attach/reconcile notes — and so offline note-create can
+POST to `/api/catalogue/item/:previewID/notes` (previously broken: the app only had a random local UUID).
+
+**Delta catches note edits.** A note create/edit/delete bumps its parent `Preview.updatedAt`
+(`NoteModelMiddleware`), and catalogue delta (`since`) matches `createdAt > since OR updatedAt > since`;
+load-more (`before`/cursor) stays on `createdAt`. So an item re-surfaces in delta whenever its notes change.
 
 ---
 
@@ -20,7 +71,7 @@ The backend has three distinct kinds of catalogue item that the native app must 
 | Kind | Examples | Backing model | Notes? | How synced |
 |------|----------|--------------|--------|------------|
 | `.entry` (typed) | Song, Album, Book, Movie, Podcast, Playlist | Yes (SongResponse etc.) | Yes | Per-type list endpoints |
-| `.orphan` | Recipe, Guide, Link, user-defined | No | Yes | `GET /api/catalogue?orphanOnly=true` |
+| `.orphan` | Recipe, Guide, Link, user-defined | No | Yes | `GET /api/catalogue/orphans?notes=true` |
 | `.promotable` | Track (unresolved) | No | **No** | Not synced — shown as part of album/playlist tracks |
 
 **Critical rule** (from memory): use `kind.isShallow` — not `parentID == nil` — to check whether an item can have notes. Orphans have `parentID == nil` but CAN have notes.
@@ -33,7 +84,7 @@ Orphan items are identified in `PreviewResponse` by `category != nil` (only set 
 
 **PR scope**: `tmbr-core` + `tmbr-web`
 
-**Goal**: Establish the reusable pagination types used by every list endpoint. Add all the list endpoints the native app needs for sync. Expose `GET /api/notes` as a Bearer-authenticated endpoint.
+**Goal**: Establish the reusable pagination types used by every list endpoint. Add all the list endpoints the native app needs for sync. (Originally also planned a `GET /api/notes` endpoint — **dropped**; see "Notes Sync Design" above. Notes sync embedded in catalogue items.)
 
 ### Shared Types (tmbr-core)
 
@@ -121,14 +172,14 @@ return PageResult(from: models, limit: input.limit) { ThingResponse(thing: $0) }
 
 ### Endpoints
 
-**Notes (new API endpoint):**
-- `GET /api/notes` — Bearer auth — returns `PageResult<NoteResponse>` for the current user's notes, sorted by `createdAt DESC`.
+**Notes:** no standalone notes endpoint — notes sync embedded in catalogue items (see "Notes Sync
+Design" above). `PUT`/`DELETE /api/notes/:noteID` remain for editing/deleting an existing note.
 
 **Posts (pagination added):**
 - `GET /api/posts` — accepts `PageQuery`, returns `PageResult<PostResponse>`. Non-paged web route uses the same `list` command with `page: nil`.
 
-**Catalogue (pagination + orphan filter):**
-- `GET /api/catalogue` — accepts `PageQuery`. `orphanOnly=true` returns only `.orphan` kind items.
+**Catalogue (orphan list for sync):**
+- `GET /api/catalogue/orphans` — accepts `PageQuery`; `?notes=true` embeds each orphan's notes. Returns `PageResult<PreviewResponse>` (now including `PreviewResponse.id`).
 
 **Deletion tombstones (new):**
 - `GET /api/sync/deletions?since=<ISO8601>` — optional auth. Unauthenticated callers receive tombstones for public deletions only; authenticated callers additionally receive their own private deletions. No cursor pagination — deletions are sparse and always queried since last sync. When a catalogue item is deleted, its Preview deletion cascades through `DeletionMiddleware<Preview>` and produces a `.catalogueItem` tombstone. Each tombstone stores `ownerID` and `access` so the endpoint can filter without joining the original table (which no longer exists for a deleted record).
@@ -176,9 +227,9 @@ All return the owner's items with embedded notes. Sorted by `createdAt DESC` (Pr
 - [x] `PageInput`, `QueryBuilder+Page.swift`, `Pagination.swift` in tmbr-web Core
 - [x] `QueryBuilder+Previewable.swift` — Previewable overload of `page()`
 - [x] `Command+ListNotes.swift` + `Commands+Notes.list` added
-- [x] `GET /api/notes` with Bearer auth, returns `PageResult<NoteResponse>`
+- [x] ~~`GET /api/notes`~~ **dropped** — notes sync embedded in catalogue items (see Notes Sync Design)
 - [x] `GET /api/posts` returns `PageResult<PostResponse>` with `PageQuery`
-- [x] `GET /api/catalogue` with `PageQuery` + `orphanOnly` filter
+- [x] `GET /api/catalogue/orphans` with `PageQuery` + `?notes=true` (embeds orphan notes)
 - [x] `GET /api/songs`, albums, books, movies, podcasts, playlists (all per-type endpoints)
 - [x] `Deletions/` folder — `CreateDeletion` migration, `DeletionMiddleware<M>`, `DeletionsAPIController`; wired via `configure.swift` (not a Module — middleware registrations live in Notes/Previews/Posts modules)
 - [x] `GET /api/sync/deletions?since=` endpoint — optional auth, public-only for guests
@@ -190,6 +241,27 @@ All return the owner's items with embedded notes. Sorted by `createdAt DESC` (Pr
 **PR scope**: `tmbr-app` only (no networking, no sync yet)
 
 **Goal**: SwiftData schema in place, `ModelContainer` wired into the app. Lists still show placeholders. This PR gets the local DB right before anything else depends on it.
+
+### CloudKit Compatibility (required — see Product Identity section)
+
+The schema must satisfy SwiftData's CloudKit private-DB mirroring rules so Product 2 can adopt it
+unchanged:
+
+- **No `@Attribute(.unique)`.** CloudKit does not support unique constraints. Dropped from all five
+  sites (`NoteRecord.clientKey`, `PostRecord.clientKey`, `QuoteRecord.clientKey`,
+  `CatalogueItemRecord.id`, `UserRecord.serverID`). Uniqueness now lives in `SyncEngine`'s upsert
+  (fetch-by-identity before insert) — the single insertion path, run serially on `@MainActor`. A
+  dedup test guards this.
+- **Every stored attribute optional or defaulted.** CloudKit requires it. Non-optional fields get a
+  stored default (e.g. `var title: String = ""`); init-parameter defaults are not sufficient.
+- **Relationships must be optional** — already satisfied: the schema is fully denormalized with no
+  `@Relationship`.
+- **Catalogue flattened** — the typed subclasses were removed in favour of a single
+  `CatalogueItemRecord` (see Product Identity section); SwiftData `@Model` inheritance is both
+  non-compiling and CloudKit-unsafe. The subclass code blocks below are retained for history only.
+
+The `@Attribute(.unique)` annotations in the code blocks below have been removed accordingly; the
+blocks remain otherwise illustrative of the fields each record carries.
 
 ### SwiftData Schema
 
@@ -208,7 +280,7 @@ enum SyncState: String, Codable {
 **NoteRecord**:
 ```swift
 @Model final class NoteRecord {
-    @Attribute(.unique) var clientKey: UUID  // always client-generated; stable local identity
+    var clientKey: UUID = UUID()             // client-generated; stable local identity (no .unique — CloudKit)
     var serverID: UUID?                       // set from NoteResponse.id after first push
     var body: String
     var accessRaw: String                     // Access.rawValue
@@ -230,7 +302,7 @@ enum SyncState: String, Codable {
 **PostRecord**:
 ```swift
 @Model final class PostRecord {
-    @Attribute(.unique) var clientKey: UUID  // stable local identity
+    var clientKey: UUID = UUID()             // stable local identity (no .unique — CloudKit)
     var serverID: Int?                        // nil until server assigns PostID
     var title: String
     var content: String
@@ -247,7 +319,7 @@ enum SyncState: String, Codable {
 **QuoteRecord**:
 ```swift
 @Model final class QuoteRecord {
-    @Attribute(.unique) var clientKey: UUID
+    var clientKey: UUID = UUID()             // no .unique — CloudKit; dedup via upsert
     var body: String
     var noteClientKey: UUID                   // links to NoteRecord.clientKey
     var noteServerID: UUID?                   // set once parent note has a serverID
@@ -268,7 +340,7 @@ The `subtitle` field in the base serves list display for all types. For typed it
 
 ```swift
 @Model class CatalogueItemRecord {
-    @Attribute(.unique) var id: UUID           // PreviewID (stable cross-type identifier)
+    var id: UUID = UUID()                      // PreviewID (stable cross-type identifier; no .unique — CloudKit)
     var title: String                          // PreviewResponse.primaryInfo
     var subtitle: String?                      // PreviewResponse.secondaryInfo — used in list display
     var categoryType: String                   // "song"|"album"|"recipe"|etc. (source.type slug)
@@ -325,7 +397,7 @@ The `subtitle` field in the base serves list display for all types. For typed it
 **UserRecord**:
 ```swift
 @Model final class UserRecord {
-    @Attribute(.unique) var serverID: Int
+    var serverID: Int = 0                     // no .unique — CloudKit; dedup via upsert
     var appleID: String
     var email: String?
     var firstName: String?
@@ -348,6 +420,9 @@ In `tmbr.swift`, create the container with all model types registered. `Catalogu
 - [ ] `UserRecord.swift`
 - [ ] `tmbr.swift` — create `ModelContainer` with all models; inject via `.modelContainer(container)`
 - [ ] App builds and runs on both iOS and macOS targets (placeholders still showing)
+- [ ] CloudKit compatibility: no `@Attribute(.unique)`, all attributes optional-or-defaulted
+- [ ] Spike: SwiftData inheritance round-trips to a `.private` CloudKit store (decides catalogue shape)
+- [ ] Dedup test: upserting the same identity twice yields exactly one record
 
 ---
 
@@ -364,17 +439,17 @@ App opens
   → @Query renders cached SwiftData immediately (no loading state, no spinner)
   → if signed in: Task { await SyncEngine.syncDelta() }
       push any pending local changes (none in read-only stage)
-      in parallel:
-        GET /api/notes?since=lastSyncAt            → upsert NoteRecord + QuoteRecord
+      in parallel (each typed response carries its `.notes`, upserted per item):
         GET /api/posts?since=lastSyncAt            → upsert PostRecord
-        GET /api/songs?since=lastSyncAt            → upsert SongRecord (full domain data)
-        GET /api/albums?since=lastSyncAt           → upsert AlbumRecord
-        GET /api/books?since=lastSyncAt            → upsert BookRecord
-        GET /api/movies?since=lastSyncAt           → upsert MovieRecord
-        GET /api/podcasts?since=lastSyncAt         → upsert PodcastRecord
-        GET /api/playlists?since=lastSyncAt        → upsert PlaylistRecord
-        GET /api/catalogue?orphanOnly=true&since=lastSyncAt → upsert OrphanRecord
+        GET /api/songs?since=lastSyncAt            → upsert CatalogueItemRecord + its notes
+        GET /api/albums?since=lastSyncAt           → upsert CatalogueItemRecord + its notes
+        GET /api/books?since=lastSyncAt            → upsert CatalogueItemRecord + its notes
+        GET /api/movies?since=lastSyncAt           → upsert CatalogueItemRecord + its notes
+        GET /api/podcasts?since=lastSyncAt         → upsert CatalogueItemRecord + its notes
+        GET /api/playlists?since=lastSyncAt        → upsert CatalogueItemRecord + its notes
+        GET /api/catalogue/orphans?notes=true&since=lastSyncAt → upsert orphan CatalogueItemRecord + its notes
         GET /api/sync/deletions?since=lastSyncAt   → apply DeletionRecord (delete local records)
+      (delta `since` matches createdAt OR updatedAt, so items whose notes changed re-surface)
       save lastSyncAt = .now to UserDefaults
   → @Query auto-updates as records arrive
 
@@ -399,18 +474,16 @@ With `since` filtering, most requests return 0 items on a typical launch — 10 
     func syncFull() async throws   // slow, paginated, fetches all history (Stage 5)
 
     // Pull helpers (each paginates to completion)
-    private func fetchNotes(since: Date?) async throws
     private func fetchPosts(since: Date?) async throws
     private func fetchTypedItems(since: Date?) async throws  // all 6 types in parallel
-    private func fetchOrphans(since: Date?) async throws
+    private func fetchOrphans(since: Date?) async throws      // sends ?notes=true
     private func fetchDeletions(since: Date?) async throws
 
-    // Upsert helpers
-    private func upsertNotes(_ responses: [NoteResponse])
+    // Upsert helpers (catalogue is one flat CatalogueItemRecord — see native-apps-architecture.md)
     private func upsertPosts(_ responses: [PostResponse])
-    private func upsertSongs(_ responses: [SongResponse])
-    // ... etc per type
-    private func upsertOrphans(_ responses: [PreviewResponse])
+    private func upsertTyped<T: CatalogueItemResponse>(_ responses: [T], type: String)  // + each item's notes
+    private func upsertOrphans(_ responses: [PreviewResponse])                           // + each orphan's notes
+    private func upsertNotes(_ responses: [NoteResponse], forPreviewID: UUID)            // per-item reconcile
 
     // Deletion helper — removes local records matching tombstones
     private func applyDeletions(_ records: [DeletionRecord])
@@ -421,11 +494,11 @@ With `since` filtering, most requests return 0 items on a typical launch — 10 
 }
 ```
 
-**Upsert logic for typed items**: match on `sourceID + categoryType`. If found and `.synced`, update all fields (including `subtitle` and the semantic subclass field). If not found, create the correct subclass. Notes embedded in type responses (e.g., `SongResponse.notes`) are NOT used here — notes come from the dedicated notes sync which supports delta.
+**Upsert logic for typed items**: match on `sourceID + categoryType`. If found and `.synced`, update all fields; if not found, create a `CatalogueItemRecord` with `id` = the response's `PreviewID`. Notes embedded in the type response (e.g., `SongResponse.notes`) **are** upserted here, per item, scoped by PreviewID — there is no separate notes sync (see "Notes Sync Design" above).
 
-**Upsert logic for orphans**: match on `id` (PreviewID). Orphans get `OrphanRecord`; `subtitle` = `secondaryInfo`.
+**Upsert logic for orphans**: match on `id` (PreviewID). An orphan is a `CatalogueItemRecord` with `sourceID == nil`; `subtitle` = `secondaryInfo`. Its embedded notes (from `?notes=true`) are upserted per item.
 
-**Upsert logic for notes**: match on `serverID`. If `.synced`, update fields and sync embedded quotes (match by `noteServerID + body`, delete missing). If `syncState != .synced`, skip body/fields but still sync quotes (they are server-owned). Delete notes with `serverID` and `.synced` state absent from response.
+**Upsert logic for notes** (per item, scoped by PreviewID — called from the typed/orphan upserts): match on `serverID`. If found and `.synced`, update fields; if not found, create with `attachmentPreviewID` set to the item's PreviewID. Delete this item's `.synced` notes absent from the embedded array (handles server-side note deletes). Records with `syncState != .synced` are preserved until pushed. (Syncing `NoteResponse.quotes` into `QuoteRecord` is not yet implemented.)
 
 **Deletion logic**: `DeletionRecord.itemID` is always a string — parse as `UUID` for notes/catalogueItems, `Int` for posts. Skip records where `syncState != .synced`; a locally-pending record should not be deleted by a server tombstone (the push flow resolves the conflict).
 
@@ -510,9 +583,8 @@ tmbr/Catalogue/
     @Catalogue.swift
     View+Catalogue.swift
     Actions/SyncCatalogueAction.swift
-    Requests/NotesRequest.swift
-    Requests/SongsRequest.swift + AlbumsRequest.swift + ... (one per type)
-    Requests/OrphansRequest.swift
+    Requests/SongsRequest.swift + AlbumsRequest.swift + ... (one per type; each response carries .notes)
+    Requests/OrphansRequest.swift  (sent with ?notes=true; no standalone NotesRequest)
     Requests/DeletionsRequest.swift
 ```
 

--- a/.claude/docs/repository-layout.md
+++ b/.claude/docs/repository-layout.md
@@ -6,8 +6,25 @@
 |---------|------|------------|
 | `tmbr-core` | Shared Codable/Sendable types. No platform-specific deps. | Swift stdlib only |
 | `tmbr-web` | Vapor backend + Leaf frontend | `tmbr-core`, Vapor, Fluent, Leaf |
-| `tmbr-app` | Native SwiftUI app | `tmbr-core`, `api-kit`, SwiftUI, MusicKit |
+| `tmbr-app` | Native SwiftUI apps (three targets — see below) | `tmbr-core`, `api-kit`, `AppCore`, SwiftUI, MusicKit |
 | `api-kit` | Networking infra (RequestLoader, AuthToken) | Swift stdlib only |
+
+## Native App: three targets over one shared core
+
+`tmbr-app` ships **three apps** from one shared local SPM package (`AppCore`). See
+`.claude/docs/native-apps-architecture.md` for the full design.
+
+| Module / target | Role | Can import |
+|---|---|---|
+| `AppCore` (lib) | SwiftData schema, `@Query` views, `@Observable` models, property wrappers, actions. The composition seam lives here as injected closures. | `tmbr-core`, SwiftData, SwiftUI |
+| `AppBackend` (lib) | api-kit request structs + shared pull/push helpers | `AppCore`, `tmbr-core`, `api-kit` |
+| **Author** (target) | Owner app: offline-first, `SyncEngine` backend sync | `AppCore`, `AppBackend` |
+| **Reader** (target) | Public read-only app: on-demand ETag cache | `AppCore`, `AppBackend` |
+| **Personal** (target) | Private consumer app: `.private` CloudKit, no engine | `AppCore` only (no networking) |
+
+**Hard dependency rule:** `AppCore` must import **neither networking (`api-kit`/`URLSession`) nor
+CloudKit.** That isolation is what lets one core serve all three apps; per-app sync is injected as
+closures at the app layer.
 
 ## What Belongs in `tmbr-core`
 

--- a/.claude/docs/two-product-architecture.md
+++ b/.claude/docs/two-product-architecture.md
@@ -1,0 +1,13 @@
+# Two-Product Architecture — superseded
+
+This document has been superseded by the three-app pivot. The "two products from one core" framing
+(owner app + future guest read-mode as Product 1; CloudKit consumer app as Product 2) split into
+**three apps** once the real product shape became clear:
+
+- **Reader** — public, read-only, on-demand ETag cache
+- **Author** — the owner, offline-first, full backend sync (this is what the old "Product 1" became)
+- **Personal** — CloudKit-only consumer app (the old "Product 2")
+
+See **`.claude/docs/native-apps-architecture.md`** for the current canonical architecture. It carries
+forward the still-valid decisions from this doc (the composition seam, the CloudKit schema
+constraints) and explains what changed and why.

--- a/tmbr-app/CLAUDE.md
+++ b/tmbr-app/CLAUDE.md
@@ -52,12 +52,23 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-pa
 - `[Domain]Kit` = headless logic (`@Observable` models, no SwiftUI). `[Domain]UI` = controls, property wrappers, actions, styles.
 - Module-level access control enforces feature isolation — internal navigation state is never `public`.
 
+**Three apps, one shared core** (see `.claude/docs/native-apps-architecture.md`)
+- `tmbr-app` ships **three** targets — **Author** (owner, offline-first backend sync), **Reader**
+  (public, read-only ETag cache), **Personal** (private, CloudKit-only) — over one shared local SPM
+  package, `AppCore` (+ `AppBackend` for networking, used by Author + Reader only).
+- **Hard rule: `AppCore` imports neither networking (`api-kit`/`URLSession`) nor CloudKit.** Per-app
+  sync is injected at the app layer as closures (the composition seam), never referenced from the core.
+- Write path: actions → SwiftData + an injected `requestSync` closure. Read/refresh: a per-screen
+  `@Observable` detail model holding an injected refresh-strategy closure. Same env-key, different
+  body per app — that injection point *is* the three-app seam; do not branch on app inside `AppCore`.
+
 **Concurrency**
 - `@MainActor` on all `@Observable` classes and action structs.
 - `nonisolated` on pure-closure action inits.
 
 ## Before Starting
 
+- Native apps architecture (three apps, shared `AppCore`, composition seam) → `.claude/docs/native-apps-architecture.md`
 - SwiftUI architecture (Observable, env injection, property wrappers, actions, styles) → `.claude/docs/swiftui-architecture.md`
 - Navigation pattern (NavigationModel, scoped feature navigation) → `.claude/docs/navigation.md`
 - Networking (RequestLoader, AuthToken, api-kit) → `.claude/docs/networking.md`


### PR DESCRIPTION
Records the pivot from the two-product vision to **three apps over one shared `AppCore` package** — so the architecture references survive between sessions while we build out the stages.

## What's here
- **New canonical** `.claude/docs/native-apps-architecture.md` — the three apps (Reader / Author / Personal), the composition seam (injected `requestSync` + per-screen `@Observable` detail models), and the **normalized SwiftData schema** mirroring the backend (`PreviewRecord` + per-type `SongRecord`/etc. linked by `previewID` + `ContainerEntryRecord`; Author/Personal author catalogue items offline, Reader is a thin cache).
- `two-product-architecture.md` — left as a superseded stub pointing to the new doc.
- `offline-first-native-app.md` — reframed as the three-app staged roadmap.
- `repository-layout.md` + `tmbr-app/CLAUDE.md` — updated for `AppCore`/`AppBackend` + three targets and the "AppCore imports no networking/CloudKit" rule.

Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)