### PR TITLE
core-api: RequestLoader<Input, Response> + Syncer + SyncGroup

### DIFF
--- a/core-api/Sources/CoreApi/HTTP/RequestLoader.swift
+++ b/core-api/Sources/CoreApi/HTTP/RequestLoader.swift
@@ -1,25 +1,27 @@
 import Foundation
+import OSLog
 
-/// A thin wrapper around a single `load(from:)` closure that turns a request's `Input` into its `Response`.
+/// A thin wrapper around a single `load(from:)` closure that turns `Input` into `Response`.
 ///
 /// The loader holds no coding state — a `Request` owns that. Build one from a `Request` with the
-/// convenience inits below (auth-refreshing or plain), or hand it any closure for tests/composition.
-public struct RequestLoader<R: Request>: Sendable {
+/// convenience inits (auth-refreshing or plain), or supply any closure directly for tests/composition.
+/// Chain `.logged()` to attach request/response logging at debug level.
+public struct RequestLoader<Input: Sendable, Response: Decodable & Sendable>: Sendable {
 
-    private let _load: @Sendable (R.Input) async throws -> R.Response
+    private let _load: @Sendable (Input) async throws -> Response
 
-    public init(_ load: @escaping @Sendable (R.Input) async throws -> R.Response) {
+    public init(_ load: @escaping @Sendable (Input) async throws -> Response) {
         self._load = load
     }
 
-    public func load(from input: R.Input) async throws -> R.Response {
+    public func load(from input: Input) async throws -> Response {
         try await _load(input)
     }
 }
 
-public extension RequestLoader where R.Input == Void {
+public extension RequestLoader where Input == Void {
 
-    func load() async throws -> R.Response {
+    func load() async throws -> Response {
         try await load(from: ())
     }
 }
@@ -29,14 +31,14 @@ public extension RequestLoader where R.Input == Void {
 public extension RequestLoader {
 
     /// Loads `request` without authentication.
-    init(request: R, session: URLSession = .shared) {
+    init<R: Request>(request: R, session: URLSession = .shared) where R.Input == Input, R.Response == Response {
         self.init { input in
             try await Self.send(request, input, token: nil, session: session)
         }
     }
 
     /// Loads `request` with a bearer token from `auth`, refreshing once on a 401 and retrying.
-    init(request: R, session: URLSession = .shared, auth: AuthProvider) {
+    init<R: Request>(request: R, session: URLSession = .shared, auth: AuthProvider) where R.Input == Input, R.Response == Response {
         self.init { input in
             let token = await auth.value
             do {
@@ -49,7 +51,7 @@ public extension RequestLoader {
         }
     }
 
-    private static func send(
+    private static func send<R: Request>(
         _ request: R,
         _ input: R.Input,
         token: String?,
@@ -62,4 +64,28 @@ public extension RequestLoader {
         }
         return try request.parseResponse(data)
     }
+}
+
+// MARK: - Logging
+
+public extension RequestLoader {
+
+    /// Returns a loader that logs the outgoing request type and decoded response at `.debug` level.
+    func logged(by logger: Logger = .networking) -> RequestLoader<Input, Response> {
+        RequestLoader { input in
+            logger.debug("→ \(String(describing: Response.self))")
+            do {
+                let response = try await self.load(from: input)
+                logger.debug("← \(String(describing: response))")
+                return response
+            } catch {
+                logger.error("✗ \(String(describing: Response.self)): \(error)")
+                throw error
+            }
+        }
+    }
+}
+
+public extension Logger {
+    static let networking = Logger(subsystem: "me.tmbr", category: "networking")
 }

--- a/core-api/Sources/CoreApi/Sync/CursorQuery.swift
+++ b/core-api/Sources/CoreApi/Sync/CursorQuery.swift
@@ -16,17 +16,17 @@ extension OrphanPageQuery: CursorQuery {
     }
 }
 
-public extension RequestLoader where R.Input: CursorQuery {
+public extension RequestLoader where Input: CursorQuery {
 
     /// Drives a paginated endpoint to completion.
     ///
     /// Sends `since` on the **first** page only, then follows `nextCursor` (older pages) until the
     /// server returns `nil`.
-    func syncAll<T>(since: Date?, limit: Int = 50) async throws -> [T] where R.Response == PageResult<T> {
+    func syncAll<T>(since: Date?, limit: Int = 50) async throws -> [T] where Response == PageResult<T> {
         var all: [T] = []
         var cursor: String?
         repeat {
-            let query = R.Input(since: all.isEmpty ? since : nil, cursor: cursor, limit: limit)
+            let query = Input(since: all.isEmpty ? since : nil, cursor: cursor, limit: limit)
             let page = try await load(from: query)
             all.append(contentsOf: page.items)
             cursor = page.nextCursor

--- a/core-api/Sources/CoreApi/Sync/SyncLoaders.swift
+++ b/core-api/Sources/CoreApi/Sync/SyncLoaders.swift
@@ -1,62 +1,124 @@
 import Foundation
 import CoreTmbr
 
-// Ready-to-use, auth-refreshing loaders for each sync endpoint — the loader counterpart to the
-// request factories in `SyncRequests.swift`. Drive them to completion with `.syncAll(since:)`
-// (or `.load(from:)` for the unpaginated deletions endpoint), e.g.
+// Loader typealiases — the `RequestLoader` counterpart to the request typealiases in `SyncRequests.swift`.
+// Each pairs with its request: `SongsRequest` ↔ `SongsLoader`, `PostsRequest` ↔ `PostsLoader`, etc.
+
+public typealias SongsLoader     = RequestLoader<PageQuery, PageResult<SongResponse>>
+public typealias AlbumsLoader    = RequestLoader<PageQuery, PageResult<AlbumResponse>>
+public typealias BooksLoader     = RequestLoader<PageQuery, PageResult<BookResponse>>
+public typealias MoviesLoader    = RequestLoader<PageQuery, PageResult<MovieResponse>>
+public typealias PodcastsLoader  = RequestLoader<PageQuery, PageResult<PodcastResponse>>
+public typealias PlaylistsLoader = RequestLoader<PageQuery, PageResult<PlaylistResponse>>
+public typealias PostsLoader     = RequestLoader<PageQuery, PageResult<PostResponse>>
+public typealias OrphansLoader   = RequestLoader<OrphanPageQuery, PageResult<PreviewResponse>>
+public typealias DeletionsLoader = RequestLoader<SinceQuery, [DeletionRecord]>
+
+// Unauthenticated loader factories — for public endpoints (Reader app).
+// Drive with `.load(from:)` and a plain `PageQuery` / `OrphanPageQuery`.
+
+public extension SongsLoader {
+    static func songs(baseURL: URL, session: URLSession = .shared) -> Self {
+        SongsLoader(request: SongsRequest.songQuery(baseURL: baseURL), session: session)
+    }
+}
+
+public extension AlbumsLoader {
+    static func albums(baseURL: URL, session: URLSession = .shared) -> Self {
+        AlbumsLoader(request: AlbumsRequest.albumQuery(baseURL: baseURL), session: session)
+    }
+}
+
+public extension BooksLoader {
+    static func books(baseURL: URL, session: URLSession = .shared) -> Self {
+        BooksLoader(request: BooksRequest.bookQuery(baseURL: baseURL), session: session)
+    }
+}
+
+public extension MoviesLoader {
+    static func movies(baseURL: URL, session: URLSession = .shared) -> Self {
+        MoviesLoader(request: MoviesRequest.movieQuery(baseURL: baseURL), session: session)
+    }
+}
+
+public extension PodcastsLoader {
+    static func podcasts(baseURL: URL, session: URLSession = .shared) -> Self {
+        PodcastsLoader(request: PodcastsRequest.podcastQuery(baseURL: baseURL), session: session)
+    }
+}
+
+public extension PlaylistsLoader {
+    static func playlists(baseURL: URL, session: URLSession = .shared) -> Self {
+        PlaylistsLoader(request: PlaylistsRequest.playlistQuery(baseURL: baseURL), session: session)
+    }
+}
+
+public extension PostsLoader {
+    static func posts(baseURL: URL, session: URLSession = .shared) -> Self {
+        PostsLoader(request: PostsRequest.postQuery(baseURL: baseURL), session: session)
+    }
+}
+
+public extension OrphansLoader {
+    static func orphans(baseURL: URL, session: URLSession = .shared) -> Self {
+        OrphansLoader(request: OrphansRequest.orphanQuery(baseURL: baseURL), session: session)
+    }
+}
+
+// Ready-to-use, auth-refreshing loader factories — drive with `.syncAll(since:)` or `.load(from:)`, e.g.
 //
-//     let songs = try await RequestLoader<SongsRequest>.songs(baseURL: url, auth: auth).syncAll(since: lastSync)
+//     let songs = try await SongsLoader.songs(baseURL: url, auth: auth).syncAll(since: lastSync)
 
-public extension RequestLoader where R == SongsRequest {
+public extension SongsLoader {
     static func songs(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
-        RequestLoader(request: .songQuery(baseURL: baseURL), session: session, auth: auth)
+        SongsLoader(request: SongsRequest.songQuery(baseURL: baseURL), session: session, auth: auth)
     }
 }
 
-public extension RequestLoader where R == AlbumsRequest {
+public extension AlbumsLoader {
     static func albums(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
-        RequestLoader(request: .albumQuery(baseURL: baseURL), session: session, auth: auth)
+        AlbumsLoader(request: AlbumsRequest.albumQuery(baseURL: baseURL), session: session, auth: auth)
     }
 }
 
-public extension RequestLoader where R == BooksRequest {
+public extension BooksLoader {
     static func books(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
-        RequestLoader(request: .bookQuery(baseURL: baseURL), session: session, auth: auth)
+        BooksLoader(request: BooksRequest.bookQuery(baseURL: baseURL), session: session, auth: auth)
     }
 }
 
-public extension RequestLoader where R == MoviesRequest {
+public extension MoviesLoader {
     static func movies(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
-        RequestLoader(request: .movieQuery(baseURL: baseURL), session: session, auth: auth)
+        MoviesLoader(request: MoviesRequest.movieQuery(baseURL: baseURL), session: session, auth: auth)
     }
 }
 
-public extension RequestLoader where R == PodcastsRequest {
+public extension PodcastsLoader {
     static func podcasts(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
-        RequestLoader(request: .podcastQuery(baseURL: baseURL), session: session, auth: auth)
+        PodcastsLoader(request: PodcastsRequest.podcastQuery(baseURL: baseURL), session: session, auth: auth)
     }
 }
 
-public extension RequestLoader where R == PlaylistsRequest {
+public extension PlaylistsLoader {
     static func playlists(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
-        RequestLoader(request: .playlistQuery(baseURL: baseURL), session: session, auth: auth)
+        PlaylistsLoader(request: PlaylistsRequest.playlistQuery(baseURL: baseURL), session: session, auth: auth)
     }
 }
 
-public extension RequestLoader where R == PostsRequest {
+public extension PostsLoader {
     static func posts(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
-        RequestLoader(request: .postQuery(baseURL: baseURL), session: session, auth: auth)
+        PostsLoader(request: PostsRequest.postQuery(baseURL: baseURL), session: session, auth: auth)
     }
 }
 
-public extension RequestLoader where R == OrphansRequest {
+public extension OrphansLoader {
     static func orphans(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
-        RequestLoader(request: .orphanQuery(baseURL: baseURL), session: session, auth: auth)
+        OrphansLoader(request: OrphansRequest.orphanQuery(baseURL: baseURL), session: session, auth: auth)
     }
 }
 
-public extension RequestLoader where R == DeletionsRequest {
+public extension DeletionsLoader {
     static func deletions(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
-        RequestLoader(request: .deletionQuery(baseURL: baseURL), session: session, auth: auth)
+        DeletionsLoader(request: DeletionsRequest.deletionQuery(baseURL: baseURL), session: session, auth: auth)
     }
 }

--- a/core-api/Sources/CoreApi/Sync/Syncer.swift
+++ b/core-api/Sources/CoreApi/Sync/Syncer.swift
@@ -1,0 +1,70 @@
+import Foundation
+import OSLog
+import CoreTmbr
+
+/// One unit of sync: fetch from a paginated endpoint, hand the items to a sink (e.g. a store
+/// upsert). Type-erased to `() async throws -> Void` so heterogeneous syncers can be grouped;
+/// `label` identifies the endpoint in diagnostics.
+public struct Syncer: Sendable {
+
+    public let label: String
+    let run: @Sendable () async throws -> Void
+
+    public init(_ label: String = "", run: @escaping @Sendable () async throws -> Void) {
+        self.label = label
+        self.run = run
+    }
+
+    /// Couples a single-page load with a sink that consumes the loaded items.
+    public init<Input, Element>(
+        _ label: String = "",
+        loader: RequestLoader<Input, PageResult<Element>>,
+        from input: Input,
+        into sink: @escaping @Sendable ([Element]) async throws -> Void
+    ) where Input: Sendable, Element: Sendable {
+        self.init(label) {
+            try await sink(loader.load(from: input).items)
+        }
+    }
+}
+
+/// Runs a collection of independent `Syncer`s concurrently with **partial-success** semantics:
+/// every syncer runs to completion regardless of others' failures; collected errors are logged by
+/// label; the first error is rethrown so callers can surface a "couldn't update" state while
+/// keeping every successfully-committed result visible.
+public struct SyncGroup: Sendable {
+
+    private let syncers: [Syncer]
+    private let logger: Logger
+
+    public init(_ syncers: [Syncer], logger: Logger = .sync) {
+        self.syncers = syncers
+        self.logger = logger
+    }
+
+    public func run() async throws {
+        let failures: [(String, any Error)] = await withTaskGroup(of: (String, (any Error))?.self) { group in
+            for syncer in syncers {
+                group.addTask {
+                    do { try await syncer.run(); return nil }
+                    catch { return (syncer.label, error) }
+                }
+            }
+            var collected: [(String, any Error)] = []
+            for await failure in group {
+                if let failure { collected.append(failure) }
+            }
+            return collected
+        }
+        for (label, error) in failures {
+            logger.error("Sync '\(label)' failed: \(error)")
+        }
+        if let (_, error) = failures.first {
+            throw error
+        }
+    }
+}
+
+public extension Logger {
+    static let sync = Logger(subsystem: "me.tmbr", category: "sync")
+}

--- a/core-api/Tests/CoreApiTests/SyncTests.swift
+++ b/core-api/Tests/CoreApiTests/SyncTests.swift
@@ -10,7 +10,7 @@ struct SyncAllTests {
     // (delta `since` on page 1 only, then follow `nextCursor`) is tested in isolation.
 
     @Test func walksEveryPageFollowingCursor() async throws {
-        let loader = RequestLoader<BasicRequest<PageQuery, PageResult<Int>>> { (query: PageQuery) in
+        let loader = RequestLoader<PageQuery, PageResult<Int>> { (query: PageQuery) in
             if query.cursor == nil {
                 #expect(query.since != nil)         // delta cursor on the first page only
                 return PageResult(items: [1, 2], nextCursor: "c1")
@@ -25,7 +25,7 @@ struct SyncAllTests {
     }
 
     @Test func orphanQueryAlwaysRequestsNotes() async throws {
-        let loader = RequestLoader<BasicRequest<OrphanPageQuery, PageResult<Int>>> { (query: OrphanPageQuery) in
+        let loader = RequestLoader<OrphanPageQuery, PageResult<Int>> { (query: OrphanPageQuery) in
             #expect(query.notes)                    // orphans always ask for embedded notes
             return query.cursor == nil
                 ? PageResult(items: [1], nextCursor: "c1")
@@ -36,11 +36,61 @@ struct SyncAllTests {
     }
 
     @Test func stopsAfterOnePageWhenNoCursor() async throws {
-        let loader = RequestLoader<BasicRequest<PageQuery, PageResult<Int>>> { _ in
+        let loader = RequestLoader<PageQuery, PageResult<Int>> { _ in
             PageResult(items: [1], nextCursor: nil)
         }
         let all: [Int] = try await loader.syncAll(since: nil)
         #expect(all == [1])
+    }
+}
+
+@Suite("SyncGroup concurrent runner")
+struct SyncGroupTests {
+
+    // Thread-safe collector — Sendable so child tasks can safely append concurrently.
+    private actor Collector {
+        var items: [String] = []
+        func append(_ item: String) { items.append(item) }
+    }
+
+    @Test func allSucceedRunsSilently() async throws {
+        let collector = Collector()
+        let group = SyncGroup([
+            Syncer("a") { await collector.append("a") },
+            Syncer("b") { await collector.append("b") },
+        ])
+        try await group.run()
+        let ran = await collector.items
+        #expect(ran.sorted() == ["a", "b"])
+    }
+
+    @Test func oneFailureLetOthersFinishThenRethrows() async throws {
+        struct Boom: Error {}
+        let collector = Collector()
+        let group = SyncGroup([
+            Syncer("ok1") { await collector.append("ok1") },
+            Syncer("bad") { throw Boom() },
+            Syncer("ok2") { await collector.append("ok2") },
+        ])
+        await #expect(throws: Boom.self) { try await group.run() }
+        let succeeded = await collector.items
+        #expect(succeeded.sorted() == ["ok1", "ok2"])  // both non-failing syncers ran
+    }
+
+    @Test func allFailRethrowsFirst() async throws {
+        struct Boom: Error { }
+        let group = SyncGroup([
+            Syncer("a") { throw Boom() },
+            Syncer("b") { throw Boom() },
+        ])
+        var didThrow = false
+        do {
+            try await group.run()
+        } catch {
+            didThrow = true
+            #expect(error is Boom)
+        }
+        #expect(didThrow)
     }
 }
 


### PR DESCRIPTION
## Summary

- **`RequestLoader<Input, Response>`** — erases the `Request` type parameter so loader identity is what it loads, not how it was built. Enables `logged(by:)` as a plain `RequestLoader → RequestLoader` transform without changing stored types. Breaking change: `RequestLoader<SongsRequest>` → `RequestLoader<PageQuery, PageResult<SongResponse>>` (callsite adaptations follow in the Catalogue PR).
- **`Syncer`** — type-erases one fetch→sink unit to `@Sendable () async throws -> Void`. Convenience init couples a `RequestLoader<Input, PageResult<Element>>` to an injected async sink (e.g. `store.upsert`), hiding per-type generics so heterogeneous endpoints can be grouped.
- **`SyncGroup`** — runs `[Syncer]` concurrently with partial-success semantics: every task runs to completion, failures are collected and logged by label, first error is rethrown. One bad endpoint never cancels peers or discards committed successes.
- **No-auth loader factories** — unauthenticated overloads for all catalogue + posts loaders (Reader is public and has no `AuthProvider`).

## Test plan

- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path core-api` — 40/40 pass including 3 new `SyncGroup` tests (all-succeed, one-fails-others-finish, all-fail-rethrows)
- [ ] Callsite compilation verified in Catalogue PR (tmbr-app adapts `RequestLoader<R>` → `RequestLoader<R.Input, R.Response>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)