### PR TITLE
docs: align native architecture with restructure + Reader-first plan

### DIFF
--- a/.claude/docs/native-apps-architecture.md
+++ b/.claude/docs/native-apps-architecture.md
@@ -21,14 +21,19 @@ Companion: `.claude/docs/plans/offline-first-native-app.md` (the staged roadmap)
 | **Content** | The owner's *public* blog + catalogue | The owner's *full* blog + catalogue + notes | The user's *own* private catalogue + notes |
 | **Read/Write** | Read-only | Read + author | Read + author |
 | **Local store** | SwiftData as **cache** | SwiftData as **full mirror** | SwiftData as **full mirror** |
-| **Freshness** | On-demand, lazy: cache only what's viewed; conditional GET (ETag) refresh | Eager full delta sync; push-then-pull; tombstones; offline writes | CloudKit auto-mirror across the user's Apple devices |
+| **Freshness** | On-demand, lazy: cache only what's viewed; fetch+upsert on open (ETag/`304` later) | Eager full delta sync; push-then-pull; tombstones; offline writes | CloudKit auto-mirror across the user's Apple devices |
 | **Backend** | Vapor public read API (new, additive) | Vapor sync API (built) | **None** — iCloud private DB only |
 | **Auth** | None / optional | Sign in with Apple | iCloud account (implicit) |
 
 **Reader's data-flow** (the genuinely new piece): open UI → `@Query` renders cached SwiftData
-instantly → background conditional fetch (`If-None-Match` with stored ETag) → on `200`, upsert into
-SwiftData (UI refreshes); on `304`, do nothing. Detail pages are cached when first opened. There is
-**no** `syncState`, no tombstones, no push — it is a stale-while-revalidate cache, not a sync engine.
+instantly → background fetch → upsert into SwiftData (UI refreshes reactively). **Lists and detail are
+both fetched lazily on open** — only viewed items get cached. There is **no** `syncState`, no
+tombstones, no push — it is a stale-while-revalidate cache, not a sync engine.
+
+**First build (now):** Reader runs against the **existing** per-type list + orphan endpoints,
+**unauthenticated** (guests are already scoped to `access == .public`) — no new backend. ETag /
+`If-None-Match` → `304` (skip unchanged upserts) and a dedicated public read API / per-item detail JSON
+are **deferred optimizations**, layered later under the same fetch+upsert abstraction.
 
 ---
 
@@ -62,31 +67,39 @@ own iCloud. Apple-only reach for other users was explicitly judged acceptable.
 
 ### Shared core + three compositions
 
+Two repo-root SPM packages back the three app targets (renamed in the package restructure):
+
 ```
-        ┌────────────────────────── shared local SPM package ──────────────────────────┐
-        │  AppCore   (no networking, no CloudKit, no sync engine)                       │
+        ┌──────────────────────── core-app  (module CoreApp) ──────────────────────────┐
+        │  No networking, no CloudKit, no sync engine.                                  │
         │    • SwiftData @Model records + SyncState   (CloudKit-constrained schema)     │
+        │    • DTO→record upsert helpers (import CoreTmbr only, ModelContext-based)      │
         │    • @Query-driven views (Blog/Catalogue/detail/editors), capability-gated    │
         │    • @Observable models (BlogModel, CatalogueModel, per-screen detail models) │
         │    • property wrappers (@Blog, @Catalogue, @Post …), environment keys         │
         │    • write Actions (Create/Update/Delete) → SwiftData + injected requestSync() │
-        │                                                                              │
-        │  AppBackend  (api-kit requests + shared pull/push helpers)  ← Reader + Author │
+        └──────────────────────────────────────────────────────────────────────────────┘
+        ┌──────────────────────── core-api  (module CoreApi) ──────────────────────────┐
+        │  HTTP client + per-endpoint requests + RequestLoader.syncAll  ← Reader+Author │
         └──────────────────────────────────────────────────────────────────────────────┘
                   ▲                        ▲                          ▲
         ┌─────────┘            ┌───────────┘             ┌────────────┘
- ┌──────┴───────┐     ┌────────┴────────┐       ┌────────┴────────┐
- │ Reader (1)   │     │  Author (2)     │       │  Personal (3)   │
- │ CacheLoader  │     │  SyncEngine     │       │ .private CloudKit│
- │ (ETag, lazy) │     │ (delta/push/pull)│      │  ModelContainer  │
- │ plain container│   │ plain container │       │ requestSync = {} │
- │ read-only UI │     │ auth + bg sync  │       │ no networking    │
- └──────────────┘     └─────────────────┘       └──────────────────┘
+ ┌──────┴───────┐     ┌────────┴─────────┐      ┌────────┴─────────┐
+ │ Reader (1)   │     │  Author (2)      │      │  Personal (3)    │
+ │ fetch+upsert │     │  SyncEngine      │      │ .private CloudKit│
+ │ (lazy, unauth)│    │ (delta/push/pull)│      │  ModelContainer  │
+ │ plain container│   │ plain container  │      │ requestSync = {} │
+ │ read-only UI │     │ auth + bg sync   │      │ no networking    │
+ └──────────────┘     └──────────────────┘      └──────────────────┘
 ```
 
-**The invariant that makes one core serve three apps:** `AppCore` depends on **SwiftData + closures
-only** — never on `SyncEngine`, `CacheLoader`, `URLSession`, `api-kit`, or CloudKit. Each app injects
-its own composition.
+`CoreApp` + `CoreApi` are the (former) `AppCore` + `AppBackend` from the original sketch, now standalone
+root packages (`core-app`, `core-api`) sharing `core-tmbr`/`CoreTmbr` DTOs. Reader + Author link
+`CoreApi`; **Personal does not** (no networking).
+
+**The invariant that makes one core serve three apps:** `CoreApp` depends on **SwiftData + CoreTmbr DTOs
++ injected closures only** — never on `SyncEngine`, a Reader fetcher, `URLSession`, `CoreApi`, or
+CloudKit. Each app injects its own composition.
 
 ### The seam is the existing Action pattern — no new protocol
 
@@ -112,7 +125,7 @@ risky deviation from that reference.)
 
 The model owns: the observed record, the refresh `Task` lifecycle, and a `phase` enum
 (empty/loading/loaded/error — subsumes `isUpdating`, last-updated, and Reader's not-yet-cached case).
-It holds an **injected refresh strategy closure** — never ApiKit/SyncEngine/CloudKit — so `AppCore`
+It holds an **injected refresh strategy closure** — never CoreApi/SyncEngine/CloudKit — so `CoreApp`
 stays clean. Injected scoped to the detail subtree at navigation time.
 
 Access uses the full house pattern; each layer earns its place:
@@ -120,9 +133,11 @@ Access uses the full house pattern; each layer earns its place:
   for the keypath it reads) + mandated by `tmbr-app/CLAUDE.md`. ~20 lines; the pattern already
   exists twice (`@Blog`, `@Catalogue`).
 - **Refresh as an action** (`RefreshPostAction`) — **this is the three-app seam.** One env key,
-  a different body per app (Author → `syncEngine`; Reader → `cacheLoader` ETag GET; Personal →
+  a different body per app (Author → `syncEngine`; Reader → fetch-public-item + upsert; Personal →
   no-op). `EnvironmentValues` can't be generic, so use one concrete key per entity type
   (`refreshPost`, `refreshCatalogueItem`) — matching the existing "one key per action" convention.
+  The same shape repeats at list level (`refreshBlog`, `refreshCatalogue`): Reader fetches the public
+  list page + upserts; Author runs `syncAll`; Personal no-ops.
 - **Atomic controls** (phase indicator, refresh button) — built **lazily**, only when a second
   consumer appears (YAGNI, per `networking.md`'s "add on concrete need").
 
@@ -171,7 +186,7 @@ by Personal) and are unaffected by normalization:
 `syncState`/`serverID`/tombstone fields are used fully by Author, set-but-ignored by Personal, and
 effectively always-`.synced` in Reader. One shared schema across all three.
 
-**Status:** the `AppCore` package + this schema are **built and compiling** (`swift build`).
+**Status:** the `CoreApp` package + this schema are **built and compiling** (`swift build`).
 **Still to validate at runtime (before Personal ships):** that the schema round-trips to a `.private`
 CloudKit database.
 
@@ -179,39 +194,39 @@ CloudKit database.
 
 ## Project structure
 
-One local SPM package + three app targets, inside `tmbr-app/`:
+Two repo-root SPM packages (shared with the web side via `core-tmbr`) + three thin app targets:
 
 ```
+core-tmbr/                      ← module CoreTmbr — shared Codable DTOs (also used by tmbr-web)
+core-api/                       ← module CoreApi  — HTTP client + Sync/ (per-endpoint requests,
+                                   RequestLoader.syncAll); linked by Reader + Author, NOT Personal
+core-app/                       ← module CoreApp  — Persistence/, Blog/, Catalogue/, shared views,
+                                   property wrappers, environments, actions, detail models,
+                                   DTO→record upsert; SwiftData + CoreTmbr only (no networking)
 tmbr-app/
-  AppCore/                      ← local SPM package
-    Package.swift               ← products: AppCore (all 3 apps), AppBackend (Reader + Author)
-    Sources/AppCore/            ← Persistence/, Blog/, Catalogue/, shared views, property wrappers,
-                                   environments, actions, detail models, NetworkMonitor
-    Sources/AppBackend/         ← api-kit request structs; shared pull/push helpers (PageLoader)
   Author/                       ← @main, ModelContainer, SyncEngine, AuthState, background sync
-  Reader/                       ← @main, plain container, read-only UI, CacheLoader, public APIConfig
+  Reader/                       ← @main, plain container, read-only UI, fetch+upsert, public APIConfig
   Personal/                     ← @main, .private CloudKit container, CloudKit entitlement, no engine
   Configs/                      ← shared base .xcconfig + per-app overrides (bundle id, entitlements,
                                    APIBaseURL, CloudKit container id)
 ```
 
-Names are provisional. `AppKit` is avoided (clashes with Apple's framework). The `AppBackend` split
-exists so Personal carries **no** networking code; it may fold back into `AppCore` later if it proves
-to be overhead, but keeping Personal backend-free is a deliberate guard.
+The `core-api` split (formerly `AppBackend`) exists so Personal carries **no** networking code; keeping
+Personal backend-free is a deliberate guard.
 
 ---
 
 ## Backend: kept, not redesigned
 
 The branch's backend is, field-for-field, Author's backend — fully aligned, not a two-product
-compromise. Keep as-is: the `tmbr-core` pagination contract; `tmbr-web` Core pagination infra;
-per-type list endpoints; `GET /api/posts` pagination; `GET /api/catalogue/orphans?notes=true`;
-embedded-notes design; deletion tombstones; `PreviewResponse.id`; the `NoteModelMiddleware`
-`updatedAt` bump.
+compromise. Keep as-is: the `core-tmbr` pagination contract; `core-web` pagination infra; per-type list
+endpoints; `GET /api/posts` pagination; `GET /api/catalogue/orphans?notes=true`; embedded-notes design;
+deletion tombstones; `PreviewResponse.id`; the `NoteModelMiddleware` `updatedAt` bump.
 
 - **Personal needs:** nothing.
-- **Reader needs (new, additive, built later):** a *public* read API (browse/feed + detail JSON) and
-  ETag / `If-None-Match` → `304` support. Does not exist yet; does not conflict with the branch.
+- **Reader needs now:** nothing — it runs on the **existing** per-type list + orphan endpoints,
+  unauthenticated (public-only scoping below). **Reader optimization (additive, later):** a dedicated
+  public read API (browse/feed + per-item detail JSON) and ETag / `If-None-Match` → `304` support.
 
 The optional/soft auth on the list + deletions endpoints (added during the earlier guest-sync
 experiment) is **safe and reusable**, not dead weight: the previewable `query` permission scopes
@@ -220,10 +235,16 @@ never receive private data — which is exactly the access model the Reader app 
 
 ---
 
-## Deferred (designed here, not built now)
+## Build order & deferred
 
-- **Reader app**: `CacheLoader` (stale-while-revalidate, lazy detail caching), read-only UI, and its
-  backend (public read API + ETags).
+**Building now (Reader first):** the three-target split, the shared UI moved into `CoreApp`, and the
+**Reader** app's read path (lazy fetch+upsert of public lists + detail over the existing endpoints).
+Reader is the simplest *complete* app — it validates the whole stack before Author's heavier sync.
+
+**Deferred (designed here, not built now):**
+- **Reader optimization**: ETag/`304` stale-while-revalidate + a dedicated public read API (per-item
+  detail JSON). The first build refetches over the existing endpoints.
+- **Author app**: the delta `SyncEngine` (eager `syncAll` + push/pull + tombstones), auth, offline writes.
 - **Personal app**: the `.private` CloudKit container wiring and runtime mirror validation.
 - **Atomic controls** for the read/refresh detail models — added when a second consumer appears.
-- Whether `AppBackend` stays separate or folds into `AppCore`.
+- Whether `CoreApi` stays separate or folds into `CoreApp`.

--- a/.claude/docs/plans/offline-first-native-app.md
+++ b/.claude/docs/plans/offline-first-native-app.md
@@ -10,26 +10,47 @@ Each app feels fast and reliable regardless of connectivity, driven by SwiftData
 - **No spinners on launch**: the user always sees their data
 - **Author/Personal**: offline writes saved locally first; **Reader**: stale-while-revalidate cache
 
+## Current status (2026-06) — read this first
+
+The package restructure and the networking foundation are **done**, and the build order is now
+**Reader-first**. This supersedes the stale internals below:
+
+- **Packages renamed** (repo root): `tmbr-core`→`core-tmbr`/`CoreTmbr`, `api-kit`→`core-api`/`CoreApi`,
+  `app-core`→`core-app`/`CoreApp`; `tmbr-web` split into `core-web`/`CoreWeb` + `core-auth`/`CoreAuth` +
+  the `Backend` exe. The doc's `AppCore`/`AppBackend` = `CoreApp`/`CoreApi`. Read names below accordingly.
+- **Networking built** in `core-api`: `RequestLoader` loader factories (`.songs`/`.posts`/`.orphans`/
+  `.deletions`…) + `RequestLoader.syncAll(since:)` (the pagination driver) + per-endpoint `…Query`
+  requests. The `SyncAPI`/`PageLoader` code blocks below are **superseded**. `OrphanPageQuery`/`SinceQuery`
+  live in `core-tmbr`.
+- **Schema**: there is **no `CatalogueItemRecord`** — it's `PreviewRecord` (unified list driver) +
+  per-type records (`SongRecord`…) linked by `previewID`. Wherever the text below says
+  `CatalogueItemRecord`, read `PreviewRecord` (+ its typed record). See the architecture doc.
+- **Build order** (active plan): three-target split → **Reader** (lazy fetch+upsert over the *existing*
+  public endpoints, **no new backend**; ETag/`304` deferred) → Author (delta `SyncEngine` + auth) →
+  Personal (CloudKit). Stages 1–5 below describe the already-built **Author** path and remain the
+  reference/regression checklist; they are **not** the build sequence.
+
 ## Roadmap structure
 
 | Phase | App | Status |
 |---|---|---|
-| **Stages 1–5** (below) | **Author** (offline-first, backend sync) | **Built** — the original monolithic app *is* the Author app |
-| **Restructure** | Extract `AppCore`/`AppBackend`; re-home app as Author; Reader + Personal target skeletons | Next |
-| **Reader backend** | Public read API (browse/feed + detail JSON) + ETag/`304` in `tmbr-web` | Later |
-| **Reader app** | `CacheLoader` (lazy ETag cache), read-only UI | Later |
+| **Stages 1–5** (below) | **Author** (offline-first, backend sync) | **Built** — original monolithic app; reference impl |
+| **Restructure** | `core-*` package rename; `core-api` networking foundation | **Done** |
+| **Three-target split** | Author/Reader/Personal targets; shared UI → `CoreApp` | **Next** |
+| **Reader app** | lazy fetch+upsert over existing public endpoints, read-only UI | **Next** (building first) |
+| **Author app** | re-home over `CoreApp`/`CoreApi`; delta `SyncEngine` + auth + writes | Later |
 | **Personal app** | `.private` CloudKit container + runtime mirror validation | Later |
+| **Reader optimization** | public read API + ETag/`304` in the backend | Later |
 
-The **Stages 1–5 below are the Author app, already built.** They are retained as the reference
-implementation and regression checklist for the extraction. The Domain Primer and Notes Sync Design
-sections that follow are still accurate and apply to all backend-wired apps (Reader + Author).
+The Domain Primer and Notes Sync Design sections below are still accurate and apply to all backend-wired
+apps (Reader + Author).
 
 ### Seam & schema (see architecture doc for full rationale)
 
 - **Composition, not a protocol.** Write actions call an injected `requestSync` closure
   (`syncEngine.runSync()` for Author, `{}` for Personal); read/refresh uses a per-screen
-  `@Observable` detail model holding an injected refresh-strategy closure (`SyncEngine` / `CacheLoader`
-  ETag GET / no-op). `AppCore` imports no networking, no CloudKit.
+  `@Observable` detail model holding an injected refresh-strategy closure (Author `SyncEngine` / Reader
+  fetch+upsert / Personal no-op). `CoreApp` imports no networking, no CloudKit.
 - **Normalized schema mirroring the backend** (Author + Personal author catalogue items offline):
   `PreviewRecord` (unified list driver + note anchor, keyed by server PreviewID) + typed
   `SongRecord`/etc. linked by `previewID` + `ContainerEntryRecord` for tracks. CloudKit-constrained


### PR DESCRIPTION
Stacked on #194 (review/merge that first). Docs-only.

Aligns `.claude/docs/native-apps-architecture.md` (canonical) and
`.claude/docs/plans/offline-first-native-app.md` (roadmap) with the shipped package restructure and the agreed Stage 3 direction:

- **Packages**: `core-app`/`CoreApp` + `core-api`/`CoreApi` (formerly `AppCore`/`AppBackend`) as repo-root packages sharing `core-tmbr` DTOs; diagram + project-structure rewritten; package-name pass.
- **Reader**: corrected to **lazy fetch+upsert over the existing public endpoints** (lists *and* detail), unauthenticated (guests already scoped to `access == .public`). ETag/`304` + a dedicated public read API are **deferred optimizations** — no new backend needed now.
- **Build order**: Reader-first (simplest complete app), then Author (delta `SyncEngine` + auth), then Personal (CloudKit).
- **Schema**: clarified `PreviewRecord` + per-type records (no `CatalogueItemRecord`); networking = `core-api`'s `RequestLoader.syncAll` + loader factories.

The roadmap gets a "current status — read this first" banner that supersedes the stale internals; the historical Stage 1–5 reference is left intact rather than churned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)