### PR TITLE
AppCore package: normalized SwiftData schema

### DIFF
--- a/app-core/Package.swift
+++ b/app-core/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "app-core",
+    platforms: [.iOS(.v18), .macOS(.v15)],
+    products: [
+        // Shared across all three apps (Author / Reader / Personal).
+        // MUST NOT depend on networking (ApiKit/URLSession) or CloudKit — per-app sync is
+        // injected at the app layer as closures. See .claude/docs/native-apps-architecture.md.
+        .library(name: "AppCore", targets: ["AppCore"]),
+    ],
+    dependencies: [
+        .package(path: "../tmbr-core"),
+    ],
+    targets: [
+        .target(
+            name: "AppCore",
+            dependencies: [.product(name: "TmbrCore", package: "tmbr-core")]
+        ),
+    ]
+)

--- a/app-core/Sources/AppCore/Persistence/AlbumRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/AlbumRecord.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SwiftData
+
+/// Rich, typed data for an album. Tracks are modelled separately via `ContainerEntryRecord`
+/// (mirroring the backend `ContainerEntry`). Linked to its `PreviewRecord` by `previewID`.
+@Model
+public final class AlbumRecord {
+
+    public var previewID: UUID = UUID()
+    public var sourceID: Int?
+
+    public var title: String = ""
+    public var artist: String = ""
+    public var genre: String?
+    public var releaseDate: Date?
+    public var artworkURL: String?
+    public var resourceURLs: [String] = []
+    public var accessRaw: String = ""
+    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    public init(
+        previewID: UUID = UUID(),
+        sourceID: Int? = nil,
+        title: String = "",
+        artist: String = "",
+        genre: String? = nil,
+        releaseDate: Date? = nil,
+        artworkURL: String? = nil,
+        resourceURLs: [String] = [],
+        accessRaw: String = "",
+        syncState: SyncState = .synced
+    ) {
+        self.previewID = previewID
+        self.sourceID = sourceID
+        self.title = title
+        self.artist = artist
+        self.genre = genre
+        self.releaseDate = releaseDate
+        self.artworkURL = artworkURL
+        self.resourceURLs = resourceURLs
+        self.accessRaw = accessRaw
+        self.syncStateRaw = syncState.rawValue
+    }
+}
+
+public extension AlbumRecord {
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+}

--- a/app-core/Sources/AppCore/Persistence/AlbumRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/AlbumRecord.swift
@@ -3,20 +3,29 @@ import SwiftData
 
 /// Rich, typed data for an album. Tracks are modelled separately via `ContainerEntryRecord`
 /// (mirroring the backend `ContainerEntry`). Linked to its `PreviewRecord` by `previewID`.
+///
 @Model
 public final class AlbumRecord {
 
     public var previewID: UUID = UUID()
+
     public var sourceID: Int?
 
     public var title: String = ""
+
     public var artist: String = ""
+
     public var genre: String?
+
     public var releaseDate: Date?
+
     public var artworkURL: String?
+
     public var resourceURLs: [String] = []
-    public var accessRaw: String = ""
-    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    var accessRaw: String = ""
+
+    var syncStateRaw: String = SyncState.synced.rawValue
 
     public init(
         previewID: UUID = UUID(),
@@ -27,7 +36,7 @@ public final class AlbumRecord {
         releaseDate: Date? = nil,
         artworkURL: String? = nil,
         resourceURLs: [String] = [],
-        accessRaw: String = "",
+        access: Access = .private,
         syncState: SyncState = .synced
     ) {
         self.previewID = previewID
@@ -38,12 +47,17 @@ public final class AlbumRecord {
         self.releaseDate = releaseDate
         self.artworkURL = artworkURL
         self.resourceURLs = resourceURLs
-        self.accessRaw = accessRaw
+        self.accessRaw = access.rawValue
         self.syncStateRaw = syncState.rawValue
     }
 }
 
 public extension AlbumRecord {
+    var access: Access {
+        get { Access(rawValue: accessRaw) ?? .private }
+        set { accessRaw = newValue.rawValue }
+    }
+
     var syncState: SyncState {
         get { SyncState(rawValue: syncStateRaw) ?? .synced }
         set { syncStateRaw = newValue.rawValue }

--- a/app-core/Sources/AppCore/Persistence/AppSchema.swift
+++ b/app-core/Sources/AppCore/Persistence/AppSchema.swift
@@ -6,6 +6,7 @@ import SwiftData
 /// Each app builds its own `ModelContainer` from this list with its own `ModelConfiguration`
 /// (plain on-disk for Author/Reader; `.private` CloudKit for Personal). The schema is the same;
 /// only the container configuration and the injected sync composition differ.
+/// 
 public enum AppSchema {
 
     public static let models: [any PersistentModel.Type] = [

--- a/app-core/Sources/AppCore/Persistence/AppSchema.swift
+++ b/app-core/Sources/AppCore/Persistence/AppSchema.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftData
+
+/// The single SwiftData schema shared by all three apps (Author / Reader / Personal).
+///
+/// Each app builds its own `ModelContainer` from this list with its own `ModelConfiguration`
+/// (plain on-disk for Author/Reader; `.private` CloudKit for Personal). The schema is the same;
+/// only the container configuration and the injected sync composition differ.
+public enum AppSchema {
+
+    public static let models: [any PersistentModel.Type] = [
+        PreviewRecord.self,
+        SongRecord.self,
+        AlbumRecord.self,
+        BookRecord.self,
+        MovieRecord.self,
+        PodcastRecord.self,
+        PlaylistRecord.self,
+        ContainerEntryRecord.self,
+        NoteRecord.self,
+        PostRecord.self,
+        QuoteRecord.self,
+        UserRecord.self,
+    ]
+
+    public static var schema: Schema { Schema(models) }
+}

--- a/app-core/Sources/AppCore/Persistence/BookRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/BookRecord.swift
@@ -3,20 +3,29 @@ import SwiftData
 
 /// Rich, typed data for a book. Linked to its `PreviewRecord` by `previewID`.
 /// Mirrors the backend `Book` / `BookResponse`.
+///
 @Model
 public final class BookRecord {
 
     public var previewID: UUID = UUID()
+
     public var sourceID: Int?
 
     public var title: String = ""
+
     public var author: String = ""
+
     public var genre: String?
+
     public var releaseDate: Date?
+
     public var coverURL: String?
+
     public var resourceURLs: [String] = []
-    public var accessRaw: String = ""
-    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    var accessRaw: String = ""
+
+    var syncStateRaw: String = SyncState.synced.rawValue
 
     public init(
         previewID: UUID = UUID(),
@@ -27,7 +36,7 @@ public final class BookRecord {
         releaseDate: Date? = nil,
         coverURL: String? = nil,
         resourceURLs: [String] = [],
-        accessRaw: String = "",
+        access: Access = .private,
         syncState: SyncState = .synced
     ) {
         self.previewID = previewID
@@ -38,12 +47,17 @@ public final class BookRecord {
         self.releaseDate = releaseDate
         self.coverURL = coverURL
         self.resourceURLs = resourceURLs
-        self.accessRaw = accessRaw
+        self.accessRaw = access.rawValue
         self.syncStateRaw = syncState.rawValue
     }
 }
 
 public extension BookRecord {
+    var access: Access {
+        get { Access(rawValue: accessRaw) ?? .private }
+        set { accessRaw = newValue.rawValue }
+    }
+
     var syncState: SyncState {
         get { SyncState(rawValue: syncStateRaw) ?? .synced }
         set { syncStateRaw = newValue.rawValue }

--- a/app-core/Sources/AppCore/Persistence/BookRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/BookRecord.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SwiftData
+
+/// Rich, typed data for a book. Linked to its `PreviewRecord` by `previewID`.
+/// Mirrors the backend `Book` / `BookResponse`.
+@Model
+public final class BookRecord {
+
+    public var previewID: UUID = UUID()
+    public var sourceID: Int?
+
+    public var title: String = ""
+    public var author: String = ""
+    public var genre: String?
+    public var releaseDate: Date?
+    public var coverURL: String?
+    public var resourceURLs: [String] = []
+    public var accessRaw: String = ""
+    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    public init(
+        previewID: UUID = UUID(),
+        sourceID: Int? = nil,
+        title: String = "",
+        author: String = "",
+        genre: String? = nil,
+        releaseDate: Date? = nil,
+        coverURL: String? = nil,
+        resourceURLs: [String] = [],
+        accessRaw: String = "",
+        syncState: SyncState = .synced
+    ) {
+        self.previewID = previewID
+        self.sourceID = sourceID
+        self.title = title
+        self.author = author
+        self.genre = genre
+        self.releaseDate = releaseDate
+        self.coverURL = coverURL
+        self.resourceURLs = resourceURLs
+        self.accessRaw = accessRaw
+        self.syncStateRaw = syncState.rawValue
+    }
+}
+
+public extension BookRecord {
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+}

--- a/app-core/Sources/AppCore/Persistence/ContainerEntryRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/ContainerEntryRecord.swift
@@ -10,16 +10,24 @@ import SwiftData
 /// **Track removal honors promotion:** when a container is deleted, only `.promotable`
 /// (unpromoted) members are removed; promoted members survive — matching the backend
 /// `deleteContainerEntries` command.
+/// 
 @Model
 public final class ContainerEntryRecord {
 
     public var clientKey: UUID = UUID()
-
-    public var containerType: String = ""        // "album" | "playlist"
-    public var containerSourceID: Int = 0        // backing album/playlist Int id
-    public var memberPreviewID: UUID = UUID()    // the track member's PreviewID
+    
+    /// "album" | "playlist"
+    public var containerType: String = ""
+    
+    /// backing album/playlist Int id
+    public var containerSourceID: Int = 0
+    
+    /// the track member's PreviewID
+    public var memberPreviewID: UUID = UUID()
+    
     public var position: Int = 0
-    public var syncStateRaw: String = SyncState.synced.rawValue
+    
+    var syncStateRaw: String = SyncState.synced.rawValue
 
     public init(
         clientKey: UUID = UUID(),

--- a/app-core/Sources/AppCore/Persistence/ContainerEntryRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/ContainerEntryRecord.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftData
+
+/// One ordered membership of a track in an album or playlist — mirroring the backend
+/// `ContainerEntry`. Enables offline track-list management.
+///
+/// Links by UUID/Int (not `@Relationship`): `memberPreviewID` is the track member's PreviewID,
+/// `containerSourceID` is the album/playlist's backing Int id.
+///
+/// **Track removal honors promotion:** when a container is deleted, only `.promotable`
+/// (unpromoted) members are removed; promoted members survive — matching the backend
+/// `deleteContainerEntries` command.
+@Model
+public final class ContainerEntryRecord {
+
+    public var clientKey: UUID = UUID()
+
+    public var containerType: String = ""        // "album" | "playlist"
+    public var containerSourceID: Int = 0        // backing album/playlist Int id
+    public var memberPreviewID: UUID = UUID()    // the track member's PreviewID
+    public var position: Int = 0
+    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    public init(
+        clientKey: UUID = UUID(),
+        containerType: String = "",
+        containerSourceID: Int = 0,
+        memberPreviewID: UUID = UUID(),
+        position: Int = 0,
+        syncState: SyncState = .synced
+    ) {
+        self.clientKey = clientKey
+        self.containerType = containerType
+        self.containerSourceID = containerSourceID
+        self.memberPreviewID = memberPreviewID
+        self.position = position
+        self.syncStateRaw = syncState.rawValue
+    }
+}
+
+public extension ContainerEntryRecord {
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+}

--- a/app-core/Sources/AppCore/Persistence/MovieRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/MovieRecord.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SwiftData
+
+/// Rich, typed data for a movie. Linked to its `PreviewRecord` by `previewID`.
+/// Mirrors the backend `Movie` / `MovieResponse`.
+@Model
+public final class MovieRecord {
+
+    public var previewID: UUID = UUID()
+    public var sourceID: Int?
+
+    public var title: String = ""
+    public var director: String?
+    public var genre: String?
+    public var releaseDate: Date?
+    public var coverURL: String?
+    public var resourceURLs: [String] = []
+    public var accessRaw: String = ""
+    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    public init(
+        previewID: UUID = UUID(),
+        sourceID: Int? = nil,
+        title: String = "",
+        director: String? = nil,
+        genre: String? = nil,
+        releaseDate: Date? = nil,
+        coverURL: String? = nil,
+        resourceURLs: [String] = [],
+        accessRaw: String = "",
+        syncState: SyncState = .synced
+    ) {
+        self.previewID = previewID
+        self.sourceID = sourceID
+        self.title = title
+        self.director = director
+        self.genre = genre
+        self.releaseDate = releaseDate
+        self.coverURL = coverURL
+        self.resourceURLs = resourceURLs
+        self.accessRaw = accessRaw
+        self.syncStateRaw = syncState.rawValue
+    }
+}
+
+public extension MovieRecord {
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+}

--- a/app-core/Sources/AppCore/Persistence/MovieRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/MovieRecord.swift
@@ -3,20 +3,29 @@ import SwiftData
 
 /// Rich, typed data for a movie. Linked to its `PreviewRecord` by `previewID`.
 /// Mirrors the backend `Movie` / `MovieResponse`.
+///
 @Model
 public final class MovieRecord {
 
     public var previewID: UUID = UUID()
+
     public var sourceID: Int?
 
     public var title: String = ""
+
     public var director: String?
+
     public var genre: String?
+
     public var releaseDate: Date?
+
     public var coverURL: String?
+
     public var resourceURLs: [String] = []
-    public var accessRaw: String = ""
-    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    var accessRaw: String = ""
+
+    var syncStateRaw: String = SyncState.synced.rawValue
 
     public init(
         previewID: UUID = UUID(),
@@ -27,7 +36,7 @@ public final class MovieRecord {
         releaseDate: Date? = nil,
         coverURL: String? = nil,
         resourceURLs: [String] = [],
-        accessRaw: String = "",
+        access: Access = .private,
         syncState: SyncState = .synced
     ) {
         self.previewID = previewID
@@ -38,12 +47,17 @@ public final class MovieRecord {
         self.releaseDate = releaseDate
         self.coverURL = coverURL
         self.resourceURLs = resourceURLs
-        self.accessRaw = accessRaw
+        self.accessRaw = access.rawValue
         self.syncStateRaw = syncState.rawValue
     }
 }
 
 public extension MovieRecord {
+    var access: Access {
+        get { Access(rawValue: accessRaw) ?? .private }
+        set { accessRaw = newValue.rawValue }
+    }
+
     var syncState: SyncState {
         get { SyncState(rawValue: syncStateRaw) ?? .synced }
         set { syncStateRaw = newValue.rawValue }

--- a/app-core/Sources/AppCore/Persistence/NoteRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/NoteRecord.swift
@@ -1,0 +1,66 @@
+import Foundation
+import SwiftData
+
+/// Local representation of a user note attached to a catalogue item.
+///
+/// `clientKey` is always client-generated and is the stable local identity. `serverID` is nil until
+/// the backend confirms creation (the server generates note UUIDs). After a successful push,
+/// `NoteResponse.id` is written back into `serverID`.
+///
+/// The note anchors to its catalogue item by `attachmentPreviewID` (the server PreviewID) — a plain
+/// UUID link, not a `@Relationship`, so a note can exist before its `PreviewRecord` is synced and so
+/// CloudKit mirroring stays trivial. Push uses it to call `POST /api/catalogue/item/:previewID/notes`.
+@Model
+public final class NoteRecord {
+
+    public var clientKey: UUID = UUID()
+
+    public var serverID: UUID?
+    public var body: String = ""
+    public var accessRaw: String = ""               // Access.rawValue
+    public var languageRaw: String = ""             // Language.rawValue
+    public var createdAt: Date = Date.now
+    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    // Denormalised attachment — lets a NoteRecord display/sync without its PreviewRecord present.
+    public var attachmentPreviewID: UUID?
+    public var attachmentTitle: String = ""
+    public var attachmentSubtitle: String?
+    public var attachmentCategoryType: String?      // "song" | "book" | …
+    public var attachmentSourceID: Int?             // nil for orphan attachments
+
+    public init(
+        clientKey: UUID = UUID(),
+        serverID: UUID? = nil,
+        body: String = "",
+        accessRaw: String = "",
+        languageRaw: String = "",
+        createdAt: Date = .now,
+        syncState: SyncState = .pendingCreate,
+        attachmentPreviewID: UUID? = nil,
+        attachmentTitle: String = "",
+        attachmentSubtitle: String? = nil,
+        attachmentCategoryType: String? = nil,
+        attachmentSourceID: Int? = nil
+    ) {
+        self.clientKey = clientKey
+        self.serverID = serverID
+        self.body = body
+        self.accessRaw = accessRaw
+        self.languageRaw = languageRaw
+        self.createdAt = createdAt
+        self.syncStateRaw = syncState.rawValue
+        self.attachmentPreviewID = attachmentPreviewID
+        self.attachmentTitle = attachmentTitle
+        self.attachmentSubtitle = attachmentSubtitle
+        self.attachmentCategoryType = attachmentCategoryType
+        self.attachmentSourceID = attachmentSourceID
+    }
+}
+
+public extension NoteRecord {
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+}

--- a/app-core/Sources/AppCore/Persistence/NoteRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/NoteRecord.swift
@@ -10,31 +10,43 @@ import SwiftData
 /// The note anchors to its catalogue item by `attachmentPreviewID` (the server PreviewID) — a plain
 /// UUID link, not a `@Relationship`, so a note can exist before its `PreviewRecord` is synced and so
 /// CloudKit mirroring stays trivial. Push uses it to call `POST /api/catalogue/item/:previewID/notes`.
+///
 @Model
 public final class NoteRecord {
 
     public var clientKey: UUID = UUID()
 
     public var serverID: UUID?
+
     public var body: String = ""
-    public var accessRaw: String = ""               // Access.rawValue
-    public var languageRaw: String = ""             // Language.rawValue
+
+    var accessRaw: String = ""
+
+    var languageRaw: String = ""
+
     public var createdAt: Date = Date.now
-    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    var syncStateRaw: String = SyncState.synced.rawValue
 
     // Denormalised attachment — lets a NoteRecord display/sync without its PreviewRecord present.
     public var attachmentPreviewID: UUID?
+
     public var attachmentTitle: String = ""
+
     public var attachmentSubtitle: String?
-    public var attachmentCategoryType: String?      // "song" | "book" | …
-    public var attachmentSourceID: Int?             // nil for orphan attachments
+
+    /// "song" | "book" | …
+    public var attachmentCategoryType: String?
+
+    /// nil for orphan attachments
+    public var attachmentSourceID: Int?
 
     public init(
         clientKey: UUID = UUID(),
         serverID: UUID? = nil,
         body: String = "",
-        accessRaw: String = "",
-        languageRaw: String = "",
+        access: Access = .private,
+        language: Language? = nil,
         createdAt: Date = .now,
         syncState: SyncState = .pendingCreate,
         attachmentPreviewID: UUID? = nil,
@@ -46,8 +58,8 @@ public final class NoteRecord {
         self.clientKey = clientKey
         self.serverID = serverID
         self.body = body
-        self.accessRaw = accessRaw
-        self.languageRaw = languageRaw
+        self.accessRaw = access.rawValue
+        self.languageRaw = language?.rawValue ?? ""
         self.createdAt = createdAt
         self.syncStateRaw = syncState.rawValue
         self.attachmentPreviewID = attachmentPreviewID
@@ -59,6 +71,16 @@ public final class NoteRecord {
 }
 
 public extension NoteRecord {
+    var access: Access {
+        get { Access(rawValue: accessRaw) ?? .private }
+        set { accessRaw = newValue.rawValue }
+    }
+
+    var language: Language? {
+        get { Language(rawValue: languageRaw) }
+        set { languageRaw = newValue?.rawValue ?? "" }
+    }
+
     var syncState: SyncState {
         get { SyncState(rawValue: syncStateRaw) ?? .synced }
         set { syncStateRaw = newValue.rawValue }

--- a/app-core/Sources/AppCore/Persistence/PlaylistRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/PlaylistRecord.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SwiftData
+
+/// Rich, typed data for a playlist. Tracks are modelled separately via `ContainerEntryRecord`.
+/// Linked to its `PreviewRecord` by `previewID`. Mirrors the backend `Playlist` / `PlaylistResponse`.
+@Model
+public final class PlaylistRecord {
+
+    public var previewID: UUID = UUID()
+    public var sourceID: Int?
+
+    public var title: String = ""
+    public var playlistDescription: String?
+    public var artworkURL: String?
+    public var resourceURLs: [String] = []
+    public var accessRaw: String = ""
+    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    public init(
+        previewID: UUID = UUID(),
+        sourceID: Int? = nil,
+        title: String = "",
+        playlistDescription: String? = nil,
+        artworkURL: String? = nil,
+        resourceURLs: [String] = [],
+        accessRaw: String = "",
+        syncState: SyncState = .synced
+    ) {
+        self.previewID = previewID
+        self.sourceID = sourceID
+        self.title = title
+        self.playlistDescription = playlistDescription
+        self.artworkURL = artworkURL
+        self.resourceURLs = resourceURLs
+        self.accessRaw = accessRaw
+        self.syncStateRaw = syncState.rawValue
+    }
+}
+
+public extension PlaylistRecord {
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+}

--- a/app-core/Sources/AppCore/Persistence/PlaylistRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/PlaylistRecord.swift
@@ -3,18 +3,25 @@ import SwiftData
 
 /// Rich, typed data for a playlist. Tracks are modelled separately via `ContainerEntryRecord`.
 /// Linked to its `PreviewRecord` by `previewID`. Mirrors the backend `Playlist` / `PlaylistResponse`.
+///
 @Model
 public final class PlaylistRecord {
 
     public var previewID: UUID = UUID()
+
     public var sourceID: Int?
 
     public var title: String = ""
+
     public var playlistDescription: String?
+
     public var artworkURL: String?
+
     public var resourceURLs: [String] = []
-    public var accessRaw: String = ""
-    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    var accessRaw: String = ""
+
+    var syncStateRaw: String = SyncState.synced.rawValue
 
     public init(
         previewID: UUID = UUID(),
@@ -23,7 +30,7 @@ public final class PlaylistRecord {
         playlistDescription: String? = nil,
         artworkURL: String? = nil,
         resourceURLs: [String] = [],
-        accessRaw: String = "",
+        access: Access = .private,
         syncState: SyncState = .synced
     ) {
         self.previewID = previewID
@@ -32,12 +39,17 @@ public final class PlaylistRecord {
         self.playlistDescription = playlistDescription
         self.artworkURL = artworkURL
         self.resourceURLs = resourceURLs
-        self.accessRaw = accessRaw
+        self.accessRaw = access.rawValue
         self.syncStateRaw = syncState.rawValue
     }
 }
 
 public extension PlaylistRecord {
+    var access: Access {
+        get { Access(rawValue: accessRaw) ?? .private }
+        set { accessRaw = newValue.rawValue }
+    }
+
     var syncState: SyncState {
         get { SyncState(rawValue: syncStateRaw) ?? .synced }
         set { syncStateRaw = newValue.rawValue }

--- a/app-core/Sources/AppCore/Persistence/PodcastRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/PodcastRecord.swift
@@ -1,0 +1,57 @@
+import Foundation
+import SwiftData
+
+/// Rich, typed data for a podcast episode. Linked to its `PreviewRecord` by `previewID`.
+/// Mirrors the backend `Podcast` / `PodcastResponse`.
+@Model
+public final class PodcastRecord {
+
+    public var previewID: UUID = UUID()
+    public var sourceID: Int?
+
+    public var title: String = ""
+    public var episodeTitle: String = ""
+    public var episodeNumber: Int?
+    public var seasonNumber: Int?
+    public var genre: String?
+    public var releaseDate: Date?
+    public var artworkURL: String?
+    public var resourceURLs: [String] = []
+    public var accessRaw: String = ""
+    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    public init(
+        previewID: UUID = UUID(),
+        sourceID: Int? = nil,
+        title: String = "",
+        episodeTitle: String = "",
+        episodeNumber: Int? = nil,
+        seasonNumber: Int? = nil,
+        genre: String? = nil,
+        releaseDate: Date? = nil,
+        artworkURL: String? = nil,
+        resourceURLs: [String] = [],
+        accessRaw: String = "",
+        syncState: SyncState = .synced
+    ) {
+        self.previewID = previewID
+        self.sourceID = sourceID
+        self.title = title
+        self.episodeTitle = episodeTitle
+        self.episodeNumber = episodeNumber
+        self.seasonNumber = seasonNumber
+        self.genre = genre
+        self.releaseDate = releaseDate
+        self.artworkURL = artworkURL
+        self.resourceURLs = resourceURLs
+        self.accessRaw = accessRaw
+        self.syncStateRaw = syncState.rawValue
+    }
+}
+
+public extension PodcastRecord {
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+}

--- a/app-core/Sources/AppCore/Persistence/PodcastRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/PodcastRecord.swift
@@ -3,22 +3,33 @@ import SwiftData
 
 /// Rich, typed data for a podcast episode. Linked to its `PreviewRecord` by `previewID`.
 /// Mirrors the backend `Podcast` / `PodcastResponse`.
+///
 @Model
 public final class PodcastRecord {
 
     public var previewID: UUID = UUID()
+
     public var sourceID: Int?
 
     public var title: String = ""
+
     public var episodeTitle: String = ""
+
     public var episodeNumber: Int?
+
     public var seasonNumber: Int?
+
     public var genre: String?
+
     public var releaseDate: Date?
+
     public var artworkURL: String?
+
     public var resourceURLs: [String] = []
-    public var accessRaw: String = ""
-    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    var accessRaw: String = ""
+
+    var syncStateRaw: String = SyncState.synced.rawValue
 
     public init(
         previewID: UUID = UUID(),
@@ -31,7 +42,7 @@ public final class PodcastRecord {
         releaseDate: Date? = nil,
         artworkURL: String? = nil,
         resourceURLs: [String] = [],
-        accessRaw: String = "",
+        access: Access = .private,
         syncState: SyncState = .synced
     ) {
         self.previewID = previewID
@@ -44,12 +55,17 @@ public final class PodcastRecord {
         self.releaseDate = releaseDate
         self.artworkURL = artworkURL
         self.resourceURLs = resourceURLs
-        self.accessRaw = accessRaw
+        self.accessRaw = access.rawValue
         self.syncStateRaw = syncState.rawValue
     }
 }
 
 public extension PodcastRecord {
+    var access: Access {
+        get { Access(rawValue: accessRaw) ?? .private }
+        set { accessRaw = newValue.rawValue }
+    }
+
     var syncState: SyncState {
         get { SyncState(rawValue: syncStateRaw) ?? .synced }
         set { syncStateRaw = newValue.rawValue }

--- a/app-core/Sources/AppCore/Persistence/PostRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/PostRecord.swift
@@ -1,0 +1,58 @@
+import Foundation
+import SwiftData
+
+/// Local representation of a user blog post.
+///
+/// `clientKey` is the stable local identity, always set before the post reaches the server.
+/// `serverID` is nil until the backend assigns an integer PostID.
+@Model
+public final class PostRecord {
+
+    public var clientKey: UUID = UUID()
+
+    public var serverID: Int?
+    public var title: String = ""
+    public var content: String = ""
+    public var stateRaw: String = ""        // PostState.rawValue ("draft" | "published")
+    public var languageRaw: String = ""     // Language.rawValue
+    public var createdAt: Date = Date.now
+    public var publishedAt: Date?
+    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    // Optional catalogue item this post is about (anchored by PreviewID).
+    public var attachmentID: UUID?
+    public var attachmentTitle: String?
+
+    public init(
+        clientKey: UUID = UUID(),
+        serverID: Int? = nil,
+        title: String = "",
+        content: String = "",
+        stateRaw: String = "",
+        languageRaw: String = "",
+        createdAt: Date = .now,
+        publishedAt: Date? = nil,
+        syncState: SyncState = .pendingCreate,
+        attachmentID: UUID? = nil,
+        attachmentTitle: String? = nil
+    ) {
+        self.clientKey = clientKey
+        self.serverID = serverID
+        self.title = title
+        self.content = content
+        self.stateRaw = stateRaw
+        self.languageRaw = languageRaw
+        self.createdAt = createdAt
+        self.publishedAt = publishedAt
+        self.syncStateRaw = syncState.rawValue
+        self.attachmentID = attachmentID
+        self.attachmentTitle = attachmentTitle
+    }
+}
+
+public extension PostRecord {
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+}

--- a/app-core/Sources/AppCore/Persistence/PostRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/PostRecord.swift
@@ -5,19 +5,27 @@ import SwiftData
 ///
 /// `clientKey` is the stable local identity, always set before the post reaches the server.
 /// `serverID` is nil until the backend assigns an integer PostID.
+///
 @Model
 public final class PostRecord {
 
     public var clientKey: UUID = UUID()
 
     public var serverID: Int?
+
     public var title: String = ""
+
     public var content: String = ""
-    public var stateRaw: String = ""        // PostState.rawValue ("draft" | "published")
-    public var languageRaw: String = ""     // Language.rawValue
+
+    var stateRaw: String = ""
+
+    var languageRaw: String = ""
+
     public var createdAt: Date = Date.now
+
     public var publishedAt: Date?
-    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    var syncStateRaw: String = SyncState.synced.rawValue
 
     // Optional catalogue item this post is about (anchored by PreviewID).
     public var attachmentID: UUID?
@@ -28,8 +36,8 @@ public final class PostRecord {
         serverID: Int? = nil,
         title: String = "",
         content: String = "",
-        stateRaw: String = "",
-        languageRaw: String = "",
+        state: PostState = .draft,
+        language: Language? = nil,
         createdAt: Date = .now,
         publishedAt: Date? = nil,
         syncState: SyncState = .pendingCreate,
@@ -40,8 +48,8 @@ public final class PostRecord {
         self.serverID = serverID
         self.title = title
         self.content = content
-        self.stateRaw = stateRaw
-        self.languageRaw = languageRaw
+        self.stateRaw = state.rawValue
+        self.languageRaw = language?.rawValue ?? ""
         self.createdAt = createdAt
         self.publishedAt = publishedAt
         self.syncStateRaw = syncState.rawValue
@@ -51,6 +59,16 @@ public final class PostRecord {
 }
 
 public extension PostRecord {
+    var state: PostState {
+        get { PostState(rawValue: stateRaw) ?? .draft }
+        set { stateRaw = newValue.rawValue }
+    }
+
+    var language: Language? {
+        get { Language(rawValue: languageRaw) }
+        set { languageRaw = newValue?.rawValue ?? "" }
+    }
+
     var syncState: SyncState {
         get { SyncState(rawValue: syncStateRaw) ?? .synced }
         set { syncStateRaw = newValue.rawValue }

--- a/app-core/Sources/AppCore/Persistence/PreviewRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/PreviewRecord.swift
@@ -12,6 +12,7 @@ import SwiftData
 /// - An **orphan** is a `PreviewRecord` with no backing per-type record (`sourceID == nil`).
 /// - `id` is the **server PreviewID** (a UUID). No `@Attribute(.unique)` — CloudKit forbids it;
 ///   uniqueness is enforced by upsert (fetch-by-identity before insert).
+///
 @Model
 public final class PreviewRecord {
 
@@ -37,12 +38,13 @@ public final class PreviewRecord {
     /// External resource URLs. Mirrors `PreviewResponse.resources` / `Preview.externalLinks`.
     public var externalLinks: [String] = []
 
-    public var accessRaw: String = ""   // Access.rawValue
+    var accessRaw: String = ""
 
     public var createdAt: Date = Date.now
+
     public var updatedAt: Date?
 
-    public var syncStateRaw: String = SyncState.synced.rawValue
+    var syncStateRaw: String = SyncState.synced.rawValue
 
     public init(
         id: UUID = UUID(),
@@ -52,7 +54,7 @@ public final class PreviewRecord {
         secondaryInfo: String? = nil,
         imageURL: String? = nil,
         externalLinks: [String] = [],
-        accessRaw: String = "",
+        access: Access = .private,
         createdAt: Date = .now,
         updatedAt: Date? = nil,
         syncState: SyncState = .synced
@@ -64,7 +66,7 @@ public final class PreviewRecord {
         self.secondaryInfo = secondaryInfo
         self.imageURL = imageURL
         self.externalLinks = externalLinks
-        self.accessRaw = accessRaw
+        self.accessRaw = access.rawValue
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.syncStateRaw = syncState.rawValue
@@ -72,6 +74,11 @@ public final class PreviewRecord {
 }
 
 public extension PreviewRecord {
+    var access: Access {
+        get { Access(rawValue: accessRaw) ?? .private }
+        set { accessRaw = newValue.rawValue }
+    }
+
     var syncState: SyncState {
         get { SyncState(rawValue: syncStateRaw) ?? .synced }
         set { syncStateRaw = newValue.rawValue }

--- a/app-core/Sources/AppCore/Persistence/PreviewRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/PreviewRecord.swift
@@ -1,0 +1,82 @@
+import Foundation
+import SwiftData
+
+/// The unified projection of every catalogue item — song, album, book, movie, podcast, playlist,
+/// or orphan — mirroring the backend `Preview`.
+///
+/// This is what drives the **heterogeneous catalogue list** (one `@Query<PreviewRecord>`, sorted +
+/// paginated) and the **note anchor**: notes attach to a catalogue item by this record's `id`
+/// (the server PreviewID). Rich, type-specific data for detail + offline authoring lives in the
+/// per-type records (`SongRecord`, `AlbumRecord`, …), linked back here by `previewID`.
+///
+/// - An **orphan** is a `PreviewRecord` with no backing per-type record (`sourceID == nil`).
+/// - `id` is the **server PreviewID** (a UUID). No `@Attribute(.unique)` — CloudKit forbids it;
+///   uniqueness is enforced by upsert (fetch-by-identity before insert).
+@Model
+public final class PreviewRecord {
+
+    /// Server PreviewID. Stable cross-type identity; what tombstones and note attachments key on.
+    public var id: UUID = UUID()
+
+    /// Category slug — `"song" | "album" | "book" | "movie" | "podcast" | "playlist"` or an
+    /// orphan/user-defined category. Mirrors `PreviewResponse.source.type`.
+    public var categoryType: String = ""
+
+    /// Int id of the backing catalogue model (Song, Book, …). `nil` for orphans and unpromoted
+    /// (promotable) items. Mirrors `Preview.parentID`.
+    public var sourceID: Int?
+
+    /// Display title. Mirrors `PreviewResponse.primaryInfo`.
+    public var primaryInfo: String = ""
+
+    /// Display subtitle. Mirrors `PreviewResponse.secondaryInfo`.
+    public var secondaryInfo: String?
+
+    public var imageURL: String?
+
+    /// External resource URLs. Mirrors `PreviewResponse.resources` / `Preview.externalLinks`.
+    public var externalLinks: [String] = []
+
+    public var accessRaw: String = ""   // Access.rawValue
+
+    public var createdAt: Date = Date.now
+    public var updatedAt: Date?
+
+    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    public init(
+        id: UUID = UUID(),
+        categoryType: String = "",
+        sourceID: Int? = nil,
+        primaryInfo: String = "",
+        secondaryInfo: String? = nil,
+        imageURL: String? = nil,
+        externalLinks: [String] = [],
+        accessRaw: String = "",
+        createdAt: Date = .now,
+        updatedAt: Date? = nil,
+        syncState: SyncState = .synced
+    ) {
+        self.id = id
+        self.categoryType = categoryType
+        self.sourceID = sourceID
+        self.primaryInfo = primaryInfo
+        self.secondaryInfo = secondaryInfo
+        self.imageURL = imageURL
+        self.externalLinks = externalLinks
+        self.accessRaw = accessRaw
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.syncStateRaw = syncState.rawValue
+    }
+}
+
+public extension PreviewRecord {
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+
+    /// An orphan has no backing per-type record.
+    var isOrphan: Bool { sourceID == nil }
+}

--- a/app-core/Sources/AppCore/Persistence/QuoteRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/QuoteRecord.swift
@@ -6,18 +6,30 @@ import SwiftData
 /// `QuoteResponse` has no server-side ID — quotes are identified on the server by `(noteID, body)`.
 /// The local `clientKey` is the stable identity; `noteServerID + body` is the dedup key when merging
 /// pull responses. Source fields are denormalised so quotes render without loading other records.
+/// 
 @Model
 public final class QuoteRecord {
 
     public var clientKey: UUID = UUID()
 
     public var body: String = ""
-    public var noteClientKey: UUID = UUID()   // links to NoteRecord.clientKey
-    public var noteServerID: UUID?            // set once the parent NoteRecord has a serverID
-    public var sourcePreviewID: UUID = UUID() // PreviewID of the quoted item
-    public var sourceTitle: String = ""       // denormalised title of the quoted item
-    public var sourceType: String?            // "song" | "book" | …
-    public var syncStateRaw: String = SyncState.synced.rawValue
+    
+    /// links to NoteRecord.clientKey/
+    public var noteClientKey: UUID = UUID()
+    
+    /// set once the parent NoteRecord has a serverID
+    public var noteServerID: UUID?
+    
+    /// PreviewID of the quoted item
+    public var sourcePreviewID: UUID = UUID()
+    
+    /// denormalised title of the quoted item
+    public var sourceTitle: String = ""
+    
+    /// "song" | "book" | …
+    public var sourceType: String?
+    
+    var syncStateRaw: String = SyncState.synced.rawValue
 
     public init(
         clientKey: UUID = UUID(),

--- a/app-core/Sources/AppCore/Persistence/QuoteRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/QuoteRecord.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SwiftData
+
+/// Local representation of a text quote attached to a note.
+///
+/// `QuoteResponse` has no server-side ID — quotes are identified on the server by `(noteID, body)`.
+/// The local `clientKey` is the stable identity; `noteServerID + body` is the dedup key when merging
+/// pull responses. Source fields are denormalised so quotes render without loading other records.
+@Model
+public final class QuoteRecord {
+
+    public var clientKey: UUID = UUID()
+
+    public var body: String = ""
+    public var noteClientKey: UUID = UUID()   // links to NoteRecord.clientKey
+    public var noteServerID: UUID?            // set once the parent NoteRecord has a serverID
+    public var sourcePreviewID: UUID = UUID() // PreviewID of the quoted item
+    public var sourceTitle: String = ""       // denormalised title of the quoted item
+    public var sourceType: String?            // "song" | "book" | …
+    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    public init(
+        clientKey: UUID = UUID(),
+        body: String = "",
+        noteClientKey: UUID = UUID(),
+        noteServerID: UUID? = nil,
+        sourcePreviewID: UUID = UUID(),
+        sourceTitle: String = "",
+        sourceType: String? = nil,
+        syncState: SyncState = .synced
+    ) {
+        self.clientKey = clientKey
+        self.body = body
+        self.noteClientKey = noteClientKey
+        self.noteServerID = noteServerID
+        self.sourcePreviewID = sourcePreviewID
+        self.sourceTitle = sourceTitle
+        self.sourceType = sourceType
+        self.syncStateRaw = syncState.rawValue
+    }
+}
+
+public extension QuoteRecord {
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+}

--- a/app-core/Sources/AppCore/Persistence/SongRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/SongRecord.swift
@@ -1,0 +1,58 @@
+import Foundation
+import SwiftData
+
+/// Rich, typed data for a song — for the detail screen and offline authoring.
+/// Linked to its `PreviewRecord` by `previewID` (a plain UUID link, not a `@Relationship`, so
+/// CloudKit mirroring stays trivial). Mirrors the backend `Song` / `SongResponse`.
+@Model
+public final class SongRecord {
+
+    /// Links to `PreviewRecord.id` (the server PreviewID).
+    public var previewID: UUID = UUID()
+
+    /// Backing `SongID`. `nil` until the backend assigns one (offline-created songs).
+    public var sourceID: Int?
+
+    public var title: String = ""
+    public var artist: String = ""
+    public var album: String?
+    public var genre: String?
+    public var releaseDate: Date?
+    public var artworkURL: String?
+    public var resourceURLs: [String] = []
+    public var accessRaw: String = ""   // Access.rawValue
+    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    public init(
+        previewID: UUID = UUID(),
+        sourceID: Int? = nil,
+        title: String = "",
+        artist: String = "",
+        album: String? = nil,
+        genre: String? = nil,
+        releaseDate: Date? = nil,
+        artworkURL: String? = nil,
+        resourceURLs: [String] = [],
+        accessRaw: String = "",
+        syncState: SyncState = .synced
+    ) {
+        self.previewID = previewID
+        self.sourceID = sourceID
+        self.title = title
+        self.artist = artist
+        self.album = album
+        self.genre = genre
+        self.releaseDate = releaseDate
+        self.artworkURL = artworkURL
+        self.resourceURLs = resourceURLs
+        self.accessRaw = accessRaw
+        self.syncStateRaw = syncState.rawValue
+    }
+}
+
+public extension SongRecord {
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+}

--- a/app-core/Sources/AppCore/Persistence/SongRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/SongRecord.swift
@@ -4,6 +4,7 @@ import SwiftData
 /// Rich, typed data for a song — for the detail screen and offline authoring.
 /// Linked to its `PreviewRecord` by `previewID` (a plain UUID link, not a `@Relationship`, so
 /// CloudKit mirroring stays trivial). Mirrors the backend `Song` / `SongResponse`.
+///
 @Model
 public final class SongRecord {
 
@@ -14,14 +15,22 @@ public final class SongRecord {
     public var sourceID: Int?
 
     public var title: String = ""
+
     public var artist: String = ""
+
     public var album: String?
+
     public var genre: String?
+
     public var releaseDate: Date?
+
     public var artworkURL: String?
+
     public var resourceURLs: [String] = []
-    public var accessRaw: String = ""   // Access.rawValue
-    public var syncStateRaw: String = SyncState.synced.rawValue
+
+    var accessRaw: String = ""
+
+    var syncStateRaw: String = SyncState.synced.rawValue
 
     public init(
         previewID: UUID = UUID(),
@@ -33,7 +42,7 @@ public final class SongRecord {
         releaseDate: Date? = nil,
         artworkURL: String? = nil,
         resourceURLs: [String] = [],
-        accessRaw: String = "",
+        access: Access = .private,
         syncState: SyncState = .synced
     ) {
         self.previewID = previewID
@@ -45,12 +54,17 @@ public final class SongRecord {
         self.releaseDate = releaseDate
         self.artworkURL = artworkURL
         self.resourceURLs = resourceURLs
-        self.accessRaw = accessRaw
+        self.accessRaw = access.rawValue
         self.syncStateRaw = syncState.rawValue
     }
 }
 
 public extension SongRecord {
+    var access: Access {
+        get { Access(rawValue: accessRaw) ?? .private }
+        set { accessRaw = newValue.rawValue }
+    }
+
     var syncState: SyncState {
         get { SyncState(rawValue: syncStateRaw) ?? .synced }
         set { syncStateRaw = newValue.rawValue }

--- a/app-core/Sources/AppCore/Persistence/SyncState.swift
+++ b/app-core/Sources/AppCore/Persistence/SyncState.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Tracks whether a local record needs to be pushed to the backend.
+///
+/// Stored as a `String` rawValue in each `@Model` record so SwiftData can persist it without a
+/// migration when cases are added. Used fully by the Author app, set-but-ignored by Personal
+/// (CloudKit mirrors), and effectively always `.synced` in the read-only Reader app.
+public enum SyncState: String, Codable, Sendable {
+    /// Matches the server state exactly.
+    case synced
+    /// Exists locally, not yet on the server.
+    case pendingCreate
+    /// Local version differs from the server's.
+    case pendingUpdate
+    /// Deleted locally; server delete is pending.
+    case pendingDelete
+}

--- a/app-core/Sources/AppCore/Persistence/SyncState.swift
+++ b/app-core/Sources/AppCore/Persistence/SyncState.swift
@@ -5,13 +5,18 @@ import Foundation
 /// Stored as a `String` rawValue in each `@Model` record so SwiftData can persist it without a
 /// migration when cases are added. Used fully by the Author app, set-but-ignored by Personal
 /// (CloudKit mirrors), and effectively always `.synced` in the read-only Reader app.
+/// 
 public enum SyncState: String, Codable, Sendable {
+    
     /// Matches the server state exactly.
     case synced
+    
     /// Exists locally, not yet on the server.
     case pendingCreate
+    
     /// Local version differs from the server's.
     case pendingUpdate
+    
     /// Deleted locally; server delete is pending.
     case pendingDelete
 }

--- a/app-core/Sources/AppCore/Persistence/UserRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/UserRecord.swift
@@ -4,14 +4,18 @@ import SwiftData
 /// Cached profile of the currently signed-in user (Author app) or the iCloud user (Personal).
 ///
 /// Written once during sync; never has pending state — the profile is server/account-owned.
+/// 
 @Model
 public final class UserRecord {
 
     public var serverID: Int = 0
 
     public var appleID: String = ""
+    
     public var email: String?
+    
     public var firstName: String?
+    
     public var lastName: String?
 
     public init(

--- a/app-core/Sources/AppCore/Persistence/UserRecord.swift
+++ b/app-core/Sources/AppCore/Persistence/UserRecord.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftData
+
+/// Cached profile of the currently signed-in user (Author app) or the iCloud user (Personal).
+///
+/// Written once during sync; never has pending state — the profile is server/account-owned.
+@Model
+public final class UserRecord {
+
+    public var serverID: Int = 0
+
+    public var appleID: String = ""
+    public var email: String?
+    public var firstName: String?
+    public var lastName: String?
+
+    public init(
+        serverID: Int = 0,
+        appleID: String = "",
+        email: String? = nil,
+        firstName: String? = nil,
+        lastName: String? = nil
+    ) {
+        self.serverID = serverID
+        self.appleID = appleID
+        self.email = email
+        self.firstName = firstName
+        self.lastName = lastName
+    }
+}

--- a/tmbr-app/tmbr-app.xcodeproj/project.pbxproj
+++ b/tmbr-app/tmbr-app.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		E2497B602FE1302F00D1B325 /* AppCore in Frameworks */ = {isa = PBXBuildFile; productRef = E2497B5F2FE1302F00D1B325 /* AppCore */; };
 		E27B48712FC58690006866D7 /* TmbrCore in Frameworks */ = {isa = PBXBuildFile; productRef = E27B48722FC58690006866D7 /* TmbrCore */; };
 		E27C0B542FC5FE480055C952 /* ApiKit in Frameworks */ = {isa = PBXBuildFile; productRef = E27C0B532FC5FE480055C952 /* ApiKit */; };
+		E2497B602FE1302F00D1B325 /* AppCore in Frameworks */ = {isa = PBXBuildFile; productRef = E2497B5F2FE1302F00D1B325 /* AppCore */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,9 +74,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E2497B602FE1302F00D1B325 /* AppCore in Frameworks */,
 				E27C0B542FC5FE480055C952 /* ApiKit in Frameworks */,
 				E27B48712FC58690006866D7 /* TmbrCore in Frameworks */,
+				E2497B602FE1302F00D1B325 /* AppCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -245,7 +245,7 @@
 			packageReferences = (
 				E27B48702FC58689006866D7 /* XCLocalSwiftPackageReference "../tmbr-core" */,
 				E27C0B512FC5FE100055C952 /* XCLocalSwiftPackageReference "../api-kit" */,
-				E2497B5E2FE1302F00D1B325 /* XCLocalSwiftPackageReference "AppCore" */,
+				E2497BB72FE13F5400D1B325 /* XCLocalSwiftPackageReference "../app-core" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E27B47892FC4E864006866D7 /* Products */;
@@ -671,9 +671,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		E2497B5E2FE1302F00D1B325 /* XCLocalSwiftPackageReference "AppCore" */ = {
+		E2497BB72FE13F5400D1B325 /* XCLocalSwiftPackageReference "../app-core" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = AppCore;
+			relativePath = "../app-core";
 		};
 		E27B48702FC58689006866D7 /* XCLocalSwiftPackageReference "../tmbr-core" */ = {
 			isa = XCLocalSwiftPackageReference;
@@ -688,6 +688,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		E2497B5F2FE1302F00D1B325 /* AppCore */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = E2497BB72FE13F5400D1B325 /* XCLocalSwiftPackageReference "../app-core" */;
 			productName = AppCore;
 		};
 		E27B48722FC58690006866D7 /* TmbrCore */ = {

--- a/tmbr-app/tmbr-app.xcodeproj/project.pbxproj
+++ b/tmbr-app/tmbr-app.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E2497B602FE1302F00D1B325 /* AppCore in Frameworks */ = {isa = PBXBuildFile; productRef = E2497B5F2FE1302F00D1B325 /* AppCore */; };
 		E27B48712FC58690006866D7 /* TmbrCore in Frameworks */ = {isa = PBXBuildFile; productRef = E27B48722FC58690006866D7 /* TmbrCore */; };
 		E27C0B542FC5FE480055C952 /* ApiKit in Frameworks */ = {isa = PBXBuildFile; productRef = E27C0B532FC5FE480055C952 /* ApiKit */; };
 /* End PBXBuildFile section */
@@ -73,6 +74,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E2497B602FE1302F00D1B325 /* AppCore in Frameworks */,
 				E27C0B542FC5FE480055C952 /* ApiKit in Frameworks */,
 				E27B48712FC58690006866D7 /* TmbrCore in Frameworks */,
 			);
@@ -156,6 +158,7 @@
 			packageProductDependencies = (
 				E27B48722FC58690006866D7 /* TmbrCore */,
 				E27C0B532FC5FE480055C952 /* ApiKit */,
+				E2497B5F2FE1302F00D1B325 /* AppCore */,
 			);
 			productName = tmbr;
 			productReference = E27B47882FC4E864006866D7 /* tmbr.app */;
@@ -242,6 +245,7 @@
 			packageReferences = (
 				E27B48702FC58689006866D7 /* XCLocalSwiftPackageReference "../tmbr-core" */,
 				E27C0B512FC5FE100055C952 /* XCLocalSwiftPackageReference "../api-kit" */,
+				E2497B5E2FE1302F00D1B325 /* XCLocalSwiftPackageReference "AppCore" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = E27B47892FC4E864006866D7 /* Products */;
@@ -667,6 +671,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
+		E2497B5E2FE1302F00D1B325 /* XCLocalSwiftPackageReference "AppCore" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = AppCore;
+		};
 		E27B48702FC58689006866D7 /* XCLocalSwiftPackageReference "../tmbr-core" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "../tmbr-core";
@@ -678,6 +686,10 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		E2497B5F2FE1302F00D1B325 /* AppCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AppCore;
+		};
 		E27B48722FC58690006866D7 /* TmbrCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E27B48702FC58689006866D7 /* XCLocalSwiftPackageReference "../tmbr-core" */;

--- a/tmbr-web/Sources/App/Modules/Previews/Routes/Web/PreviewViewModel.swift
+++ b/tmbr-web/Sources/App/Modules/Previews/Routes/Web/PreviewViewModel.swift
@@ -23,7 +23,7 @@ struct PreviewViewModel: Encodable, Sendable {
         } else {
             href = "/catalogue/item/\(preview.id!)"
         }
-        created = (preview.createdAt ?? .now).formatted(.publishDate)
+        created = (preview.createdAt).formatted(.publishDate)
         self.isNoteMatch = isNoteMatch
     }
 }

--- a/tmbr.xcworkspace/contents.xcworkspacedata
+++ b/tmbr.xcworkspace/contents.xcworkspacedata
@@ -11,6 +11,9 @@
       location = "container:api-kit">
    </FileRef>
    <FileRef
+      location = "container:app-core">
+   </FileRef>
+   <FileRef
       location = "container:tmbr-web">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
First chunk of the native app restructure (App-PR-1): the shared **`AppCore`** local SPM package and its **normalized SwiftData schema**. Schema only — no networking, no app targets yet.

## What's here
`tmbr-app/AppCore/` — a local package (depends only on `TmbrCore`) that all three apps (Author / Reader / Personal) will share. **`AppCore` imports neither networking nor CloudKit** — per-app sync is injected at the app layer.

Normalized schema mirroring the backend (so Author + Personal can author catalogue items offline; Reader caches):
- **`PreviewRecord`** — the unified projection (mirrors backend `Preview`), keyed by the server **PreviewID**. Drives the heterogeneous catalogue list via one `@Query`, and anchors notes.
- **Per-type records** — `SongRecord`, `AlbumRecord`, `BookRecord`, `MovieRecord`, `PodcastRecord`, `PlaylistRecord` — rich typed fields for detail + offline authoring, linked to their Preview by `previewID` (a UUID link, **not** a `@Relationship` — matches backend `preview_id`, keeps CloudKit mirroring trivial).
- **`ContainerEntryRecord`** — album/playlist track ordering (mirrors backend `ContainerEntry`).
- `NoteRecord` / `PostRecord` / `QuoteRecord` / `UserRecord`, anchored by UUID.
- **`AppSchema.models`** — the single shared model list each app turns into its own `ModelContainer`.

## CloudKit-safe (for the Personal app, later)
No `@Attribute(.unique)` (uniqueness via upsert), every attribute optional-or-defaulted, links by UUID rather than `@Relationship`.

## Verification
- `swift build` (AppCore) ✓

Design rationale: `.claude/docs/native-apps-architecture.md` (merged in #190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)