### PR TITLE
fix: preserve AuthKit migration name in CoreAuth after package rename

### DIFF
--- a/core-auth/Sources/CoreAuth/Models/Migrations/CreateAccess.swift
+++ b/core-auth/Sources/CoreAuth/Models/Migrations/CreateAccess.swift
@@ -3,7 +3,9 @@ import Foundation
 import SQLKit
 
 public struct CreateAccess: AsyncMigration {
-    
+
+    public var name: String { "AuthKit.CreateAccess" }
+
     public init() {}
     
     public func prepare(on database: Database) async throws {


### PR DESCRIPTION
Fluent tracks migrations by module.TypeName. Renaming the AuthKit target to CoreAuth changed the registered name from AuthKit.CreateAccess to CoreAuth.CreateAccess, causing Fluent to attempt re-running the already- applied migration on startup.

Overriding `name` to return the original identifier prevents the duplicate run without touching the database.