### PR TITLE
core-api: networking redesign + per-endpoint sync requests

### DIFF
--- a/core-api/Sources/CoreApi/HTTP/BasicRequest.swift
+++ b/core-api/Sources/CoreApi/HTTP/BasicRequest.swift
@@ -1,21 +1,32 @@
 import Foundation
 
+/// The default `Request`: a URL plus two closures — one that builds the `URLRequest`, one that decodes
+/// the `Output`. Both own their coding (a `JSONEncoder`/`JSONDecoder` or `QueryItemEncoder` created
+/// inside the closure), so the request stays `Sendable` without storing a non-`Sendable` coder.
 public struct BasicRequest<Input: Sendable, Response: Decodable & Sendable>: Request {
 
     private let url: URL
-    
-    private let build: @Sendable (URL, Input, String?, JSONEncoder) throws -> URLRequest
+
+    private let build: @Sendable (_ url: URL, _ input: Input, _ token: String?) throws -> URLRequest
+
+    private let decode: @Sendable (_ data: Data) throws -> Response
 
     public init(
         url: URL,
-        build: @escaping @Sendable (URL, Input, String?, JSONEncoder) throws -> URLRequest
+        build: @escaping @Sendable (_ url: URL, _ input: Input, _ token: String?) throws -> URLRequest,
+        decode: @escaping @Sendable (_ data: Data) throws -> Response = { try JSONDecoder().decode(Response.self, from: $0) }
     ) {
         self.url = url
         self.build = build
+        self.decode = decode
     }
 
-    public func makeRequest(from input: Input, token: String?, using encoder: JSONEncoder) throws -> URLRequest {
-        try build(url, input, token, encoder)
+    public func makeRequest(from input: Input, token: String?) throws -> URLRequest {
+        try build(url, input, token)
+    }
+
+    public func parseResponse(_ data: Data) throws -> Response {
+        try decode(data)
     }
 }
 
@@ -24,7 +35,7 @@ public struct BasicRequest<Input: Sendable, Response: Decodable & Sendable>: Req
 public extension BasicRequest where Input == Void {
 
     static func get(baseURL: URL, path: String) -> Self {
-        BasicRequest(url: baseURL.appending(path: path)) { url, _, token, _ in
+        BasicRequest(url: baseURL.appending(path: path)) { url, _, token in
             var req = URLRequest(url: url)
             req.httpMethod = HTTPMethod.get.rawValue
             if let token { req.addHeader(.authorization.bearer(token)) }
@@ -33,7 +44,7 @@ public extension BasicRequest where Input == Void {
     }
 
     static func delete(baseURL: URL, path: String) -> Self {
-        BasicRequest(url: baseURL.appending(path: path)) { url, _, token, _ in
+        BasicRequest(url: baseURL.appending(path: path)) { url, _, token in
             var req = URLRequest(url: url)
             req.httpMethod = HTTPMethod.delete.rawValue
             if let token { req.addHeader(.authorization.bearer(token)) }
@@ -47,40 +58,19 @@ public extension BasicRequest where Input == Void {
 public extension BasicRequest where Input: Encodable {
 
     static func post(baseURL: URL, path: String) -> Self {
-        BasicRequest(url: baseURL.appending(path: path)) { url, body, token, encoder in
-            var req = URLRequest(url: url)
-            req.httpMethod = HTTPMethod.post.rawValue
-            req.addHeader(.contentType.json)
-            req.httpBody = try encoder.encode(body)
-            if let token { req.addHeader(.authorization.bearer(token)) }
-            return req
-        }
+        body(baseURL: baseURL, path: path, method: .post)
     }
 
     static func put(baseURL: URL, path: String) -> Self {
-        BasicRequest(url: baseURL.appending(path: path)) { url, body, token, encoder in
-            var req = URLRequest(url: url)
-            req.httpMethod = HTTPMethod.put.rawValue
-            req.addHeader(.contentType.json)
-            req.httpBody = try encoder.encode(body)
-            if let token { req.addHeader(.authorization.bearer(token)) }
-            return req
-        }
+        body(baseURL: baseURL, path: path, method: .put)
     }
 
     static func patch(baseURL: URL, path: String) -> Self {
-        BasicRequest(url: baseURL.appending(path: path)) { url, body, token, encoder in
-            var req = URLRequest(url: url)
-            req.httpMethod = HTTPMethod.patch.rawValue
-            req.addHeader(.contentType.json)
-            req.httpBody = try encoder.encode(body)
-            if let token { req.addHeader(.authorization.bearer(token)) }
-            return req
-        }
+        body(baseURL: baseURL, path: path, method: .patch)
     }
 
     static func query(baseURL: URL, path: String) -> Self {
-        BasicRequest(url: baseURL.appending(path: path)) { url, params, token, _ in
+        BasicRequest(url: baseURL.appending(path: path)) { url, params, token in
             guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
                 throw URLBuildingError.invalidURL(url)
             }
@@ -90,6 +80,17 @@ public extension BasicRequest where Input: Encodable {
             }
             var req = URLRequest(url: finalURL)
             req.httpMethod = HTTPMethod.get.rawValue
+            if let token { req.addHeader(.authorization.bearer(token)) }
+            return req
+        }
+    }
+
+    private static func body(baseURL: URL, path: String, method: HTTPMethod) -> Self {
+        BasicRequest(url: baseURL.appending(path: path)) { url, body, token in
+            var req = URLRequest(url: url)
+            req.httpMethod = method.rawValue
+            req.addHeader(.contentType.json)
+            req.httpBody = try JSONEncoder().encode(body)
             if let token { req.addHeader(.authorization.bearer(token)) }
             return req
         }

--- a/core-api/Sources/CoreApi/HTTP/QueryItemEncoder.swift
+++ b/core-api/Sources/CoreApi/HTTP/QueryItemEncoder.swift
@@ -11,6 +11,13 @@ public struct QueryItemEncoder {
     }
 }
 
+// MARK: - Date formatting
+
+/// Dates in query parameters are serialized as ISO 8601 with fractional seconds to match the backend's
+/// URL-encoded-form date decoder (`.withInternetDateTime, .withFractionalSeconds`). Without this a
+/// `Date` would fall through `Encodable` and serialize as a bare `Double`, which the server rejects.
+private let queryDateStyle = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+
 // MARK: - Internal encoder
 
 private final class _Storage {
@@ -72,6 +79,10 @@ private struct _KeyedContainer<Key: CodingKey>: KeyedEncodingContainerProtocol {
     mutating func encode(_ value: UInt64, forKey key: Key) throws { storage.append(name: key.stringValue, value: "\(value)") }
 
     mutating func encode<T: Encodable>(_ value: T, forKey key: Key) throws {
+        if let date = value as? Date {
+            storage.append(name: key.stringValue, value: date.formatted(queryDateStyle))
+            return
+        }
         let sub = _Encoder(codingPath: codingPath + [key], storage: storage)
         try value.encode(to: sub)
     }
@@ -115,6 +126,11 @@ private struct _UnkeyedContainer: UnkeyedEncodingContainer {
     mutating func encode(_ value: UInt64) throws { storage.append(name: name, value: "\(value)"); count += 1 }
 
     mutating func encode<T: Encodable>(_ value: T) throws {
+        if let date = value as? Date {
+            storage.append(name: name, value: date.formatted(queryDateStyle))
+            count += 1
+            return
+        }
         let sub = _Encoder(codingPath: codingPath, storage: storage)
         try value.encode(to: sub)
         count += 1
@@ -159,6 +175,10 @@ private struct _SingleValueContainer: SingleValueEncodingContainer {
     mutating func encode(_ value: UInt64) throws { storage.append(name: key, value: "\(value)") }
 
     mutating func encode<T: Encodable>(_ value: T) throws {
+        if let date = value as? Date {
+            storage.append(name: key, value: date.formatted(queryDateStyle))
+            return
+        }
         let sub = _Encoder(codingPath: codingPath, storage: storage)
         try value.encode(to: sub)
     }

--- a/core-api/Sources/CoreApi/HTTP/Request.swift
+++ b/core-api/Sources/CoreApi/HTTP/Request.swift
@@ -1,36 +1,30 @@
 import Foundation
 
+/// A single typed endpoint: how to turn an `Input` into a `URLRequest`, and how to decode its `Output`.
+///
+/// A request owns its own encoding/decoding — the loader is coding-agnostic. Conformers bake whatever
+/// `JSONEncoder`/`JSONDecoder` (or query encoder) they need into `makeRequest`/`parseResponse`.
 public protocol Request: Sendable {
 
     associatedtype Input: Sendable
 
     associatedtype Response: Decodable & Sendable
 
-    func makeRequest(from input: Input, token: String?, using encoder: JSONEncoder) throws -> URLRequest
+    func makeRequest(from input: Input, token: String?) throws -> URLRequest
 
-    func parseResponse(_ data: Data, using decoder: JSONDecoder) throws -> Response
+    func parseResponse(_ data: Data) throws -> Response
 }
 
 public extension Request {
 
-    func makeRequest(from input: Input, using encoder: JSONEncoder) throws -> URLRequest {
-        try makeRequest(from: input, token: nil, using: encoder)
-    }
-
-    func parseResponse(
-        _ data: Data,
-        using decoder: JSONDecoder = JSONDecoder()
-    ) throws -> Response {
-        try decoder.decode(Response.self, from: data)
+    func makeRequest(from input: Input) throws -> URLRequest {
+        try makeRequest(from: input, token: nil)
     }
 }
 
 public extension Request where Input == Void {
 
-    func makeRequest(
-        token: String? = nil,
-        using encoder: JSONEncoder = JSONEncoder()
-    ) throws -> URLRequest {
-        try makeRequest(from: (), token: token, using: encoder)
+    func makeRequest(token: String? = nil) throws -> URLRequest {
+        try makeRequest(from: (), token: token)
     }
 }

--- a/core-api/Sources/CoreApi/HTTP/RequestLoader.swift
+++ b/core-api/Sources/CoreApi/HTTP/RequestLoader.swift
@@ -1,68 +1,65 @@
 import Foundation
 
-public final class RequestLoader<R: Request>: Sendable {
-    
-    private let request: R
-    
-    private let session: URLSession
-    
-    private let auth: AuthProvider?
-    
-    private let decoder: JSONDecoder
-    
-    private let encoder: JSONEncoder
+/// A thin wrapper around a single `load(from:)` closure that turns a request's `Input` into its `Response`.
+///
+/// The loader holds no coding state — a `Request` owns that. Build one from a `Request` with the
+/// convenience inits below (auth-refreshing or plain), or hand it any closure for tests/composition.
+public struct RequestLoader<R: Request>: Sendable {
 
-    public init(
-        request: R,
-        session: URLSession = .shared,
-        auth: AuthProvider? = nil,
-        decoder: JSONDecoder = JSONDecoder(),
-        encoder: JSONEncoder = JSONEncoder()
-    ) {
-        self.request = request
-        self.session = session
-        self.auth = auth
-        self.decoder = decoder
-        self.encoder = encoder
+    private let _load: @Sendable (R.Input) async throws -> R.Response
+
+    public init(_ load: @escaping @Sendable (R.Input) async throws -> R.Response) {
+        self._load = load
     }
 
     public func load(from input: R.Input) async throws -> R.Response {
-        let token = await auth?.value
-        let urlRequest = try request.makeRequest(
-            from: input,
-            token: token,
-            using: encoder
-        )
-        do {
-            return try await execute(urlRequest)
-        } catch {
-            if let reqError = error as? RequestError,
-               case .httpError(let statusCode, _) = reqError,
-               statusCode == 401,
-               let auth {
-                let fresh = try await auth.refreshedToken()
-                let retryRequest = try request.makeRequest(
-                    from: input,
-                    token: fresh,
-                    using: encoder
-                )
-                return try await execute(retryRequest)
-            }
-            throw error
-        }
-    }
-
-    private func execute(_ urlRequest: URLRequest) async throws -> R.Response {
-        let (data, response) = try await session.data(for: urlRequest)
-        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
-            throw RequestError.httpError(statusCode: httpResponse.statusCode, data: data)
-        }
-        return try request.parseResponse(data, using: decoder)
+        try await _load(input)
     }
 }
 
-extension RequestLoader where R.Input == Void {
-    public func load() async throws -> R.Response {
+public extension RequestLoader where R.Input == Void {
+
+    func load() async throws -> R.Response {
         try await load(from: ())
+    }
+}
+
+// MARK: - Building from a Request
+
+public extension RequestLoader {
+
+    /// Loads `request` without authentication.
+    init(request: R, session: URLSession = .shared) {
+        self.init { input in
+            try await Self.send(request, input, token: nil, session: session)
+        }
+    }
+
+    /// Loads `request` with a bearer token from `auth`, refreshing once on a 401 and retrying.
+    init(request: R, session: URLSession = .shared, auth: AuthProvider) {
+        self.init { input in
+            let token = await auth.value
+            do {
+                return try await Self.send(request, input, token: token, session: session)
+            } catch let error as RequestError {
+                guard case .httpError(401, _) = error else { throw error }
+                let fresh = try await auth.refreshedToken()
+                return try await Self.send(request, input, token: fresh, session: session)
+            }
+        }
+    }
+
+    private static func send(
+        _ request: R,
+        _ input: R.Input,
+        token: String?,
+        session: URLSession
+    ) async throws -> R.Response {
+        let urlRequest = try request.makeRequest(from: input, token: token)
+        let (data, response) = try await session.data(for: urlRequest)
+        if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+            throw RequestError.httpError(statusCode: http.statusCode, data: data)
+        }
+        return try request.parseResponse(data)
     }
 }

--- a/core-api/Sources/CoreApi/Sync/CursorQuery.swift
+++ b/core-api/Sources/CoreApi/Sync/CursorQuery.swift
@@ -1,0 +1,36 @@
+import Foundation
+import CoreTmbr
+
+/// A cursor-paginated query the `syncAll` driver can re-issue page after page.
+///
+/// Unifies `PageQuery` and `OrphanPageQuery` so a single driver walks either to completion.
+public protocol CursorQuery: Encodable & Sendable {
+    init(since: Date?, cursor: String?, limit: Int)
+}
+
+extension PageQuery: CursorQuery {}
+
+extension OrphanPageQuery: CursorQuery {
+    public init(since: Date?, cursor: String?, limit: Int) {
+        self.init(since: since, cursor: cursor, limit: limit, notes: true)
+    }
+}
+
+public extension RequestLoader where R.Input: CursorQuery {
+
+    /// Drives a paginated endpoint to completion.
+    ///
+    /// Sends `since` on the **first** page only, then follows `nextCursor` (older pages) until the
+    /// server returns `nil`.
+    func syncAll<T>(since: Date?, limit: Int = 50) async throws -> [T] where R.Response == PageResult<T> {
+        var all: [T] = []
+        var cursor: String?
+        repeat {
+            let query = R.Input(since: all.isEmpty ? since : nil, cursor: cursor, limit: limit)
+            let page = try await load(from: query)
+            all.append(contentsOf: page.items)
+            cursor = page.nextCursor
+        } while cursor != nil
+        return all
+    }
+}

--- a/core-api/Sources/CoreApi/Sync/SyncLoaders.swift
+++ b/core-api/Sources/CoreApi/Sync/SyncLoaders.swift
@@ -1,0 +1,62 @@
+import Foundation
+import CoreTmbr
+
+// Ready-to-use, auth-refreshing loaders for each sync endpoint — the loader counterpart to the
+// request factories in `SyncRequests.swift`. Drive them to completion with `.syncAll(since:)`
+// (or `.load(from:)` for the unpaginated deletions endpoint), e.g.
+//
+//     let songs = try await RequestLoader<SongsRequest>.songs(baseURL: url, auth: auth).syncAll(since: lastSync)
+
+public extension RequestLoader where R == SongsRequest {
+    static func songs(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
+        RequestLoader(request: .songQuery(baseURL: baseURL), session: session, auth: auth)
+    }
+}
+
+public extension RequestLoader where R == AlbumsRequest {
+    static func albums(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
+        RequestLoader(request: .albumQuery(baseURL: baseURL), session: session, auth: auth)
+    }
+}
+
+public extension RequestLoader where R == BooksRequest {
+    static func books(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
+        RequestLoader(request: .bookQuery(baseURL: baseURL), session: session, auth: auth)
+    }
+}
+
+public extension RequestLoader where R == MoviesRequest {
+    static func movies(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
+        RequestLoader(request: .movieQuery(baseURL: baseURL), session: session, auth: auth)
+    }
+}
+
+public extension RequestLoader where R == PodcastsRequest {
+    static func podcasts(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
+        RequestLoader(request: .podcastQuery(baseURL: baseURL), session: session, auth: auth)
+    }
+}
+
+public extension RequestLoader where R == PlaylistsRequest {
+    static func playlists(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
+        RequestLoader(request: .playlistQuery(baseURL: baseURL), session: session, auth: auth)
+    }
+}
+
+public extension RequestLoader where R == PostsRequest {
+    static func posts(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
+        RequestLoader(request: .postQuery(baseURL: baseURL), session: session, auth: auth)
+    }
+}
+
+public extension RequestLoader where R == OrphansRequest {
+    static func orphans(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
+        RequestLoader(request: .orphanQuery(baseURL: baseURL), session: session, auth: auth)
+    }
+}
+
+public extension RequestLoader where R == DeletionsRequest {
+    static func deletions(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
+        RequestLoader(request: .deletionQuery(baseURL: baseURL), session: session, auth: auth)
+    }
+}

--- a/core-api/Sources/CoreApi/Sync/SyncRequests.swift
+++ b/core-api/Sources/CoreApi/Sync/SyncRequests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import CoreTmbr
+
+// Per-endpoint query requests for native catalogue/blog sync. The request is just the query endpoint;
+// the "sync" behaviour (walking every page) lives on `RequestLoader.syncAll`. See `SyncLoaders.swift`
+// for the matching loader factories.
+//
+// Each per-type list response embeds its `.notes` and its `.preview.id`.
+
+public typealias SongsRequest = BasicRequest<PageQuery, PageResult<SongResponse>>
+public extension Request where Self == SongsRequest {
+    static func songQuery(baseURL: URL) -> Self { .query(baseURL: baseURL, path: "api/songs") }
+}
+
+public typealias AlbumsRequest = BasicRequest<PageQuery, PageResult<AlbumResponse>>
+public extension Request where Self == AlbumsRequest {
+    static func albumQuery(baseURL: URL) -> Self { .query(baseURL: baseURL, path: "api/albums") }
+}
+
+public typealias BooksRequest = BasicRequest<PageQuery, PageResult<BookResponse>>
+public extension Request where Self == BooksRequest {
+    static func bookQuery(baseURL: URL) -> Self { .query(baseURL: baseURL, path: "api/books") }
+}
+
+public typealias MoviesRequest = BasicRequest<PageQuery, PageResult<MovieResponse>>
+public extension Request where Self == MoviesRequest {
+    static func movieQuery(baseURL: URL) -> Self { .query(baseURL: baseURL, path: "api/movies") }
+}
+
+public typealias PodcastsRequest = BasicRequest<PageQuery, PageResult<PodcastResponse>>
+public extension Request where Self == PodcastsRequest {
+    static func podcastQuery(baseURL: URL) -> Self { .query(baseURL: baseURL, path: "api/podcasts") }
+}
+
+public typealias PlaylistsRequest = BasicRequest<PageQuery, PageResult<PlaylistResponse>>
+public extension Request where Self == PlaylistsRequest {
+    static func playlistQuery(baseURL: URL) -> Self { .query(baseURL: baseURL, path: "api/playlists") }
+}
+
+public typealias PostsRequest = BasicRequest<PageQuery, PageResult<PostResponse>>
+public extension Request where Self == PostsRequest {
+    static func postQuery(baseURL: URL) -> Self { .query(baseURL: baseURL, path: "api/posts") }
+}
+
+/// Orphans are sent with `?notes=true` so each orphan carries its embedded notes.
+public typealias OrphansRequest = BasicRequest<OrphanPageQuery, PageResult<PreviewResponse>>
+public extension Request where Self == OrphansRequest {
+    static func orphanQuery(baseURL: URL) -> Self { .query(baseURL: baseURL, path: "api/catalogue/orphans") }
+}
+
+/// Deletion tombstones — sparse, unpaginated; always queried since the last sync.
+public typealias DeletionsRequest = BasicRequest<SinceQuery, [DeletionRecord]>
+public extension Request where Self == DeletionsRequest {
+    static func deletionQuery(baseURL: URL) -> Self { .query(baseURL: baseURL, path: "api/sync/deletions") }
+}

--- a/core-api/Tests/CoreApiTests/BasicRequestTests.swift
+++ b/core-api/Tests/CoreApiTests/BasicRequestTests.swift
@@ -6,7 +6,7 @@ import Foundation
 struct BasicRequestNoBodyTests {
     @Test func getBuildsURL() throws {
         let req = BasicRequest<Void, Echo>.get(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: (), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: (), token: nil)
         #expect(urlRequest.url?.absoluteString == "https://test.example.com/api/things")
         #expect(urlRequest.httpMethod == "GET")
         #expect(urlRequest.httpBody == nil)
@@ -14,19 +14,19 @@ struct BasicRequestNoBodyTests {
 
     @Test func getOmitsAuthHeaderWhenTokenNil() throws {
         let req = BasicRequest<Void, Echo>.get(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: (), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: (), token: nil)
         #expect(urlRequest.value(forHTTPHeaderField: "Authorization") == nil)
     }
 
     @Test func getAttachesAuthHeaderWhenTokenPresent() throws {
         let req = BasicRequest<Void, Echo>.get(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: (), token: "abc123", using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: (), token: "abc123")
         #expect(urlRequest.value(forHTTPHeaderField: "Authorization") == "Bearer abc123")
     }
 
     @Test func deleteBuildsURL() throws {
         let req = BasicRequest<Void, Echo>.delete(baseURL: testBase, path: "/api/things/1")
-        let urlRequest = try req.makeRequest(from: (), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: (), token: nil)
         #expect(urlRequest.url?.absoluteString == "https://test.example.com/api/things/1")
         #expect(urlRequest.httpMethod == "DELETE")
     }
@@ -44,45 +44,45 @@ struct BasicRequestBodyTests {
 
     @Test func postBuildsURLAndMethod() throws {
         let req = BasicRequest<Payload, Echo>.post(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: nil)
         #expect(urlRequest.url?.absoluteString == "https://test.example.com/api/things")
         #expect(urlRequest.httpMethod == "POST")
     }
 
     @Test func postEncodesBodyAsJSON() throws {
         let req = BasicRequest<Payload, Echo>.post(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: Payload(name: "hello"), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: Payload(name: "hello"), token: nil)
         let decoded = try JSONDecoder().decode(Payload.self, from: urlRequest.httpBody!)
         #expect(decoded.name == "hello")
     }
 
     @Test func postSetsContentTypeHeader() throws {
         let req = BasicRequest<Payload, Echo>.post(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: nil)
         #expect(urlRequest.value(forHTTPHeaderField: "Content-Type") == "application/json")
     }
 
     @Test func putUsesCorrectMethod() throws {
         let req = BasicRequest<Payload, Echo>.put(baseURL: testBase, path: "/api/things/1")
-        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: nil)
         #expect(urlRequest.httpMethod == "PUT")
     }
 
     @Test func patchUsesCorrectMethod() throws {
         let req = BasicRequest<Payload, Echo>.patch(baseURL: testBase, path: "/api/things/1")
-        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: nil)
         #expect(urlRequest.httpMethod == "PATCH")
     }
 
     @Test func bodyOmitsAuthHeaderWhenTokenNil() throws {
         let req = BasicRequest<Payload, Echo>.post(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: nil)
         #expect(urlRequest.value(forHTTPHeaderField: "Authorization") == nil)
     }
 
     @Test func bodyAttachesAuthHeaderWhenTokenPresent() throws {
         let req = BasicRequest<Payload, Echo>.post(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: "tok", using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: Payload(name: "x"), token: "tok")
         #expect(urlRequest.value(forHTTPHeaderField: "Authorization") == "Bearer tok")
     }
 }
@@ -96,7 +96,7 @@ struct BasicRequestQueryTests {
 
     @Test func encodesQueryParams() throws {
         let req = BasicRequest<SearchParams, Echo>.query(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: SearchParams(q: "hello", page: 2), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: SearchParams(q: "hello", page: 2), token: nil)
         let components = URLComponents(url: urlRequest.url!, resolvingAgainstBaseURL: false)
         let items = components?.queryItems ?? []
         #expect(items.contains(URLQueryItem(name: "q", value: "hello")))
@@ -105,19 +105,19 @@ struct BasicRequestQueryTests {
 
     @Test func queryUsesGetMethod() throws {
         let req = BasicRequest<SearchParams, Echo>.query(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: SearchParams(q: "x", page: 1), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: SearchParams(q: "x", page: 1), token: nil)
         #expect(urlRequest.httpMethod == "GET")
     }
 
     @Test func queryHasNoBody() throws {
         let req = BasicRequest<SearchParams, Echo>.query(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: SearchParams(q: "x", page: 1), token: nil, using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: SearchParams(q: "x", page: 1), token: nil)
         #expect(urlRequest.httpBody == nil)
     }
 
     @Test func queryAttachesAuthHeaderWhenTokenPresent() throws {
         let req = BasicRequest<SearchParams, Echo>.query(baseURL: testBase, path: "/api/things")
-        let urlRequest = try req.makeRequest(from: SearchParams(q: "x", page: 1), token: "tok", using: JSONEncoder())
+        let urlRequest = try req.makeRequest(from: SearchParams(q: "x", page: 1), token: "tok")
         #expect(urlRequest.value(forHTTPHeaderField: "Authorization") == "Bearer tok")
     }
 }

--- a/core-api/Tests/CoreApiTests/SyncTests.swift
+++ b/core-api/Tests/CoreApiTests/SyncTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import Foundation
+import CoreTmbr
+@testable import CoreApi
+
+@Suite("syncAll pagination driver")
+struct SyncAllTests {
+
+    // Drive `syncAll` against a stubbed loader closure — no URLSession, so the driver logic
+    // (delta `since` on page 1 only, then follow `nextCursor`) is tested in isolation.
+
+    @Test func walksEveryPageFollowingCursor() async throws {
+        let loader = RequestLoader<BasicRequest<PageQuery, PageResult<Int>>> { (query: PageQuery) in
+            if query.cursor == nil {
+                #expect(query.since != nil)         // delta cursor on the first page only
+                return PageResult(items: [1, 2], nextCursor: "c1")
+            } else {
+                #expect(query.since == nil)         // dropped on subsequent pages
+                #expect(query.cursor == "c1")
+                return PageResult(items: [3], nextCursor: nil)
+            }
+        }
+        let all: [Int] = try await loader.syncAll(since: .now)
+        #expect(all == [1, 2, 3])
+    }
+
+    @Test func orphanQueryAlwaysRequestsNotes() async throws {
+        let loader = RequestLoader<BasicRequest<OrphanPageQuery, PageResult<Int>>> { (query: OrphanPageQuery) in
+            #expect(query.notes)                    // orphans always ask for embedded notes
+            return query.cursor == nil
+                ? PageResult(items: [1], nextCursor: "c1")
+                : PageResult(items: [2], nextCursor: nil)
+        }
+        let all: [Int] = try await loader.syncAll(since: nil)
+        #expect(all == [1, 2])
+    }
+
+    @Test func stopsAfterOnePageWhenNoCursor() async throws {
+        let loader = RequestLoader<BasicRequest<PageQuery, PageResult<Int>>> { _ in
+            PageResult(items: [1], nextCursor: nil)
+        }
+        let all: [Int] = try await loader.syncAll(since: nil)
+        #expect(all == [1])
+    }
+}
+
+@Suite("Query Date encoding")
+struct QueryDateEncodingTests {
+
+    /// A `Date` query param must serialize as ISO 8601 with fractional seconds so the backend's
+    /// URL-encoded-form date decoder accepts it — not as a bare `Double`.
+    @Test func sinceRoundTripsThroughBackendParser() throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000.5)
+        let items = try QueryItemEncoder().encode(PageQuery(since: date, cursor: nil, limit: 50))
+        let sinceValue = try #require(items.first { $0.name == "since" }?.value)
+
+        #expect(sinceValue.contains("T"))      // ISO datetime, not a number
+        #expect(sinceValue.hasSuffix("Z"))
+
+        // Re-parse with the backend's exact formatter (Configuration+Content.swift).
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let parsed = try #require(formatter.date(from: sinceValue))
+        #expect(abs(parsed.timeIntervalSince(date)) < 0.001)
+    }
+}

--- a/core-tmbr/Sources/CoreTmbr/Pagination/OrphanPageQuery.swift
+++ b/core-tmbr/Sources/CoreTmbr/Pagination/OrphanPageQuery.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// `PageQuery` plus `notes=true` — the orphans endpoint embeds each orphan's notes only when asked.
+///
+/// Same cursor semantics as `PageQuery` (`since` for delta sync, `cursor` for load-more), with an
+/// extra `notes` flag the backend uses to decide whether to inline `PreviewResponse.notes`.
+public struct OrphanPageQuery: Codable, Sendable {
+
+    public let since: Date?
+
+    public let cursor: String?
+
+    public let limit: Int
+
+    public let notes: Bool
+
+    public init(
+        since: Date? = nil,
+        cursor: String? = nil,
+        limit: Int = 50,
+        notes: Bool = true
+    ) {
+        self.since = since
+        self.cursor = cursor
+        self.limit = limit
+        self.notes = notes
+    }
+}

--- a/core-tmbr/Sources/CoreTmbr/Pagination/SinceQuery.swift
+++ b/core-tmbr/Sources/CoreTmbr/Pagination/SinceQuery.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Query for the deletion-tombstone endpoint — just a delta cursor.
+///
+/// Tombstones are sparse and unpaginated: the client always asks for everything deleted since the
+/// last successful sync.
+public struct SinceQuery: Codable, Sendable {
+
+    public let since: Date?
+
+    public init(since: Date? = nil) {
+        self.since = since
+    }
+}


### PR DESCRIPTION
Stacked on #193 (review/merge that first).

## What

Reshapes the half-wired `SyncAPI` / `PageLoader` scaffolding into a composable networking layer in `core-api`.

### HTTP core
- **`Request`** owns its own coding — no more `encoder`/`decoder` parameters.
- **`BasicRequest`** buries encode/decode in `@Sendable` closures (per-call coders), so it stays `Sendable` without storing a non-`Sendable` `JSONEncoder`/`JSONDecoder`.
- **`RequestLoader`** is now a `struct` wrapping a single `load(from:)` closure, with two convenience inits: plain, and auth-refreshing (401 → refresh token → retry once). `load(from:)` / `load()` preserved, so call sites are unchanged.

### Sync (`core-api/Sources/CoreApi/Sync/`)
- Per-endpoint **query requests**: `SongsRequest` + `.songQuery(baseURL:)`, … plus `orphanQuery` / `deletionQuery`.
- Matching **loader factories**: `RequestLoader<SongsRequest>.songs(baseURL:auth:)`, ….
- **`CursorQuery`** unifies `PageQuery` / `OrphanPageQuery`; **`RequestLoader.syncAll(since:)`** drives a paginated endpoint to completion (replaces `PageLoader.fetchAll`). `SinceQuery` (deletions) is intentionally **not** a `CursorQuery` — it's unpaginated.

### Fixes
- **`QueryItemEncoder`** now serializes `Date` as ISO 8601 with fractional seconds to match the backend's URL-encoded-form decoder (was a bare `Double` — silently broken).
- `OrphanPageQuery` / `SinceQuery` moved into `core-tmbr` next to `PageQuery`.

`SyncAPI` (endpoint-coupling struct) and `PageLoader` (enum of static funcs) are gone.

## Verification

`core-api` builds and **37 tests pass** (incl. the `syncAll` driver for both query types and the query-`Date` round-trip through the backend's exact parser); the `App` scheme builds via the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)