### PR TITLE
Expose PreviewID + embed orphan notes for native sync

### DIFF
--- a/tmbr-core/Sources/TmbrCore/Responses/PreviewResponse.swift
+++ b/tmbr-core/Sources/TmbrCore/Responses/PreviewResponse.swift
@@ -13,6 +13,10 @@ public struct PreviewResponse: Codable, Sendable {
         }
     }
 
+    /// Stable cross-type identifier (Preview UUID). Optional only because a few synthesized previews
+    /// (search/quote matches) have no backing row; catalogue sync responses always set it.
+    public let id: PreviewID?
+
     public let primaryInfo: String
 
     public let secondaryInfo: String?
@@ -27,15 +31,22 @@ public struct PreviewResponse: Codable, Sendable {
 
     public let isNoteMatch: Bool
 
+    /// Notes attached to this item. `nil` when not requested (lists omit them by default); populated
+    /// when the endpoint is asked to embed notes (e.g. `?notes=true`).
+    public let notes: [NoteResponse]?
+
     public init(
+        id: PreviewID? = nil,
         primaryInfo: String,
         secondaryInfo: String?,
         image: ImageResponse?,
         resources: [String],
         source: Source,
         category: String? = nil,
-        isNoteMatch: Bool = false
+        isNoteMatch: Bool = false,
+        notes: [NoteResponse]? = nil
     ) {
+        self.id = id
         self.primaryInfo = primaryInfo
         self.secondaryInfo = secondaryInfo
         self.image = image
@@ -43,5 +54,6 @@ public struct PreviewResponse: Codable, Sendable {
         self.source = source
         self.category = category
         self.isNoteMatch = isNoteMatch
+        self.notes = notes
     }
 }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/API/CatalogueAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/API/CatalogueAPIController.swift
@@ -102,8 +102,18 @@ struct CatalogueAPIController: RouteCollection {
         let input = PreviewQueryInput(kind: .orphan, since: pageQuery.since, before: pageQuery.cursorDate, limit: limit + 1)
         let previews = try await request.commands.previews.list(input)
         let baseURL = request.baseURL
+
+        // ?notes=true embeds each orphan's notes (sync needs them; orphans have no per-type endpoint).
+        let includeNotes = (try? request.query.get(Bool.self, at: "notes")) ?? false
+        let notesByPreviewID: [PreviewID: [Note]] = includeNotes
+            ? try await request.commands.notes.grouped(previews.compactMap(\.id))
+            : [:]
+
         return PageResult(from: previews, limit: limit) { preview in
-            PreviewResponse(preview: preview, baseURL: baseURL)
+            let embedded: [NoteResponse]? = includeNotes
+                ? (preview.id.flatMap { notesByPreviewID[$0] } ?? []).map { NoteResponse(note: $0, baseURL: baseURL) }
+                : nil
+            return PreviewResponse(preview: preview, baseURL: baseURL, notes: embedded)
         }
     }
 

--- a/tmbr-web/Sources/App/Modules/Previews/Commands/Command/Command+ListPreviews.swift
+++ b/tmbr-web/Sources/App/Modules/Previews/Commands/Command/Command+ListPreviews.swift
@@ -64,7 +64,14 @@ extension Command where Self == PlainCommand<PreviewQueryInput, [Preview]> {
                     group.filter(\.$secondaryInfo, .custom("ILIKE"), "%\(term)%")
                 }
             }
-            if let since = input.since { query.filter(\.$createdAt > since) }
+            // Delta (`since`) matches items created OR whose notes changed since last sync — note
+            // edits bump updatedAt (see NoteModelMiddleware). Load-more (`before`) stays on createdAt.
+            if let since = input.since {
+                query.group(.or) { or in
+                    or.filter(\.$createdAt > since)
+                    or.filter(\.$updatedAt > since)
+                }
+            }
             if let before = input.before { query.filter(\.$createdAt < before) }
             if let limit = input.limit { query.limit(limit) }
             try await permission.grant(query)

--- a/tmbr-web/Sources/App/Modules/Previews/Models/QueryBuilder+Previewable.swift
+++ b/tmbr-web/Sources/App/Modules/Previews/Models/QueryBuilder+Previewable.swift
@@ -4,7 +4,15 @@ import Core
 extension QueryBuilder where Model: Previewable {
     @discardableResult
     func page(_ input: PageInput) -> Self {
-        if let since = input.since { filter(Preview.self, \Preview.$createdAt > since) }
+        // Delta (`since`) matches items created OR whose notes changed since last sync — note edits
+        // bump Preview.updatedAt (see NoteModelMiddleware). Load-more (`before`) stays on createdAt
+        // for stable backward paging.
+        if let since = input.since {
+            group(.or) { or in
+                or.filter(Preview.self, \Preview.$createdAt > since)
+                or.filter(Preview.self, \Preview.$updatedAt > since)
+            }
+        }
         if let before = input.before { filter(Preview.self, \Preview.$createdAt < before) }
         return limit(input.limit + 1)
     }

--- a/tmbr-web/Sources/App/Modules/Previews/Routes/API/Responses/PreviewResponse.swift
+++ b/tmbr-web/Sources/App/Modules/Previews/Routes/API/Responses/PreviewResponse.swift
@@ -3,9 +3,10 @@ import TmbrCore
 
 extension PreviewResponse {
 
-    init(preview: Preview, baseURL: String, isNoteMatch: Bool = false) {
+    init(preview: Preview, baseURL: String, isNoteMatch: Bool = false, notes: [NoteResponse]? = nil) {
         let category = preview.catalogueCategory
         self.init(
+            id: preview.id,
             primaryInfo: preview.primaryInfo,
             secondaryInfo: preview.secondaryInfo,
             image: preview.image.map { image in
@@ -17,7 +18,8 @@ extension PreviewResponse {
                 type: category?.slug ?? "item"
             ),
             category: category?.kind == .orphan ? category?.slug : nil,
-            isNoteMatch: isNoteMatch
+            isNoteMatch: isNoteMatch,
+            notes: notes
         )
     }
 }


### PR DESCRIPTION
The native app keys its local catalogue records by the server **PreviewID (UUID)** and anchors notes to it — so the sync responses must carry it. This was missing from #184 (it was added later, during the app stages). Small, additive, backward-compatible.

## Changes
- `PreviewResponse.id: PreviewID?` and `PreviewResponse.notes: [NoteResponse]?` — both optional (synthesized search/quote previews leave them `nil`; catalogue sync responses always set `id`).
- The central `PreviewResponse(preview:)` Vapor init sets `id = preview.id`, so **every per-type response's embedded preview now carries the PreviewID automatically** (no per-type controller changes needed).
- `GET /api/catalogue/orphans?notes=true` embeds each orphan's notes (orphans have no per-type endpoint).
- Catalogue delta (`since`) now matches `createdAt OR updatedAt`, so an item re-surfaces when its notes change (note edits bump `Preview.updatedAt` via `NoteModelMiddleware`); load-more (`before`) stays on `createdAt`.

## Why
Without the PreviewID in responses, the app can't key `PreviewRecord`, match `.catalogueItem` deletion tombstones, or POST notes to `/item/:previewID/notes`. Unblocks the Author app's sync engine.

## Verification
- `swift build` (tmbr-web) ✓
- Backend tests need a Postgres DB — run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)