### PR TITLE
tmbr-web: include tracks in album/playlist API list response

### DIFF
--- a/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/API/AlbumsAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/API/AlbumsAPIController.swift
@@ -23,10 +23,23 @@ struct AlbumsAPIController: RouteCollection {
             let input = PageInput(since: pageQuery.since, before: pageQuery.cursorDate, limit: pageQuery.limit)
             let albums = try await request.commands.albums.list(input)
             let previewIDs = albums.map { $0.$preview.id }
-            let notesByPreviewID = try await request.commands.notes.grouped(previewIDs)
+            async let notesByPreviewID = request.commands.notes.grouped(previewIDs)
+            let albumIDs = albums.compactMap(\.id)
+            let tracksByAlbumID: [AlbumID: [Preview]] = try await withThrowingTaskGroup(of: (AlbumID, [Preview]).self) { group in
+                for albumID in albumIDs {
+                    group.addTask { (albumID, try await request.commands.previews.listContainerPreviews("album", albumID)) }
+                }
+                return try await group.reduce(into: [:]) { $0[$1.0] = $1.1 }
+            }
+            let resolvedNotes = try await notesByPreviewID
             let baseURL = request.baseURL
             return PageResult(from: albums, limit: input.limit) { album in
-                AlbumResponse(album: album, notes: notesByPreviewID[album.$preview.id] ?? [], baseURL: baseURL)
+                AlbumResponse(
+                    album: album,
+                    notes: resolvedNotes[album.$preview.id] ?? [],
+                    trackPreviews: album.id.flatMap { tracksByAlbumID[$0] } ?? [],
+                    baseURL: baseURL
+                )
             }
         }
 

--- a/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/API/PlaylistsAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/API/PlaylistsAPIController.swift
@@ -16,10 +16,23 @@ struct PlaylistsAPIController: RouteCollection {
             let input = PageInput(since: pageQuery.since, before: pageQuery.cursorDate, limit: pageQuery.limit)
             let playlists = try await request.commands.playlists.list(input)
             let previewIDs = playlists.map { $0.$preview.id }
-            let notesByPreviewID = try await request.commands.notes.grouped(previewIDs)
+            async let notesByPreviewID = request.commands.notes.grouped(previewIDs)
+            let playlistIDs = playlists.compactMap(\.id)
+            let tracksByPlaylistID: [PlaylistID: [Preview]] = try await withThrowingTaskGroup(of: (PlaylistID, [Preview]).self) { group in
+                for playlistID in playlistIDs {
+                    group.addTask { (playlistID, try await request.commands.previews.listContainerPreviews("playlist", playlistID)) }
+                }
+                return try await group.reduce(into: [:]) { $0[$1.0] = $1.1 }
+            }
+            let resolvedNotes = try await notesByPreviewID
             let baseURL = request.baseURL
             return PageResult(from: playlists, limit: input.limit) { playlist in
-                PlaylistResponse(playlist: playlist, notes: notesByPreviewID[playlist.$preview.id] ?? [], baseURL: baseURL)
+                PlaylistResponse(
+                    playlist: playlist,
+                    notes: resolvedNotes[playlist.$preview.id] ?? [],
+                    trackPreviews: playlist.id.flatMap { tracksByPlaylistID[$0] } ?? [],
+                    baseURL: baseURL
+                )
             }
         }
 


### PR DESCRIPTION
## Summary

- Batch-fetches container previews for each album/playlist in parallel using `withThrowingTaskGroup`
- Populates the existing `AlbumResponse.tracks` / `PlaylistResponse.tracks` array on the list endpoints (previously always `[]`)
- Required by the native Reader app to sync and display track lists on catalogue detail views

## Test plan

- [ ] `GET /api/albums` — each album in the response includes a non-empty `tracks` array for albums that have tracks
- [ ] `GET /api/playlists` — same for playlists
- [ ] No regression on response shape for albums/playlists with zero tracks (empty array, not missing)
- [ ] Parallel fetch completes without timeout for large lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)