### PR TITLE
core-app: block-level MarkdownView for posts and notes

### DIFF
--- a/core-app/Sources/CoreApp/Blog/BlogTab.swift
+++ b/core-app/Sources/CoreApp/Blog/BlogTab.swift
@@ -39,7 +39,7 @@ struct BlogTab: View {
             .navigationDestination(for: PostRecord.self) { post in
                 PostReaderView(
                     title: post.title,
-                    content: post.markdown ?? AttributedString(post.content),
+                    content: post.content,
                     created: post.createdAt,
                     published: post.publishedAt
                 )

--- a/core-app/Sources/CoreApp/Blog/Post/PostReaderView.swift
+++ b/core-app/Sources/CoreApp/Blog/Post/PostReaderView.swift
@@ -11,26 +11,17 @@ struct PostReaderView: View {
     let published: Date?
 
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text(title)
-                        .font(.title.bold())
-                    Text((published ?? created).formatted(.publishDate))
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    MarkdownView(raw: content)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding()
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(title)
+                    .font(.title.bold())
+                Text((published ?? created).formatted(.publishDate))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                MarkdownView(raw: content)
             }
-            // Intercept fragment URLs (e.g. `#reference-1`) for in-page anchor jumps.
-            // External/internal links without a fragment fall through to the system handler.
-            .environment(\.openURL, OpenURLAction { url in
-                guard url.host == nil, let fragment = url.fragment else { return .systemAction }
-                withAnimation { proxy.scrollTo(fragment, anchor: .top) }
-                return .handled
-            })
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
         }
         .navigationTitle(title)
 #if os(iOS)

--- a/core-app/Sources/CoreApp/Blog/Post/PostReaderView.swift
+++ b/core-app/Sources/CoreApp/Blog/Post/PostReaderView.swift
@@ -11,17 +11,26 @@ struct PostReaderView: View {
     let published: Date?
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
-                Text(title)
-                    .font(.title.bold())
-                Text((published ?? created).formatted(.publishDate))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                MarkdownView(raw: content)
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(title)
+                        .font(.title.bold())
+                    Text((published ?? created).formatted(.publishDate))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    MarkdownView(raw: content)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding()
+            // Intercept fragment URLs (e.g. `#reference-1`) for in-page anchor jumps.
+            // External/internal links without a fragment fall through to the system handler.
+            .environment(\.openURL, OpenURLAction { url in
+                guard url.host == nil, let fragment = url.fragment else { return .systemAction }
+                withAnimation { proxy.scrollTo(fragment, anchor: .top) }
+                return .handled
+            })
         }
         .navigationTitle(title)
 #if os(iOS)

--- a/core-app/Sources/CoreApp/Blog/Post/PostReaderView.swift
+++ b/core-app/Sources/CoreApp/Blog/Post/PostReaderView.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
 struct PostReaderView: View {
-        
+
     let title: String
-    
-    let content: AttributedString
-        
+
+    let content: String
+
     let created: Date
-    
+
     let published: Date?
 
     var body: some View {
@@ -18,8 +18,7 @@ struct PostReaderView: View {
                 Text((published ?? created).formatted(.publishDate))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
-                Text(content)
-                    .textSelection(.enabled)
+                MarkdownView(raw: content)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding()

--- a/core-app/Sources/CoreApp/Catalogue/CatalogueItemDetailView.swift
+++ b/core-app/Sources/CoreApp/Catalogue/CatalogueItemDetailView.swift
@@ -29,8 +29,7 @@ struct CatalogueItemDetailView: View {
             if !notes.isEmpty {
                 Section("Notes") {
                     ForEach(notes) { note in
-                        Text(note.markdown ?? AttributedString(note.body))
-                            .textSelection(.enabled)
+                        MarkdownView(raw: note.body)
                     }
                 }
             }

--- a/core-app/Sources/CoreApp/Persistence/NoteRecord.swift
+++ b/core-app/Sources/CoreApp/Persistence/NoteRecord.swift
@@ -72,10 +72,6 @@ public final class NoteRecord {
 }
 
 public extension NoteRecord {
-    var markdown: AttributedString? {
-        try? AttributedString(markdown: body)
-    }
-
     var access: Access {
         get { Access(rawValue: accessRaw) ?? .private }
         set { accessRaw = newValue.rawValue }

--- a/core-app/Sources/CoreApp/Persistence/PostRecord.swift
+++ b/core-app/Sources/CoreApp/Persistence/PostRecord.swift
@@ -71,10 +71,6 @@ public extension PostRecord {
         set { languageRaw = newValue?.rawValue ?? "" }
     }
     
-    var markdown: AttributedString? {
-        try? AttributedString(markdown: content)
-    }
-
     var syncState: SyncState {
         get { SyncState(rawValue: syncStateRaw) ?? .synced }
         set { syncStateRaw = newValue.rawValue }

--- a/core-app/Sources/CoreApp/Shared/Markdown/MarkdownAttributes.swift
+++ b/core-app/Sources/CoreApp/Shared/Markdown/MarkdownAttributes.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// MARK: - Attribute keys
+
+/// Maps the web's `htmltag:` inline-attribute key to Foundation's custom attribute system.
+/// Syntax in markdown: `^[text](htmltag: sup, class: reference-id)`.
+enum HTMLTagAttribute: CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+    typealias Value = String
+    static let name = "htmltag"
+}
+
+/// Maps the web's `class:` inline-attribute key.
+enum CSSClassAttribute: CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+    typealias Value = String
+    static let name = "class"
+}
+
+/// Maps the web's `id:` inline-attribute key — marks scroll-to targets (footnote references).
+/// Syntax: `^[1: Author, Work](class: reference, id: reference-1)`.
+enum AnchorIDAttribute: CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+    typealias Value = String
+    static let name = "id"
+}
+
+// MARK: - Attribute scope
+
+extension AttributeScopes {
+    /// Combined scope used when parsing markdown. Includes our custom keys AND the standard
+    /// Foundation attributes (`presentationIntent`, `link`, `inlinePresentationIntent`, …) so
+    /// that passing this scope to `AttributedString(markdown:including:)` preserves all
+    /// standard Foundation markdown attributes alongside the custom web ones.
+    struct TmbrAttributes: AttributeScope {
+        let htmlTag: HTMLTagAttribute
+        let cssClass: CSSClassAttribute
+        let anchorID: AnchorIDAttribute
+        let foundation: AttributeScopes.FoundationAttributes
+    }
+
+    var tmbr: TmbrAttributes.Type { TmbrAttributes.self }
+}

--- a/core-app/Sources/CoreApp/Shared/Markdown/MarkdownDecorator.swift
+++ b/core-app/Sources/CoreApp/Shared/Markdown/MarkdownDecorator.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+
+/// A composable unit of Markdown run styling.
+///
+/// A `MarkdownDecorator` receives a mutable `AttributedSubstring` corresponding to one run
+/// of an `AttributedString` and applies styling — fonts, colors, or any SwiftUI/UIKit/AppKit
+/// attributed string attributes. Multiple decorators compose into one via ``init(_:)``;
+/// they run in array order, so later decorators can override earlier ones.
+///
+/// Create specific decorators with the static factory properties (`.heading`, `.link`, …)
+/// and assemble a custom set with the composing initializer:
+///
+/// ```swift
+/// let myDecorator = MarkdownDecorator([
+///     .heading, .inlineCode,
+///     MarkdownDecorator { run in
+///         if run.link != nil { run.swiftUI.foregroundColor = .purple }
+///     }
+/// ])
+/// ```
+///
+/// Inject into a view hierarchy via the `\.markdownDecorator` environment key, or the
+/// `.markdownDecorator(_:)` view modifier, to override the `\.standard` default.
+///
+/// - Note: The mutable unit is `AttributedSubstring` (`content[range]`), not
+///   `AttributedString.Runs.Run`. A `Run` is read-only — it exposes attribute values for
+///   inspection but has no mutation API. `AttributedSubstring` is both readable and writable,
+///   so a single handle both reads intents and applies styling back to the string in place.
+///
+/// - Note: Decorators run *before* `presentationIntent` is stripped from each block, so the
+///   `.heading` factory can read the header level from the intent and set the font accordingly.
+public struct MarkdownDecorator: Sendable {
+
+    private let decorate: @Sendable (inout AttributedSubstring) -> Void
+
+    public init(_ decorate: @escaping @Sendable (inout AttributedSubstring) -> Void) {
+        self.decorate = decorate
+    }
+
+    public func callAsFunction(_ run: inout AttributedSubstring) {
+        decorate(&run)
+    }
+}
+
+// MARK: - Composition
+
+public extension MarkdownDecorator {
+    /// Composes multiple decorators into one, applying them in array order.
+    /// Later decorators override earlier ones where attributes overlap.
+    init(_ decorators: [MarkdownDecorator]) {
+        self.init { run in
+            for decorator in decorators { decorator(&run) }
+        }
+    }
+}
+
+// MARK: - Standard factories
+
+public extension MarkdownDecorator {
+
+    /// Sets the heading font from the run's `presentationIntent` header level.
+    /// Must run before `presentationIntent` is stripped.
+    static let heading = MarkdownDecorator { run in
+        guard let intent = run.presentationIntent else { return }
+        for component in intent.components {
+            if case .header(let level) = component.kind {
+                run.swiftUI.font = headingFont(level)
+                return
+            }
+        }
+    }
+
+    /// Applies the accent color to link runs. Tap routing for internal `/posts/<id>` links
+    /// is out of scope for this pass — links open via the standard `openURL` environment
+    /// action, which PostReaderView intercepts for `#fragment` anchor jumps.
+    static let link = MarkdownDecorator { run in
+        guard run.link != nil else { return }
+        run.swiftUI.foregroundColor = .accentColor
+    }
+
+    /// Applies a monospaced font to inline code spans.
+    static let inlineCode = MarkdownDecorator { run in
+        guard let intent = run.inlinePresentationIntent, intent.contains(.code) else { return }
+        run.swiftUI.font = .system(.body, design: .monospaced)
+    }
+
+    /// Handles the web's generic inline-attribute convention (`htmltag:`, `class:`, `id:`).
+    /// Currently styles `htmltag: sup` as a superscript — the pattern used for footnote
+    /// markers: `^[[1](#reference-1)](class: reference-id, htmltag: sup)`.
+    ///
+    /// - Note: SwiftUI has no true superscript attribute. We approximate with `.caption` size
+    ///   and a UIKit/AppKit baseline offset. The marker will appear smaller; vertical raise
+    ///   depends on platform.
+    static let customAttributes = MarkdownDecorator { run in
+        // Read custom attrs via `runs.first` — AttributedString.Runs.Run has a documented
+        // subscript `[K.Type] -> K.Value?` that returns String? for HTMLTagAttribute.
+        guard run.runs.first?[HTMLTagAttribute.self] == "sup" else { return }
+        run.swiftUI.font = .caption
+#if canImport(UIKit)
+        run.uiKit.baselineOffset = 6
+#elseif canImport(AppKit)
+        run.appKit.baselineOffset = 4
+#endif
+    }
+
+    /// Override point for bold runs. `Text` renders bold natively via `inlinePresentationIntent`;
+    /// this factory exists so callers can override bold styling without replacing the entire set.
+    static let bold = MarkdownDecorator { _ in }
+
+    /// Override point for italic runs (same rationale as `.bold`).
+    static let italic = MarkdownDecorator { _ in }
+
+    /// Override point for strikethrough runs (same rationale as `.bold`).
+    static let strikethrough = MarkdownDecorator { _ in }
+
+    /// The standard decorator set. Applied by default to all `MarkdownView` instances.
+    static let standard = MarkdownDecorator([
+        .heading, .link, .inlineCode, .customAttributes
+    ])
+}
+
+// MARK: - Private helpers
+
+private func headingFont(_ level: Int) -> Font {
+    switch level {
+    case 1: return .title.bold()
+    case 2: return .title2.bold()
+    case 3: return .title3.bold()
+    default: return .headline
+    }
+}

--- a/core-app/Sources/CoreApp/Shared/Markdown/MarkdownEnvironment.swift
+++ b/core-app/Sources/CoreApp/Shared/Markdown/MarkdownEnvironment.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+public extension EnvironmentValues {
+    /// The decorator applied to each run of `AttributedString` in `MarkdownView`.
+    /// Override per surface (e.g. posts vs notes) with `.markdownDecorator(_:)`.
+    @Entry var markdownDecorator: MarkdownDecorator = .standard
+}
+
+public extension View {
+    /// Injects a custom `MarkdownDecorator` for all `MarkdownView` instances in this subtree.
+    func markdownDecorator(_ decorator: MarkdownDecorator) -> some View {
+        environment(\.markdownDecorator, decorator)
+    }
+}

--- a/core-app/Sources/CoreApp/Shared/Markdown/MarkdownView.swift
+++ b/core-app/Sources/CoreApp/Shared/Markdown/MarkdownView.swift
@@ -1,0 +1,203 @@
+import SwiftUI
+import Foundation
+
+/// Renders a raw Markdown string as laid-out SwiftUI blocks — headings, lists, blockquotes,
+/// code blocks, and inline formatting (bold, italic, links, code spans). Uses Foundation's
+/// `AttributedString` with `interpretedSyntax: .full`; no third-party dependency.
+///
+/// Falls back to unstyled `Text` if markdown parsing fails.
+struct MarkdownView: View {
+
+    let raw: String
+
+    private var blocks: [MarkdownBlock] { MarkdownBlock.parse(raw) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(blocks, id: \.id) { block in
+                blockView(for: block)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Block rendering
+
+    @ViewBuilder
+    private func blockView(for block: MarkdownBlock) -> some View {
+        switch block.kind {
+        case .heading(let level):
+            Text(block.content)
+                .font(headingFont(level))
+                .textSelection(.enabled)
+
+        case .paragraph:
+            Text(block.content)
+                .textSelection(.enabled)
+
+        case .listItem(let ordinal, let depth):
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(ordinal.map { "\($0)." } ?? "•")
+                    .monospacedDigit()
+                    .frame(minWidth: 16, alignment: .trailing)
+                Text(block.content)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.leading, CGFloat(depth) * 12)
+
+        case .blockQuote:
+            HStack(alignment: .top, spacing: 10) {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(.secondary.opacity(0.5))
+                    .frame(width: 3)
+                Text(block.content)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+
+        case .codeBlock:
+            Text(block.content)
+                .font(.system(.body, design: .monospaced))
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+                .textSelection(.enabled)
+        }
+    }
+
+    private func headingFont(_ level: Int) -> Font {
+        switch level {
+        case 1: return .title.bold()
+        case 2: return .title2.bold()
+        case 3: return .title3.bold()
+        default: return .headline
+        }
+    }
+}
+
+// MARK: - MarkdownBlock
+
+private struct MarkdownBlock {
+
+    let id: Int
+    let content: AttributedString
+    let kind: Kind
+
+    enum Kind {
+        case heading(level: Int)
+        case paragraph
+        case listItem(ordinal: Int?, depth: Int)
+        case blockQuote
+        case codeBlock
+    }
+
+    // MARK: Parsing
+
+    static func parse(_ raw: String) -> [MarkdownBlock] {
+        guard !raw.isEmpty else { return [] }
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .full,
+            failurePolicy: .returnPartiallyParsedIfPossible
+        )
+        guard let attributed = try? AttributedString(markdown: raw, options: options) else {
+            return [MarkdownBlock(id: 0, content: AttributedString(raw), kind: .paragraph)]
+        }
+        return grouped(attributed)
+    }
+
+    /// Groups runs by innermost block identity — each paragraph / heading / list item /
+    /// blockquote gets one `MarkdownBlock`. Multiple runs sharing the same block (e.g. bold +
+    /// normal text within one paragraph) are concatenated into a single `AttributedString`.
+    private static func grouped(_ attributed: AttributedString) -> [MarkdownBlock] {
+        struct Group {
+            let id: Int
+            var content: AttributedString
+            let intent: PresentationIntent?
+        }
+
+        var groups: [Group] = []
+        var idToIndex: [Int: Int] = [:]
+        var nextFallback = 1_000_000
+
+        for run in attributed.runs {
+            let intent = run.presentationIntent
+            let id: Int
+            if let last = intent?.components.last {
+                id = last.identity
+            } else {
+                id = nextFallback
+                nextFallback += 1
+            }
+
+            let runContent = AttributedString(attributed[run.range])
+
+            if let idx = idToIndex[id] {
+                groups[idx].content += runContent
+            } else {
+                idToIndex[id] = groups.count
+                groups.append(Group(id: id, content: runContent, intent: intent))
+            }
+        }
+
+        return groups.map { group in
+            MarkdownBlock(
+                id: group.id,
+                content: strippingBlockIntent(group.content),
+                kind: blockKind(for: group.intent)
+            )
+        }
+    }
+
+    /// Determines the block kind from the `PresentationIntent` component hierarchy
+    /// (outermost → innermost, following `components` ordering).
+    private static func blockKind(for intent: PresentationIntent?) -> Kind {
+        guard let intent else { return .paragraph }
+
+        var headingLevel: Int?
+        var isCode = false
+        var isBlockQuote = false
+        var isList = false
+        var isOrdered = false
+        var listOrdinal: Int?
+
+        for component in intent.components {
+            switch component.kind {
+            case .header(level: let level):
+                headingLevel = level
+            case .codeBlock(languageHint: _):
+                isCode = true
+            case .blockQuote:
+                isBlockQuote = true
+            case .orderedList:
+                isList = true
+                isOrdered = true
+            case .unorderedList:
+                isList = true
+            case .listItem(ordinal: let ordinal):
+                listOrdinal = ordinal
+            default:
+                break
+            }
+        }
+
+        if let level = headingLevel { return .heading(level: level) }
+        if isCode { return .codeBlock }
+        if isList { return .listItem(ordinal: isOrdered ? listOrdinal : nil, depth: intent.indentationLevel) }
+        if isBlockQuote { return .blockQuote }
+        return .paragraph
+    }
+
+    /// Removes `presentationIntent` from all runs so `Text` doesn't apply its own block layout
+    /// on top of our custom block rendering while still honouring inline attributes (bold, italic…).
+    private static func strippingBlockIntent(_ content: AttributedString) -> AttributedString {
+        var result = content
+        let ranges = Array(content.runs.compactMap { run -> Range<AttributedString.Index>? in
+            run.presentationIntent != nil ? run.range : nil
+        })
+        for range in ranges {
+            result[range].presentationIntent = nil
+        }
+        return result
+    }
+}

--- a/core-app/Sources/CoreApp/Shared/Markdown/MarkdownView.swift
+++ b/core-app/Sources/CoreApp/Shared/Markdown/MarkdownView.swift
@@ -10,9 +10,8 @@ import SwiftUI
 /// Block layout (list indentation, blockquote bar, code background) is handled at the view
 /// level; inline run styling is delegated to the `MarkdownDecorator` from the environment.
 ///
-/// For anchor jumps (`^[[1](#reference-1)](htmltag: sup)` → scroll to `#reference-1`), wrap
-/// in a `ScrollViewReader` and install a custom `openURL` action that intercepts fragment URLs.
-/// See `PostReaderView` for the wiring.
+/// **Anchor jumps:** fragment URLs (`#reference-N`) are intercepted internally and resolved
+/// via `ScrollViewProxy` against the nearest enclosing `ScrollView`. No external wiring needed.
 struct MarkdownView: View {
 
     let raw: String
@@ -22,13 +21,20 @@ struct MarkdownView: View {
     private var blocks: [MarkdownBlock] { MarkdownBlock.parse(raw) }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            ForEach(blocks, id: \.id) { block in
-                blockView(for: block)
-                    .modifier(AnchorIDModifier(anchorID: block.anchorID))
+        ScrollViewReader { proxy in
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(blocks, id: \.id) { block in
+                    blockView(for: block)
+                        .modifier(AnchorIDModifier(anchorID: block.anchorID))
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .environment(\.openURL, OpenURLAction { url in
+                guard url.host == nil, let fragment = url.fragment else { return .systemAction }
+                withAnimation { proxy.scrollTo(fragment, anchor: .top) }
+                return .handled
+            })
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Block rendering

--- a/core-app/Sources/CoreApp/Shared/Markdown/MarkdownView.swift
+++ b/core-app/Sources/CoreApp/Shared/Markdown/MarkdownView.swift
@@ -36,41 +36,15 @@ struct MarkdownView: View {
     @ViewBuilder
     private func blockView(for block: MarkdownBlock) -> some View {
         let content = decoratedAndStripped(block)
-
         switch block.kind {
         case .heading, .paragraph:
-            Text(content)
-                .textSelection(.enabled)
-
+            TextBlock(content: content)
         case .listItem(let ordinal, let depth):
-            HStack(alignment: .firstTextBaseline, spacing: 4) {
-                Text(ordinal.map { "\($0)." } ?? "•")
-                    .monospacedDigit()
-                    .frame(minWidth: 16, alignment: .trailing)
-                
-                Text(content)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .padding(.leading, CGFloat(depth) * 12)
-
+            ListItemBlock(content: content, ordinal: ordinal, depth: depth)
         case .blockQuote:
-            HStack(alignment: .top, spacing: 10) {
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(.secondary.opacity(0.5))
-                    .frame(width: 3)
-                Text(content)
-                    .foregroundStyle(.secondary)
-                    .textSelection(.enabled)
-            }
-
+            QuoteBlock(content: content)
         case .codeBlock:
-            Text(content)
-                .font(.system(.body, design: .monospaced))
-                .padding(10)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
-                .textSelection(.enabled)
+            CodeBlock(content: content)
         }
     }
 
@@ -104,6 +78,60 @@ private struct AnchorIDModifier: ViewModifier {
         }
     }
 }
+
+// MARK: - Block views
+
+private struct TextBlock: View {
+    let content: AttributedString
+    var body: some View {
+        Text(content)
+            .textSelection(.enabled)
+    }
+}
+
+private struct ListItemBlock: View {
+    let content: AttributedString
+    let ordinal: Int?
+    let depth: Int
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 4) {
+            Text(ordinal.map { "\($0)." } ?? "•")
+                .monospacedDigit()
+                .frame(minWidth: 16, alignment: .trailing)
+            Text(content)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.leading, CGFloat(depth) * 12)
+    }
+}
+
+private struct QuoteBlock: View {
+    let content: AttributedString
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(.secondary.opacity(0.5))
+                .frame(width: 3)
+            Text(content)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+        }
+    }
+}
+
+private struct CodeBlock: View {
+    let content: AttributedString
+    var body: some View {
+        Text(content)
+            .font(.system(.body, design: .monospaced))
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 6))
+            .textSelection(.enabled)
+    }
+}
+
 
 // MARK: - MarkdownBlock
 

--- a/core-app/Sources/CoreApp/Shared/Markdown/MarkdownView.swift
+++ b/core-app/Sources/CoreApp/Shared/Markdown/MarkdownView.swift
@@ -1,14 +1,23 @@
 import SwiftUI
-import Foundation
 
 /// Renders a raw Markdown string as laid-out SwiftUI blocks — headings, lists, blockquotes,
-/// code blocks, and inline formatting (bold, italic, links, code spans). Uses Foundation's
-/// `AttributedString` with `interpretedSyntax: .full`; no third-party dependency.
+/// code blocks, and inline formatting (bold, italic, links, code spans, custom attributes).
 ///
-/// Falls back to unstyled `Text` if markdown parsing fails.
+/// Uses Foundation's `AttributedString` with `interpretedSyntax: .full` and the custom
+/// `TmbrAttributes` scope so the web's inline-attribute convention (`htmltag`, `class`, `id`)
+/// is decoded alongside standard Foundation attributes. No third-party dependency.
+///
+/// Block layout (list indentation, blockquote bar, code background) is handled at the view
+/// level; inline run styling is delegated to the `MarkdownDecorator` from the environment.
+///
+/// For anchor jumps (`^[[1](#reference-1)](htmltag: sup)` → scroll to `#reference-1`), wrap
+/// in a `ScrollViewReader` and install a custom `openURL` action that intercepts fragment URLs.
+/// See `PostReaderView` for the wiring.
 struct MarkdownView: View {
 
     let raw: String
+
+    @Environment(\.markdownDecorator) private var decorator
 
     private var blocks: [MarkdownBlock] { MarkdownBlock.parse(raw) }
 
@@ -16,6 +25,7 @@ struct MarkdownView: View {
         VStack(alignment: .leading, spacing: 8) {
             ForEach(blocks, id: \.id) { block in
                 blockView(for: block)
+                    .modifier(AnchorIDModifier(anchorID: block.anchorID))
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -25,14 +35,11 @@ struct MarkdownView: View {
 
     @ViewBuilder
     private func blockView(for block: MarkdownBlock) -> some View {
-        switch block.kind {
-        case .heading(let level):
-            Text(block.content)
-                .font(headingFont(level))
-                .textSelection(.enabled)
+        let content = decoratedAndStripped(block)
 
-        case .paragraph:
-            Text(block.content)
+        switch block.kind {
+        case .heading, .paragraph:
+            Text(content)
                 .textSelection(.enabled)
 
         case .listItem(let ordinal, let depth):
@@ -40,7 +47,8 @@ struct MarkdownView: View {
                 Text(ordinal.map { "\($0)." } ?? "•")
                     .monospacedDigit()
                     .frame(minWidth: 16, alignment: .trailing)
-                Text(block.content)
+                
+                Text(content)
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -51,13 +59,13 @@ struct MarkdownView: View {
                 RoundedRectangle(cornerRadius: 2)
                     .fill(.secondary.opacity(0.5))
                     .frame(width: 3)
-                Text(block.content)
+                Text(content)
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
             }
 
         case .codeBlock:
-            Text(block.content)
+            Text(content)
                 .font(.system(.body, design: .monospaced))
                 .padding(10)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -66,12 +74,33 @@ struct MarkdownView: View {
         }
     }
 
-    private func headingFont(_ level: Int) -> Font {
-        switch level {
-        case 1: return .title.bold()
-        case 2: return .title2.bold()
-        case 3: return .title3.bold()
-        default: return .headline
+    // MARK: - Decorate then strip
+
+    /// Applies the injected decorator to each run (decorators can read `presentationIntent`
+    /// for heading-level font selection), then strips `presentationIntent` so `Text` doesn't
+    /// apply its own block layout on top of our block chrome.
+    private func decoratedAndStripped(_ block: MarkdownBlock) -> AttributedString {
+        var content = block.content
+        let ranges = content.runs.map(\.range)
+        for range in ranges {
+            decorator(&content[range])
+        }
+        for range in ranges {
+            content[range].presentationIntent = nil
+        }
+        return content
+    }
+}
+
+// MARK: - Anchor ID modifier
+
+private struct AnchorIDModifier: ViewModifier {
+    let anchorID: String?
+    func body(content: Content) -> some View {
+        if let anchorID {
+            content.id(anchorID)
+        } else {
+            content
         }
     }
 }
@@ -81,6 +110,11 @@ struct MarkdownView: View {
 private struct MarkdownBlock {
 
     let id: Int
+    /// Populated from the `id:` custom inline attribute (`AnchorIDAttribute`). Used by
+    /// `MarkdownView` to tag the block view with `.id(anchorID)` for `scrollTo` targets.
+    let anchorID: String?
+    /// Content still carries `presentationIntent` at this point — stripping happens in the
+    /// view after the decorator runs so `.heading` can read the header level.
     let content: AttributedString
     let kind: Kind
 
@@ -100,8 +134,14 @@ private struct MarkdownBlock {
             interpretedSyntax: .full,
             failurePolicy: .returnPartiallyParsedIfPossible
         )
-        guard let attributed = try? AttributedString(markdown: raw, options: options) else {
-            return [MarkdownBlock(id: 0, content: AttributedString(raw), kind: .paragraph)]
+        // `including: TmbrAttributes.self` decodes the web's custom attributes (htmltag, class,
+        // id) while preserving all standard Foundation attributes (presentationIntent, link…).
+        guard let attributed = try? AttributedString(
+            markdown: raw,
+            including: AttributeScopes.TmbrAttributes.self,
+            options: options
+        ) else {
+            return [MarkdownBlock(id: 0, anchorID: nil, content: AttributedString(raw), kind: .paragraph)]
         }
         return grouped(attributed)
     }
@@ -141,16 +181,18 @@ private struct MarkdownBlock {
         }
 
         return groups.map { group in
-            MarkdownBlock(
+            let anchorID = group.content.runs
+                .compactMap { $0[AnchorIDAttribute.self] }
+                .first
+            return MarkdownBlock(
                 id: group.id,
-                content: strippingBlockIntent(group.content),
+                anchorID: anchorID,
+                content: group.content,
                 kind: blockKind(for: group.intent)
             )
         }
     }
 
-    /// Determines the block kind from the `PresentationIntent` component hierarchy
-    /// (outermost → innermost, following `components` ordering).
     private static func blockKind(for intent: PresentationIntent?) -> Kind {
         guard let intent else { return .paragraph }
 
@@ -186,18 +228,5 @@ private struct MarkdownBlock {
         if isList { return .listItem(ordinal: isOrdered ? listOrdinal : nil, depth: intent.indentationLevel) }
         if isBlockQuote { return .blockQuote }
         return .paragraph
-    }
-
-    /// Removes `presentationIntent` from all runs so `Text` doesn't apply its own block layout
-    /// on top of our custom block rendering while still honouring inline attributes (bold, italic…).
-    private static func strippingBlockIntent(_ content: AttributedString) -> AttributedString {
-        var result = content
-        let ranges = Array(content.runs.compactMap { run -> Range<AttributedString.Index>? in
-            run.presentationIntent != nil ? run.range : nil
-        })
-        for range in ranges {
-            result[range].presentationIntent = nil
-        }
-        return result
     }
 }


### PR DESCRIPTION
## Summary

- Adds `MarkdownView` in `Shared/Markdown/` that renders full markdown syntax (headings, blockquotes, ordered/unordered lists, code blocks, inline formatting) using `AttributedString(markdown:)` with `.full` `interpretedSyntax`
- Replaces the inline-only `AttributedString` rendering in `PostReaderView` and note surfaces — blockquotes (used for quotes) now render with a leading accent bar and secondary foreground
- Removes the now-redundant `markdown` computed properties on `PostRecord` and `NoteRecord`

## Test plan

- [ ] Open a post with headings — `# H1`, `## H2`, `### H3` render at scaled font sizes
- [ ] Open a post/note containing a blockquote — indented with leading accent bar, secondary color
- [ ] Unordered list `- item` and ordered list `1. item` render with bullet / number prefix
- [ ] Inline formatting (bold, italic, code) still works
- [ ] Fallback to plain text on malformed markdown (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)