### PR TITLE
core-app: rich catalogue detail view with track sync and stable navigation

### DIFF
--- a/core-app/Sources/CoreApp/Catalogue/CatalogueItemDetailView.swift
+++ b/core-app/Sources/CoreApp/Catalogue/CatalogueItemDetailView.swift
@@ -1,42 +1,86 @@
 import SwiftUI
 import SwiftData
 
-/// Reads cached records: the `PreviewRecord` projection + any notes anchored to it. Filtering notes in
-/// memory by `attachmentPreviewID` (SwiftData mistranslates the optional-UUID `#Predicate`).
+/// Single navigation destination for all catalogue item types. A `switch` over `item.category`
+/// (a `CatalogueItemType?`) embeds the matching per-type section (which fetches its typed record
+/// from SwiftData by `previewID`), followed by a shared notes section.
+///
+/// Pull-to-refresh delegates to whichever typed section is currently visible: each section
+/// publishes a `CatalogueItemRefreshKey` preference carrying a bound refresh closure, which the
+/// `List` collects and runs. This way only the single-item endpoint for the visible type fires —
+/// not the full catalogue sync.
 struct CatalogueItemDetailView: View {
-    let item: PreviewRecord
-    @Query(sort: \NoteRecord.createdAt, order: .reverse) private var allNotes: [NoteRecord]
 
-    private var notes: [NoteRecord] {
-        allNotes.filter { $0.attachmentPreviewID == item.id }
+    let item: PreviewRecord
+
+    /// Notes for this item only — filtered at the SQL level by the predicate-backed `@Query`
+    /// built in `init`. The optional-typed `previewID` matches `NoteRecord.attachmentPreviewID: UUID?`.
+    @Query private var notes: [NoteRecord]
+
+    @State private var model = CatalogueItemDetailModel()
+
+    init(item: PreviewRecord) {
+        self.item = item
+        let previewID: UUID? = item.id
+        _notes = Query(
+            filter: #Predicate<NoteRecord> { $0.attachmentPreviewID == previewID },
+            sort: \.createdAt, order: .reverse
+        )
     }
 
     var body: some View {
         List {
-            Section {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(item.primaryInfo)
-                        .font(.title2.bold())
-                    if let subtitle = item.secondaryInfo {
-                        Text(subtitle)
-                            .foregroundStyle(.secondary)
-                    }
-                    Text(item.categoryType.capitalized)
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
-            }
-            if !notes.isEmpty {
-                Section("Notes") {
-                    ForEach(notes) { note in
-                        MarkdownView(raw: note.body)
-                    }
-                }
-            }
+            typeSection
+            CatalogueItemStatusLine(
+                loading: model.loading,
+                lastError: model.lastError,
+                lastFetched: model.lastFetched
+            )
+            notesSection
         }
         .navigationTitle(item.primaryInfo)
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
 #endif
+        .onPreferenceChange(CatalogueItemRefreshKey.self) { [model] value in
+            Task { @MainActor in model.setRefresh(value) }
+        }
+        .refreshable { await model.run() }
+    }
+
+    // MARK: - Type section
+
+    @ViewBuilder
+    private var typeSection: some View {
+        switch item.category {
+        case .song:
+            SongDetailSection(previewID: item.id)
+        case .album:
+            AlbumDetailSection(previewID: item.id)
+        case .playlist:
+            PlaylistDetailSection(previewID: item.id)
+        case .book:
+            BookDetailSection(previewID: item.id)
+        case .podcast:
+            PodcastDetailSection(previewID: item.id)
+        case .movie:
+            MovieDetailSection(previewID: item.id)
+        case nil:
+            OrphanDetailSection(item: item)
+        }
+    }
+
+    // MARK: - Notes section
+
+    @ViewBuilder
+    private var notesSection: some View {
+        if !notes.isEmpty {
+            Section("Notes") {
+                ForEach(notes) { note in
+                    MarkdownView(raw: note.body)
+                        .padding(.vertical, 4)
+                }
+            }
+        }
     }
 }

--- a/core-app/Sources/CoreApp/Catalogue/CatalogueItemDetailView.swift
+++ b/core-app/Sources/CoreApp/Catalogue/CatalogueItemDetailView.swift
@@ -45,7 +45,7 @@ struct CatalogueItemDetailView: View {
         .onPreferenceChange(CatalogueItemRefreshKey.self) { [model] value in
             Task { @MainActor in model.setRefresh(value) }
         }
-        .refreshable { await model.run() }
+        .refreshable { await model.refresh() }
     }
 
     // MARK: - Type section

--- a/core-app/Sources/CoreApp/Catalogue/CatalogueItemNavigation.swift
+++ b/core-app/Sources/CoreApp/Catalogue/CatalogueItemNavigation.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import SwiftData
+
+/// Lightweight navigation value for pushing a catalogue item detail without storing a live
+/// SwiftData model in the path. Storing `@Model` references in `NavigationPath` causes stale
+/// reference failures after syncs; a plain UUID is stable across model context updates.
+struct CatalogueItemNavigation: Hashable {
+    let previewID: UUID
+}
+
+extension CatalogueItemNavigation {
+    /// Fetches the `PreviewRecord` from SwiftData and presents its detail view.
+    /// Falls back to an empty view if the record has been evicted (edge case).
+    @MainActor
+    static func destination(_ nav: CatalogueItemNavigation) -> some View {
+        CatalogueItemNavigationDestination(previewID: nav.previewID)
+    }
+}
+
+private struct CatalogueItemNavigationDestination: View {
+
+    let previewID: UUID
+
+    @Query private var records: [PreviewRecord]
+
+    init(previewID: UUID) {
+        self.previewID = previewID
+        _records = Query(filter: #Predicate<PreviewRecord> { $0.id == previewID })
+    }
+
+    var body: some View {
+        if let item = records.first {
+            CatalogueItemDetailView(item: item)
+        }
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/CatalogueItemRefresh.swift
+++ b/core-app/Sources/CoreApp/Catalogue/CatalogueItemRefresh.swift
@@ -6,12 +6,24 @@ import SwiftUI
 /// the MainActor.
 struct CatalogueItemRefresh: Equatable, @unchecked Sendable {
     let id: UUID
-    let run: @MainActor () async throws -> Void
+    
+    private let run: @MainActor () async throws -> Void
+    
+    init(id: UUID, run: @Sendable @escaping () async throws -> Void) {
+        self.id = id
+        self.run = run
+    }
+    
+    func callAsFunction() async throws {
+        try await run()
+    }
+    
     static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id }
 }
 
 struct CatalogueItemRefreshKey: PreferenceKey {
     static let defaultValue: CatalogueItemRefresh? = nil
+    
     static func reduce(value: inout CatalogueItemRefresh?, nextValue: () -> CatalogueItemRefresh?) {
         value = nextValue() ?? value
     }

--- a/core-app/Sources/CoreApp/Catalogue/CatalogueTab.swift
+++ b/core-app/Sources/CoreApp/Catalogue/CatalogueTab.swift
@@ -74,6 +74,7 @@ struct CatalogueTab: View {
                     AccountButton()
                 }
             }
+            .navigationDestination(for: CatalogueItemNavigation.self) { CatalogueItemNavigation.destination($0) }
             .refreshable { await refreshCatalogue() }
         }
         .task { await refreshCatalogue() }

--- a/core-app/Sources/CoreApp/Catalogue/Detail/AlbumDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/AlbumDetailSection.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import SwiftData
+
+struct AlbumDetailSection: View {
+
+    let previewID: UUID
+
+    @Query private var records: [AlbumRecord]
+
+    @Upserter(\.album) private var syncer
+
+    init(previewID: UUID) {
+        self.previewID = previewID
+        _records = Query(filter: #Predicate<AlbumRecord> { $0.previewID == previewID })
+    }
+
+    var body: some View {
+        if let album = records.first {
+            Section {
+                CatalogueItemHeader(
+                    title: album.title,
+                    artworkURL: album.artworkURL,
+                    credit: album.artist.isEmpty ? nil : "by \(album.artist)",
+                    info: infoLine(for: album),
+                    resourceURLs: album.resourceURLs
+                )
+            }
+            .catalogueItemRefresh(id: previewID) { [sourceID = album.sourceID] in
+                if let sourceID { try await syncer(sourceID) }
+            }
+            if let sourceID = album.sourceID {
+                TrackListSection(containerType: "album", containerSourceID: sourceID)
+            }
+        }
+    }
+
+    private func infoLine(for album: AlbumRecord) -> String? {
+        let parts = [album.genre, album.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
+            .compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Detail/AlbumDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/AlbumDetailSection.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 import SwiftData
 
+private struct AlbumInfoLine: View {
+    let album: AlbumRecord
+
+    var body: some View {
+        if let text {
+            Text(text).foregroundStyle(.secondary)
+        }
+    }
+
+    private var text: String? {
+        let parts = [album.genre, album.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
+            .compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+}
+
 struct AlbumDetailSection: View {
 
     let previewID: UUID
@@ -21,7 +37,7 @@ struct AlbumDetailSection: View {
                     title: album.title,
                     artworkURL: album.artworkURL,
                     credit: album.artist.isEmpty ? nil : "by \(album.artist)",
-                    info: infoLine(for: album),
+                    info: { AlbumInfoLine(album: album) },
                     resourceURLs: album.resourceURLs
                 )
             }
@@ -34,9 +50,4 @@ struct AlbumDetailSection: View {
         }
     }
 
-    private func infoLine(for album: AlbumRecord) -> String? {
-        let parts = [album.genre, album.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
-            .compactMap { $0 }.filter { !$0.isEmpty }
-        return parts.isEmpty ? nil : parts.joined(separator: ", ")
-    }
 }

--- a/core-app/Sources/CoreApp/Catalogue/Detail/BookDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/BookDetailSection.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import SwiftData
+
+struct BookDetailSection: View {
+
+    let previewID: UUID
+
+    @Query private var records: [BookRecord]
+
+    @Upserter(\.book) private var syncer
+
+    init(previewID: UUID) {
+        self.previewID = previewID
+        _records = Query(filter: #Predicate<BookRecord> { $0.previewID == previewID })
+    }
+
+    var body: some View {
+        if let book = records.first {
+            Section {
+                CatalogueItemHeader(
+                    title: book.title,
+                    artworkURL: book.coverURL,
+                    credit: book.author.isEmpty ? nil : "by \(book.author)",
+                    info: infoLine(for: book),
+                    resourceURLs: book.resourceURLs
+                )
+            }
+            .catalogueItemRefresh(id: previewID) { [sourceID = book.sourceID] in
+                if let sourceID { try await syncer(sourceID) }
+            }
+        }
+    }
+
+    private func infoLine(for book: BookRecord) -> String? {
+        let parts = [book.genre, book.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
+            .compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Detail/BookDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/BookDetailSection.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 import SwiftData
 
+private struct BookInfoLine: View {
+    let book: BookRecord
+
+    var body: some View {
+        if let text {
+            Text(text).foregroundStyle(.secondary)
+        }
+    }
+
+    private var text: String? {
+        let parts = [book.genre, book.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
+            .compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+}
+
 struct BookDetailSection: View {
 
     let previewID: UUID
@@ -21,7 +37,7 @@ struct BookDetailSection: View {
                     title: book.title,
                     artworkURL: book.coverURL,
                     credit: book.author.isEmpty ? nil : "by \(book.author)",
-                    info: infoLine(for: book),
+                    info: { BookInfoLine(book: book) },
                     resourceURLs: book.resourceURLs
                 )
             }
@@ -31,9 +47,4 @@ struct BookDetailSection: View {
         }
     }
 
-    private func infoLine(for book: BookRecord) -> String? {
-        let parts = [book.genre, book.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
-            .compactMap { $0 }.filter { !$0.isEmpty }
-        return parts.isEmpty ? nil : parts.joined(separator: ", ")
-    }
 }

--- a/core-app/Sources/CoreApp/Catalogue/Detail/CatalogueDetailRows.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/CatalogueDetailRows.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+// MARK: - Document-style header
+
+/// Mirrors the web's responsive catalogue item header.
+/// - Compact (iPhone): artwork centered above, then title → credit → info below.
+/// - Regular (iPad/macOS): title → credit → info on the left, artwork on the right.
+struct CatalogueItemHeader: View {
+
+    let title: String
+    var artworkURL: String? = nil
+    var credit: String? = nil
+    var info: String? = nil
+    var resourceURLs: [String] = []
+
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    var body: some View {
+        Group {
+            if sizeClass == .regular {
+                HStack(alignment: .top, spacing: 16) {
+                    textContent
+                    artworkImage
+                        .frame(width: 130, height: 130)
+                }
+                .padding(.vertical, 8)
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    artworkImage
+                        .frame(maxWidth: 200)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.bottom, 8)
+                    textContent
+                }
+                .padding(.vertical, 8)
+            }
+
+            ForEach(resourceURLs, id: \.self) { urlString in
+                if let url = URL(string: urlString) {
+                    Link(url.host ?? urlString, destination: url)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var artworkImage: some View {
+        if let artworkURL, let url = URL(string: artworkURL) {
+            AsyncImage(url: url) { image in
+                image.resizable().scaledToFit()
+            } placeholder: {
+                Rectangle()
+                    .fill(.secondary.opacity(0.12))
+                    .aspectRatio(1, contentMode: .fit)
+            }
+        }
+    }
+
+    private var textContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.title)
+                .fontWeight(.bold)
+            if let credit {
+                Text(credit)
+                    .font(.headline)
+                    .fontWeight(.bold)
+            }
+            if let info, !info.isEmpty {
+                Text(info)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Detail/CatalogueDetailRows.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/CatalogueDetailRows.swift
@@ -5,15 +5,29 @@ import SwiftUI
 /// Mirrors the web's responsive catalogue item header.
 /// - Compact (iPhone): artwork centered above, then title → credit → info below.
 /// - Regular (iPad/macOS): title → credit → info on the left, artwork on the right.
-struct CatalogueItemHeader: View {
+struct CatalogueItemHeader<InfoContent: View>: View {
 
     let title: String
     var artworkURL: String? = nil
     var credit: String? = nil
-    var info: String? = nil
+    let info: InfoContent
     var resourceURLs: [String] = []
 
     @Environment(\.horizontalSizeClass) private var sizeClass
+
+    init(
+        title: String,
+        artworkURL: String? = nil,
+        credit: String? = nil,
+        @ViewBuilder info: () -> InfoContent,
+        resourceURLs: [String] = []
+    ) {
+        self.title = title
+        self.artworkURL = artworkURL
+        self.credit = credit
+        self.info = info()
+        self.resourceURLs = resourceURLs
+    }
 
     var body: some View {
         Group {
@@ -66,10 +80,7 @@ struct CatalogueItemHeader: View {
                     .font(.headline)
                     .fontWeight(.bold)
             }
-            if let info, !info.isEmpty {
-                Text(info)
-                    .foregroundStyle(.secondary)
-            }
+            info
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/core-app/Sources/CoreApp/Catalogue/Detail/CatalogueItemDetailModel.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/CatalogueItemDetailModel.swift
@@ -12,27 +12,29 @@ public final class CatalogueItemDetailModel {
 
     /// The visible section's published "how to refresh me" (id already bound).
     /// Set via `setSyncer(_:)` from `onPreferenceChange`.
-    var refresh: CatalogueItemRefresh?
+    private var sync: CatalogueItemRefresh?
 
     public private(set) var loading: LoadingState?
+    
     public private(set) var lastError: LoadError?
+    
     public private(set) var lastFetched: Date?
 
     public init() {}
 
     /// Called by `onPreferenceChange` when the active section publishes a new refresh closure.
     func setRefresh(_ value: CatalogueItemRefresh?) {
-        refresh = value
+        sync = value
     }
 
     /// Runs the active section's refresh; updates loading/error/lastFetched.
     /// Called by `.refreshable` — errors are captured into `lastError`, never thrown to the caller.
-    public func run() async {
-        guard let refresh, loading == nil else { return }
+    public func refresh() async {
+        guard let sync, loading == nil else { return }
         loading = .refresh
         defer { loading = nil }
         do {
-            try await refresh.run()
+            try await sync()
             lastFetched = .now
             lastError = nil
         } catch {

--- a/core-app/Sources/CoreApp/Catalogue/Detail/CatalogueItemDetailModel.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/CatalogueItemDetailModel.swift
@@ -1,0 +1,43 @@
+import Foundation
+import OSLog
+
+/// Headless model for a catalogue item detail screen — tracks per-item refresh activity and
+/// outcome. Mirrors `CatalogueModel`'s shape (loading/lastError/lastFetched) but is driven by
+/// the `CatalogueItemRefresh` published up from the active type section via `PreferenceKey`.
+///
+/// Owned by `CatalogueItemDetailView`; sections stay display-only.
+@MainActor
+@Observable
+public final class CatalogueItemDetailModel {
+
+    /// The visible section's published "how to refresh me" (id already bound).
+    /// Set via `setSyncer(_:)` from `onPreferenceChange`.
+    var refresh: CatalogueItemRefresh?
+
+    public private(set) var loading: LoadingState?
+    public private(set) var lastError: LoadError?
+    public private(set) var lastFetched: Date?
+
+    public init() {}
+
+    /// Called by `onPreferenceChange` when the active section publishes a new refresh closure.
+    func setRefresh(_ value: CatalogueItemRefresh?) {
+        refresh = value
+    }
+
+    /// Runs the active section's refresh; updates loading/error/lastFetched.
+    /// Called by `.refreshable` — errors are captured into `lastError`, never thrown to the caller.
+    public func run() async {
+        guard let refresh, loading == nil else { return }
+        loading = .refresh
+        defer { loading = nil }
+        do {
+            try await refresh.run()
+            lastFetched = .now
+            lastError = nil
+        } catch {
+            Logger.sync.error("Item refresh failed: \(error)")
+            lastError = LoadError(error)
+        }
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Detail/MovieDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/MovieDetailSection.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 import SwiftData
 
+private struct MovieInfoLine: View {
+    let movie: MovieRecord
+
+    var body: some View {
+        if let text {
+            Text(text).foregroundStyle(.secondary)
+        }
+    }
+
+    private var text: String? {
+        let parts = [movie.director, movie.genre, movie.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
+            .compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+}
+
 struct MovieDetailSection: View {
 
     let previewID: UUID
@@ -20,7 +36,7 @@ struct MovieDetailSection: View {
                 CatalogueItemHeader(
                     title: movie.title,
                     artworkURL: movie.coverURL,
-                    info: infoLine(for: movie),
+                    info: { MovieInfoLine(movie: movie) },
                     resourceURLs: movie.resourceURLs
                 )
             }
@@ -30,9 +46,4 @@ struct MovieDetailSection: View {
         }
     }
 
-    private func infoLine(for movie: MovieRecord) -> String? {
-        let parts = [movie.director, movie.genre, movie.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
-            .compactMap { $0 }.filter { !$0.isEmpty }
-        return parts.isEmpty ? nil : parts.joined(separator: ", ")
-    }
 }

--- a/core-app/Sources/CoreApp/Catalogue/Detail/MovieDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/MovieDetailSection.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import SwiftData
+
+struct MovieDetailSection: View {
+
+    let previewID: UUID
+
+    @Query private var records: [MovieRecord]
+
+    @Upserter(\.movie) private var syncer
+
+    init(previewID: UUID) {
+        self.previewID = previewID
+        _records = Query(filter: #Predicate<MovieRecord> { $0.previewID == previewID })
+    }
+
+    var body: some View {
+        if let movie = records.first {
+            Section {
+                CatalogueItemHeader(
+                    title: movie.title,
+                    artworkURL: movie.coverURL,
+                    info: infoLine(for: movie),
+                    resourceURLs: movie.resourceURLs
+                )
+            }
+            .catalogueItemRefresh(id: previewID) { [sourceID = movie.sourceID] in
+                if let sourceID { try await syncer(sourceID) }
+            }
+        }
+    }
+
+    private func infoLine(for movie: MovieRecord) -> String? {
+        let parts = [movie.director, movie.genre, movie.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
+            .compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Detail/OrphanDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/OrphanDetailSection.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct OrphanDetailSection: View {
+
+    let item: PreviewRecord
+
+    @Upserter(\.orphan) private var syncer
+
+    var body: some View {
+        Section {
+            CatalogueItemHeader(
+                title: item.primaryInfo,
+                artworkURL: item.imageURL,
+                info: [item.secondaryInfo, item.categoryType.capitalized]
+                    .compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " · "),
+                resourceURLs: item.externalLinks
+            )
+        }
+        .catalogueItemRefresh(id: item.id) { [id = item.id] in
+            try await syncer(id)
+        }
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Detail/OrphanDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/OrphanDetailSection.swift
@@ -1,5 +1,17 @@
 import SwiftUI
 
+private struct OrphanInfoLine: View {
+    let item: PreviewRecord
+
+    var body: some View {
+        let text = [item.secondaryInfo, item.categoryType.capitalized]
+            .compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " · ")
+        if !text.isEmpty {
+            Text(text).foregroundStyle(.secondary)
+        }
+    }
+}
+
 struct OrphanDetailSection: View {
 
     let item: PreviewRecord
@@ -11,8 +23,7 @@ struct OrphanDetailSection: View {
             CatalogueItemHeader(
                 title: item.primaryInfo,
                 artworkURL: item.imageURL,
-                info: [item.secondaryInfo, item.categoryType.capitalized]
-                    .compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " · "),
+                info: { OrphanInfoLine(item: item) },
                 resourceURLs: item.externalLinks
             )
         }

--- a/core-app/Sources/CoreApp/Catalogue/Detail/PlaylistDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/PlaylistDetailSection.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import SwiftData
+
+struct PlaylistDetailSection: View {
+
+    let previewID: UUID
+
+    @Query private var records: [PlaylistRecord]
+
+    @Upserter(\.playlist) private var syncer
+
+    init(previewID: UUID) {
+        self.previewID = previewID
+        _records = Query(filter: #Predicate<PlaylistRecord> { $0.previewID == previewID })
+    }
+
+    var body: some View {
+        if let playlist = records.first {
+            Section {
+                CatalogueItemHeader(
+                    title: playlist.title,
+                    artworkURL: playlist.artworkURL,
+                    info: playlist.playlistDescription,
+                    resourceURLs: playlist.resourceURLs
+                )
+            }
+            .catalogueItemRefresh(id: previewID) { [sourceID = playlist.sourceID] in
+                if let sourceID { try await syncer(sourceID) }
+            }
+            if let sourceID = playlist.sourceID {
+                TrackListSection(containerType: "playlist", containerSourceID: sourceID)
+            }
+        }
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Detail/PlaylistDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/PlaylistDetailSection.swift
@@ -1,6 +1,16 @@
 import SwiftUI
 import SwiftData
 
+private struct PlaylistInfoLine: View {
+    let playlist: PlaylistRecord
+
+    var body: some View {
+        if let description = playlist.playlistDescription, !description.isEmpty {
+            Text(description).foregroundStyle(.secondary)
+        }
+    }
+}
+
 struct PlaylistDetailSection: View {
 
     let previewID: UUID
@@ -20,7 +30,7 @@ struct PlaylistDetailSection: View {
                 CatalogueItemHeader(
                     title: playlist.title,
                     artworkURL: playlist.artworkURL,
-                    info: playlist.playlistDescription,
+                    info: { PlaylistInfoLine(playlist: playlist) },
                     resourceURLs: playlist.resourceURLs
                 )
             }

--- a/core-app/Sources/CoreApp/Catalogue/Detail/PodcastDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/PodcastDetailSection.swift
@@ -1,6 +1,28 @@
 import SwiftUI
 import SwiftData
 
+private struct PodcastInfoLine: View {
+    let podcast: PodcastRecord
+
+    var body: some View {
+        if let text {
+            Text(text).foregroundStyle(.secondary)
+        }
+    }
+
+    private var text: String? {
+        let parts = [seasonEpisode, podcast.genre, podcast.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
+            .compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+
+    private var seasonEpisode: String? {
+        if let s = podcast.seasonNumber, let e = podcast.episodeNumber { return "S\(s):E\(e)" }
+        if let e = podcast.episodeNumber { return "E\(e)" }
+        return nil
+    }
+}
+
 struct PodcastDetailSection: View {
 
     let previewID: UUID
@@ -21,7 +43,7 @@ struct PodcastDetailSection: View {
                     title: podcast.title,
                     artworkURL: podcast.artworkURL,
                     credit: podcast.episodeTitle.isEmpty ? nil : podcast.episodeTitle,
-                    info: infoLine(for: podcast),
+                    info: { PodcastInfoLine(podcast: podcast) },
                     resourceURLs: podcast.resourceURLs
                 )
             }
@@ -31,14 +53,4 @@ struct PodcastDetailSection: View {
         }
     }
 
-    private func infoLine(for podcast: PodcastRecord) -> String? {
-        let seasonEpisode: String? = {
-            if let s = podcast.seasonNumber, let e = podcast.episodeNumber { return "S\(s):E\(e)" }
-            if let e = podcast.episodeNumber { return "E\(e)" }
-            return nil
-        }()
-        let parts = [seasonEpisode, podcast.genre, podcast.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
-            .compactMap { $0 }.filter { !$0.isEmpty }
-        return parts.isEmpty ? nil : parts.joined(separator: ", ")
-    }
 }

--- a/core-app/Sources/CoreApp/Catalogue/Detail/PodcastDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/PodcastDetailSection.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import SwiftData
+
+struct PodcastDetailSection: View {
+
+    let previewID: UUID
+
+    @Query private var records: [PodcastRecord]
+
+    @Upserter(\.podcast) private var syncer
+
+    init(previewID: UUID) {
+        self.previewID = previewID
+        _records = Query(filter: #Predicate<PodcastRecord> { $0.previewID == previewID })
+    }
+
+    var body: some View {
+        if let podcast = records.first {
+            Section {
+                CatalogueItemHeader(
+                    title: podcast.title,
+                    artworkURL: podcast.artworkURL,
+                    credit: podcast.episodeTitle.isEmpty ? nil : podcast.episodeTitle,
+                    info: infoLine(for: podcast),
+                    resourceURLs: podcast.resourceURLs
+                )
+            }
+            .catalogueItemRefresh(id: previewID) { [sourceID = podcast.sourceID] in
+                if let sourceID { try await syncer(sourceID) }
+            }
+        }
+    }
+
+    private func infoLine(for podcast: PodcastRecord) -> String? {
+        let seasonEpisode: String? = {
+            if let s = podcast.seasonNumber, let e = podcast.episodeNumber { return "S\(s):E\(e)" }
+            if let e = podcast.episodeNumber { return "E\(e)" }
+            return nil
+        }()
+        let parts = [seasonEpisode, podcast.genre, podcast.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
+            .compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Detail/SongDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/SongDetailSection.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import SwiftData
+
+struct SongDetailSection: View {
+
+    let previewID: UUID
+
+    @Query private var records: [SongRecord]
+
+    @Upserter(\.song) private var syncer
+
+    init(previewID: UUID) {
+        self.previewID = previewID
+        _records = Query(filter: #Predicate<SongRecord> { $0.previewID == previewID })
+    }
+
+    var body: some View {
+        if let song = records.first {
+            Section {
+                CatalogueItemHeader(
+                    title: song.title,
+                    artworkURL: song.artworkURL,
+                    credit: song.artist.isEmpty ? nil : "by \(song.artist)",
+                    info: infoLine(for: song),
+                    resourceURLs: song.resourceURLs
+                )
+            }
+            .catalogueItemRefresh(id: previewID) { [sourceID = song.sourceID] in
+                if let sourceID { try await syncer(sourceID) }
+            }
+        }
+    }
+
+    private func infoLine(for song: SongRecord) -> String? {
+        let parts = [song.album, song.genre, song.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
+            .compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Detail/SongDetailSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/SongDetailSection.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 import SwiftData
 
+private struct SongInfoLine: View {
+    let song: SongRecord
+
+    var body: some View {
+        if let text {
+            Text(text).foregroundStyle(.secondary)
+        }
+    }
+
+    private var text: String? {
+        let parts = [song.album, song.genre, song.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
+            .compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+}
+
 struct SongDetailSection: View {
 
     let previewID: UUID
@@ -21,7 +37,7 @@ struct SongDetailSection: View {
                     title: song.title,
                     artworkURL: song.artworkURL,
                     credit: song.artist.isEmpty ? nil : "by \(song.artist)",
-                    info: infoLine(for: song),
+                    info: { SongInfoLine(song: song) },
                     resourceURLs: song.resourceURLs
                 )
             }
@@ -31,9 +47,4 @@ struct SongDetailSection: View {
         }
     }
 
-    private func infoLine(for song: SongRecord) -> String? {
-        let parts = [song.album, song.genre, song.releaseDate?.formatted(date: .abbreviated, time: .omitted)]
-            .compactMap { $0 }.filter { !$0.isEmpty }
-        return parts.isEmpty ? nil : parts.joined(separator: ", ")
-    }
 }

--- a/core-app/Sources/CoreApp/Catalogue/Detail/TrackListSection.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Detail/TrackListSection.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import SwiftData
+
+/// Renders the ordered track list for an album or playlist from cached `ContainerEntryRecord`s.
+/// Pass `containerType` ("album" | "playlist") and the container's backing `sourceID` (Int).
+struct TrackListSection: View {
+
+    @Query private var entries: [ContainerEntryRecord]
+
+    init(containerType: String, containerSourceID: Int) {
+        _entries = Query(
+            filter: #Predicate<ContainerEntryRecord> {
+                $0.containerType == containerType && $0.containerSourceID == containerSourceID
+            },
+            sort: \.position
+        )
+    }
+
+    var body: some View {
+        if !entries.isEmpty {
+            Section("Tracks") {
+                ForEach(entries, id: \.clientKey) { entry in
+                    if entry.href != nil {
+                        NavigationLink(value: CatalogueItemNavigation(previewID: entry.memberPreviewID)) {
+                            trackLabel(for: entry)
+                        }
+                    } else {
+                        trackLabel(for: entry)
+                    }
+                }
+            }
+        }
+    }
+
+    private func trackLabel(for entry: ContainerEntryRecord) -> some View {
+        HStack {
+            Text("\(entry.position)")
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 24, alignment: .trailing)
+            Text(entry.title)
+        }
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Views/CatalogueItemStatusLine.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Views/CatalogueItemStatusLine.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// A non-disruptive one-liner row for a catalogue item detail screen.
+/// Parameterised twin of `CatalogueStatusLine` — same visuals, same states, but takes
+/// loading/lastError/lastFetched as direct inputs rather than reading from the catalogue model.
+struct CatalogueItemStatusLine: View {
+
+    let loading: LoadingState?
+    let lastError: LoadError?
+    let lastFetched: Date?
+
+    var body: some View {
+        statusContent
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .listRowSeparator(.hidden)
+            .listRowBackground(Color.clear)
+    }
+
+    @ViewBuilder
+    private var statusContent: some View {
+        if loading == .refresh {
+            Label("Updating\u{2026}", systemImage: "arrow.clockwise")
+        } else if lastError != nil {
+            if let date = lastFetched {
+                Label {
+                    Text("Couldn't update \u{00B7} ") + Text(date, format: .relative(presentation: .named))
+                } icon: {
+                    Image(systemName: "exclamationmark.circle")
+                }
+            } else {
+                Label("Couldn't update", systemImage: "exclamationmark.circle")
+            }
+        } else if let date = lastFetched {
+            Text("Updated ") + Text(date, format: .relative(presentation: .named))
+        }
+    }
+}

--- a/core-app/Sources/CoreApp/Persistence/CatalogueRecord+Sync.swift
+++ b/core-app/Sources/CoreApp/Persistence/CatalogueRecord+Sync.swift
@@ -121,3 +121,20 @@ public extension PlaylistRecord {
         syncState = .synced
     }
 }
+
+public extension ContainerEntryRecord {
+    /// Overwrites this entry's fields from a `TrackItem`. Denormalises the title and URLs so
+    /// the track list renders standalone without requiring the member's `PreviewRecord` to be cached.
+    func update(from track: TrackItem, containerType: String, containerSourceID: Int) {
+        self.containerType = containerType
+        self.containerSourceID = containerSourceID
+        if let id = UUID(uuidString: track.previewID) {
+            memberPreviewID = id
+        }
+        position = track.position
+        title = track.title
+        trackURL = track.trackURL
+        href = track.href
+        syncState = .synced
+    }
+}

--- a/core-app/Sources/CoreApp/Persistence/CatalogueStore.swift
+++ b/core-app/Sources/CoreApp/Persistence/CatalogueStore.swift
@@ -53,6 +53,7 @@ public struct CatalogueStore {
         var previews = try previewsByID()
         var notes = try notesByPreview()
         var typed = try typedIndex(AlbumRecord.self, key: \.previewID)
+        var containers = try containerEntriesByKey()
         for r in responses {
             guard let pid = upsertItem(r, into: &previews, notes: &notes) else { continue }
             let record = typed[pid] ?? {
@@ -62,6 +63,7 @@ public struct CatalogueStore {
                 return new
             }()
             record.update(from: r)
+            reconcileTracks(r.tracks, containerType: "album", containerSourceID: r.id, into: &containers)
         }
         try context.save()
     }
@@ -121,6 +123,7 @@ public struct CatalogueStore {
         var previews = try previewsByID()
         var notes = try notesByPreview()
         var typed = try typedIndex(PlaylistRecord.self, key: \.previewID)
+        var containers = try containerEntriesByKey()
         for r in responses {
             guard let pid = upsertItem(r, into: &previews, notes: &notes) else { continue }
             let record = typed[pid] ?? {
@@ -130,6 +133,7 @@ public struct CatalogueStore {
                 return new
             }()
             record.update(from: r)
+            reconcileTracks(r.tracks, containerType: "playlist", containerSourceID: r.id, into: &containers)
         }
         try context.save()
     }
@@ -157,6 +161,16 @@ public struct CatalogueStore {
         var index: [UUID: [NoteRecord]] = [:]
         for note in try context.fetch(FetchDescriptor<NoteRecord>()) {
             if let pid = note.attachmentPreviewID { index[pid, default: []].append(note) }
+        }
+        return index
+    }
+
+    /// Builds an index of `ContainerEntryRecord`s keyed by `"\(containerType):\(containerSourceID)"`.
+    private func containerEntriesByKey() throws -> [String: [ContainerEntryRecord]] {
+        var index: [String: [ContainerEntryRecord]] = [:]
+        for entry in try context.fetch(FetchDescriptor<ContainerEntryRecord>()) {
+            let key = "\(entry.containerType):\(entry.containerSourceID)"
+            index[key, default: []].append(entry)
         }
         return index
     }
@@ -213,6 +227,41 @@ public struct CatalogueStore {
         }
 
         byPreview[previewID] = current
+    }
+
+    /// Track reconcile: mirrors `reconcileNotes` but for `ContainerEntryRecord`s within an album
+    /// or playlist. Inserts new entries, updates existing ones, and deletes `.synced` entries
+    /// absent from the incoming track list (server-side removes).
+    private func reconcileTracks(
+        _ tracks: [TrackItem],
+        containerType: String,
+        containerSourceID: Int,
+        into byContainer: inout [String: [ContainerEntryRecord]]
+    ) {
+        let key = "\(containerType):\(containerSourceID)"
+        let incomingIDs = Set(tracks.compactMap { UUID(uuidString: $0.previewID) })
+        var current = byContainer[key] ?? []
+
+        current.removeAll { entry in
+            if entry.syncState == .synced, !incomingIDs.contains(entry.memberPreviewID) {
+                context.delete(entry)
+                return true
+            }
+            return false
+        }
+
+        for track in tracks {
+            guard let memberID = UUID(uuidString: track.previewID) else { continue }
+            let record = current.first { $0.memberPreviewID == memberID } ?? {
+                let new = ContainerEntryRecord()
+                context.insert(new)
+                current.append(new)
+                return new
+            }()
+            record.update(from: track, containerType: containerType, containerSourceID: containerSourceID)
+        }
+
+        byContainer[key] = current
     }
 
     private func upsertItem<R: CatalogueItemResponse>(

--- a/core-app/Sources/CoreApp/Persistence/ContainerEntryRecord.swift
+++ b/core-app/Sources/CoreApp/Persistence/ContainerEntryRecord.swift
@@ -27,7 +27,17 @@ public final class ContainerEntryRecord {
     public var memberPreviewID: UUID = UUID()
     
     public var position: Int = 0
-    
+
+    /// Denormalised track title — lets the list render standalone without the member's
+    /// `PreviewRecord` being cached.
+    public var title: String = ""
+
+    /// Optional direct track URL (e.g. a streaming link).
+    public var trackURL: String?
+
+    /// Route to the promoted song page (e.g. `/songs/123`); non-nil only when promoted.
+    public var href: String?
+
     var syncStateRaw: String = SyncState.synced.rawValue
 
     public init(
@@ -36,6 +46,9 @@ public final class ContainerEntryRecord {
         containerSourceID: Int = 0,
         memberPreviewID: UUID = UUID(),
         position: Int = 0,
+        title: String = "",
+        trackURL: String? = nil,
+        href: String? = nil,
         syncState: SyncState = .synced
     ) {
         self.clientKey = clientKey
@@ -43,6 +56,9 @@ public final class ContainerEntryRecord {
         self.containerSourceID = containerSourceID
         self.memberPreviewID = memberPreviewID
         self.position = position
+        self.title = title
+        self.trackURL = trackURL
+        self.href = href
         self.syncStateRaw = syncState.rawValue
     }
 }

--- a/tmbr-app/Reader/ReaderApp.swift
+++ b/tmbr-app/Reader/ReaderApp.swift
@@ -8,9 +8,9 @@ import CoreApp
 /// The shared UI's seam stays at its defaults: `canAuthor = false`, `accountToolbar = .none`.
 @main
 struct ReaderApp: App {
-    
+
     let container: ModelContainer
-    
+
     let blog: BlogModel
     let catalogue: CatalogueModel
 
@@ -46,6 +46,7 @@ struct ReaderApp: App {
             ContentView()
                 .blog(blog)
                 .catalogue(catalogue)
+                .environment(\.apiBaseURL, Self.apiBaseURL)
         }
         .modelContainer(container)
     }

--- a/tmbr-web/Sources/App/Commands/FetchCommand.swift
+++ b/tmbr-web/Sources/App/Commands/FetchCommand.swift
@@ -52,6 +52,23 @@ extension PlainCommand where Output: Model, Input == FetchParameters<Output.IDVa
     where repeat (each Property): AsyncLoadable {
         self.fetch(
             database: database,
+            readPermission: readPermission,
+            writePermission: writePermission,
+            load: repeat (each properties),
+            then: { _, _ in }
+        )
+    }
+
+    static func fetch<each Property>(
+        database: Database,
+        readPermission: BasePermissionResolver<Output>,
+        writePermission: AuthPermissionResolver<Output>,
+        load properties: repeat KeyPath<Output, each Property>,
+        then afterLoad: @escaping @Sendable (Output, any Database) async throws -> Void
+    ) -> Self
+    where repeat (each Property): AsyncLoadable {
+        self.fetch(
+            database: database,
             permission: ErasedPermissionResolver(input: { $0.item }, condition: { $0.reason }) { reason in
                 switch reason {
                 case .read: readPermission.eraseOutput()
@@ -67,6 +84,7 @@ extension PlainCommand where Output: Model, Input == FetchParameters<Output.IDVa
                 //     for try await _ in group {}
                 // }
                 try await (repeat model[keyPath: (each properties)].load(on: db))
+                try await afterLoad(model, db)
             }
         )
     }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Albums/Commands/Command/FetchAlbumCommand.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Albums/Commands/Command/FetchAlbumCommand.swift
@@ -10,7 +10,11 @@ extension CommandFactory<FetchParameters<AlbumID>, Album> {
                 database: request.commandDB,
                 readPermission: request.permissions.albums.access,
                 writePermission: request.permissions.albums.edit,
-                load: \.$artwork, \.$owner, \.$post
+                load: \.$artwork, \.$owner, \.$post, \.$preview,
+                then: { album, db in
+                    try await album.preview.$image.load(on: db)
+                    try await album.preview.$catalogueCategory.load(on: db)
+                }
             )
             .logged(name: "Fetch Album", logger: request.logger)
         }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/API/AlbumsAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/API/AlbumsAPIController.swift
@@ -76,6 +76,9 @@ struct AlbumsAPIController: RouteCollection {
             return try await request.commands.transaction { commands in
                 let albumInput = AlbumInput(payload: payload)
                 let album = try await commands.albums.create(albumInput)
+                try await album.$preview.load(on: request.commandDB)
+                try await album.preview.$image.load(on: request.commandDB)
+                try await album.preview.$catalogueCategory.load(on: request.commandDB)
                 let notesInput = payload.notes.map {
                     BatchCreateNoteInput(
                         attachment: album.preview,
@@ -109,6 +112,9 @@ struct AlbumsAPIController: RouteCollection {
                         SyncNotesInput(attachment: preview, parentAccess: payload.access, entries: syncEntries)
                     )
                 }
+                try await album.$preview.load(on: request.commandDB)
+                try await album.preview.$image.load(on: request.commandDB)
+                try await album.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: albumID, of: Album.previewType)
                 return AlbumResponse(album: album, notes: notes, baseURL: request.baseURL)
             }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Books/Commands/Command/FetchBookCommand.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Books/Commands/Command/FetchBookCommand.swift
@@ -10,7 +10,11 @@ extension CommandFactory<FetchParameters<BookID>, Book> {
                 database: request.commandDB,
                 readPermission: request.permissions.books.access,
                 writePermission: request.permissions.books.edit,
-                load: \.$cover, \.$owner, \.$post
+                load: \.$cover, \.$owner, \.$post, \.$preview,
+                then: { book, db in
+                    try await book.preview.$image.load(on: db)
+                    try await book.preview.$catalogueCategory.load(on: db)
+                }
             )
             .logged(name: "Fetch Book", logger: request.logger)
         }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Books/Routes/API/BooksAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Books/Routes/API/BooksAPIController.swift
@@ -61,6 +61,9 @@ struct BooksAPIController: RouteCollection {
             return try await request.commands.transaction { commands in
                 let bookInput = BookInput(payload: payload)
                 let book = try await commands.books.create(bookInput)
+                try await book.$preview.load(on: request.commandDB)
+                try await book.preview.$image.load(on: request.commandDB)
+                try await book.preview.$catalogueCategory.load(on: request.commandDB)
                 let notesInput = payload.notes.map { entries in
                     BatchCreateNoteInput(
                         attachment: book.preview,
@@ -94,6 +97,9 @@ struct BooksAPIController: RouteCollection {
                         SyncNotesInput(attachment: preview, parentAccess: payload.access, entries: syncEntries)
                     )
                 }
+                try await book.$preview.load(on: request.commandDB)
+                try await book.preview.$image.load(on: request.commandDB)
+                try await book.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: bookID, of: Book.previewType)
                 return BookResponse(book: book, baseURL: request.baseURL, notes: notes)
             }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Movies/Commands/Command/FetchMovieCommand.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Movies/Commands/Command/FetchMovieCommand.swift
@@ -10,7 +10,11 @@ extension CommandFactory<FetchParameters<MovieID>, Movie> {
                 database: request.commandDB,
                 readPermission: request.permissions.movies.access,
                 writePermission: request.permissions.movies.edit,
-                load: \.$cover, \.$owner, \.$post
+                load: \.$cover, \.$owner, \.$post, \.$preview,
+                then: { movie, db in
+                    try await movie.preview.$image.load(on: db)
+                    try await movie.preview.$catalogueCategory.load(on: db)
+                }
             )
             .logged(name: "Fetch Movie", logger: request.logger)
         }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Movies/Routes/API/MoviesAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Movies/Routes/API/MoviesAPIController.swift
@@ -61,6 +61,9 @@ struct MoviesAPIController: RouteCollection {
             return try await request.commands.transaction { commands in
                 let movieInput = MovieInput(payload: payload)
                 let movie = try await commands.movies.create(movieInput)
+                try await movie.$preview.load(on: request.commandDB)
+                try await movie.preview.$image.load(on: request.commandDB)
+                try await movie.preview.$catalogueCategory.load(on: request.commandDB)
                 let notesInput = payload.notes.map { entries in
                     BatchCreateNoteInput(
                         attachment: movie.preview,
@@ -94,6 +97,9 @@ struct MoviesAPIController: RouteCollection {
                         SyncNotesInput(attachment: preview, parentAccess: payload.access, entries: syncEntries)
                     )
                 }
+                try await movie.$preview.load(on: request.commandDB)
+                try await movie.preview.$image.load(on: request.commandDB)
+                try await movie.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: movieID, of: Movie.previewType)
                 return MovieResponse(movie: movie, baseURL: request.baseURL, notes: notes)
             }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Commands/Command/FetchPlaylistCommand.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Commands/Command/FetchPlaylistCommand.swift
@@ -10,7 +10,11 @@ extension CommandFactory<FetchParameters<PlaylistID>, Playlist> {
                 database: request.commandDB,
                 readPermission: request.permissions.playlists.access,
                 writePermission: request.permissions.playlists.edit,
-                load: \.$artwork, \.$owner, \.$post
+                load: \.$artwork, \.$owner, \.$post, \.$preview,
+                then: { playlist, db in
+                    try await playlist.preview.$image.load(on: db)
+                    try await playlist.preview.$catalogueCategory.load(on: db)
+                }
             )
             .logged(name: "Fetch Playlist", logger: request.logger)
         }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/API/PlaylistsAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/API/PlaylistsAPIController.swift
@@ -58,6 +58,9 @@ struct PlaylistsAPIController: RouteCollection {
             return try await request.commands.transaction { commands in
                 let playlistInput = PlaylistInput(payload: payload)
                 let playlist = try await commands.playlists.create(playlistInput)
+                try await playlist.$preview.load(on: request.commandDB)
+                try await playlist.preview.$image.load(on: request.commandDB)
+                try await playlist.preview.$catalogueCategory.load(on: request.commandDB)
                 let notesInput = payload.notes.map {
                     BatchCreateNoteInput(
                         attachment: playlist.preview,
@@ -91,6 +94,9 @@ struct PlaylistsAPIController: RouteCollection {
                         SyncNotesInput(attachment: preview, parentAccess: payload.access, entries: syncEntries)
                     )
                 }
+                try await playlist.$preview.load(on: request.commandDB)
+                try await playlist.preview.$image.load(on: request.commandDB)
+                try await playlist.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: playlistID, of: Playlist.previewType)
                 return PlaylistResponse(playlist: playlist, notes: notes, baseURL: request.baseURL)
             }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/FetchPodcastCommand.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Commands/Command/FetchPodcastCommand.swift
@@ -10,7 +10,11 @@ extension CommandFactory<FetchParameters<PodcastID>, Podcast> {
                 database: request.commandDB,
                 readPermission: request.permissions.podcasts.access,
                 writePermission: request.permissions.podcasts.edit,
-                load: \.$artwork, \.$owner, \.$post
+                load: \.$artwork, \.$owner, \.$post, \.$preview,
+                then: { podcast, db in
+                    try await podcast.preview.$image.load(on: db)
+                    try await podcast.preview.$catalogueCategory.load(on: db)
+                }
             )
             .logged(name: "Fetch Podcast", logger: request.logger)
         }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Routes/API/PodcastsAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Routes/API/PodcastsAPIController.swift
@@ -66,6 +66,9 @@ struct PodcastsAPIController: RouteCollection {
             return try await request.commands.transaction { commands in
                 let podcastInput = PodcastInput(payload: payload)
                 let podcast = try await commands.podcasts.create(podcastInput)
+                try await podcast.$preview.load(on: request.commandDB)
+                try await podcast.preview.$image.load(on: request.commandDB)
+                try await podcast.preview.$catalogueCategory.load(on: request.commandDB)
                 let notesInput = payload.notes.map { entries in
                     BatchCreateNoteInput(
                         attachment: podcast.preview,
@@ -99,6 +102,9 @@ struct PodcastsAPIController: RouteCollection {
                         SyncNotesInput(attachment: preview, parentAccess: payload.access, entries: syncEntries)
                     )
                 }
+                try await podcast.$preview.load(on: request.commandDB)
+                try await podcast.preview.$image.load(on: request.commandDB)
+                try await podcast.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: podcastID, of: Podcast.previewType)
                 return PodcastResponse(podcast: podcast, baseURL: request.baseURL, notes: notes)
             }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Songs/Commands/Command/FetchSongCommand.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Songs/Commands/Command/FetchSongCommand.swift
@@ -10,7 +10,11 @@ extension CommandFactory<FetchParameters<SongID>, Song> {
                 database: request.commandDB,
                 readPermission: request.permissions.songs.access,
                 writePermission: request.permissions.songs.edit,
-                load: \.$artwork, \.$owner, \.$post
+                load: \.$artwork, \.$owner, \.$post, \.$preview,
+                then: { song, db in
+                    try await song.preview.$image.load(on: db)
+                    try await song.preview.$catalogueCategory.load(on: db)
+                }
             )
             .logged(name: "Fetch Song", logger: request.logger)
         }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Songs/Routes/API/SongsAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Songs/Routes/API/SongsAPIController.swift
@@ -61,6 +61,9 @@ struct SongsAPIController: RouteCollection {
             return try await request.commands.transaction { commands in
                 let songInput = SongInput(payload: payload)
                 let song = try await commands.songs.create(songInput)
+                try await song.$preview.load(on: request.commandDB)
+                try await song.preview.$image.load(on: request.commandDB)
+                try await song.preview.$catalogueCategory.load(on: request.commandDB)
                 let notesInput = payload.notes.map {
                     BatchCreateNoteInput(
                         attachment: song.preview,
@@ -94,6 +97,9 @@ struct SongsAPIController: RouteCollection {
                         SyncNotesInput(attachment: preview, parentAccess: payload.access, entries: syncEntries)
                     )
                 }
+                try await song.$preview.load(on: request.commandDB)
+                try await song.preview.$image.load(on: request.commandDB)
+                try await song.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: songID, of: Song.previewType)
                 return SongResponse(song: song, notes: notes, baseURL: request.baseURL)
             }
@@ -115,6 +121,9 @@ struct SongsAPIController: RouteCollection {
             }
             let payload = try request.content.decode(PromotePayload.self)
             let song = try await request.commands.songs.promote(payload.previewID)
+            try await song.$preview.load(on: request.commandDB)
+            try await song.preview.$image.load(on: request.commandDB)
+            try await song.preview.$catalogueCategory.load(on: request.commandDB)
             let notes = try await request.commands.notes.query(id: song.id!, of: Song.previewType)
             return SongResponse(song: song, notes: notes, baseURL: request.baseURL)
         }

--- a/tmbr-web/Sources/App/Modules/Notes/Commands/Note/Command+BatchFetchNotes.swift
+++ b/tmbr-web/Sources/App/Modules/Notes/Commands/Note/Command+BatchFetchNotes.swift
@@ -14,7 +14,7 @@ extension Command where Self == PlainCommand<GroupedNotesInput, [PreviewID: [Not
             guard !input.previewIDs.isEmpty else { return [:] }
             let query = Note.query(on: database)
                 .filter(\.$attachment.$id ~~ input.previewIDs)
-                .with(\.$attachment) { a in a.with(\.$image) }
+                .with(\.$attachment) { a in a.with(\.$image).with(\.$catalogueCategory) }
                 .with(\.$author)
                 .with(\.$quotes)
             try await permission.grant(query)

--- a/tmbr-web/Sources/App/Modules/Notes/Commands/Note/Command+FetchNotesByAttachment.swift
+++ b/tmbr-web/Sources/App/Modules/Notes/Commands/Note/Command+FetchNotesByAttachment.swift
@@ -16,8 +16,10 @@ extension Command where Self == PlainCommand<PreviewID, [Note]> {
                 .query(on: database)
                 .filter(\.$attachment.$id == attachmentID)
                 .with(\.$attachment) { attachment in
-                    attachment.with(\.$image)
+                    attachment.with(\.$image).with(\.$catalogueCategory)
                 }
+                .with(\.$author)
+                .with(\.$quotes)
                 .sort(\.$createdAt, .descending)
             try await permission.grant(query)
             return try await query.all()

--- a/tmbr-web/Sources/App/Modules/Notes/Commands/Note/Command+QueryNotes.swift
+++ b/tmbr-web/Sources/App/Modules/Notes/Commands/Note/Command+QueryNotes.swift
@@ -36,8 +36,10 @@ extension Command where Self == PlainCommand<QueryNotesInput, [Note]> {
                 .filter(Preview.self, \.$parentID == input.ownerID)
                 .languages(languages)
                 .with(\.$attachment) { attachment in
-                    attachment.with(\.$image)
+                    attachment.with(\.$image).with(\.$catalogueCategory)
                 }
+                .with(\.$author)
+                .with(\.$quotes)
                 .sort(\Note.$createdAt, .descending)
             try await permission.grant(query)
             return try await query.all()

--- a/tmbr-web/Sources/App/Modules/Notes/Routes/API/Responses/NoteResponse.swift
+++ b/tmbr-web/Sources/App/Modules/Notes/Routes/API/Responses/NoteResponse.swift
@@ -11,7 +11,7 @@ extension NoteResponse {
             attachment: PreviewResponse(preview: note.attachment, baseURL: baseURL),
             author: UserResponse(user: note.author),
             body: note.body,
-            created: note.createdAt ?? .now,
+            created: note.createdAt,
             language: note.language,
             quotes: note.quotes.map { quote in
                 QuoteResponse(

--- a/tmbr-web/Sources/App/Modules/Notes/Routes/Web/NoteViewModel.swift
+++ b/tmbr-web/Sources/App/Modules/Notes/Routes/Web/NoteViewModel.swift
@@ -44,7 +44,7 @@ struct NoteViewModel: Encodable, Sendable {
         self.init(
             id: try note.requireID(),
             body: formatter.format(note.body),
-            created: (note.createdAt ?? .now).formatted(.publishDate),
+            created: note.createdAt.formatted(.publishDate),
             editDetails: isEditable ? EditDetails(rawBody: note.body, access: note.access.rawValue, language: note.language.rawValue) : nil,
             error: error
         )


### PR DESCRIPTION
## Summary

- Replaces the stub detail view with a full per-type layout: artwork, credit, genre, release date, and external links; albums and playlists add a `TrackListSection` querying `ContainerEntryRecord`s synced from the track API
- `CatalogueItemNavigation` wraps a `UUID` (not a live SwiftData model) for `NavigationPath` — avoids stale-reference failures after syncs
- Notes query is predicate-backed at the SQL level: `NoteRecord.attachmentPreviewID == previewID` filters only the current item's notes
- `CatalogueItemDetailModel` (non-generic, parent-owned): captures the active section's id-bound refresh closure via `setRefresh()`, runs it under `loading`/`lastError`/`lastFetched` — errors captured, never thrown
- `CatalogueItemStatusLine`: parameterised twin of `CatalogueStatusLine` — "Updating…" / "Couldn't update · \<date\>" / "Updated \<date\>" row in the detail `List`; no alerts, `await model.run()` (no `try?`)
- Reader injects `\.apiBaseURL`; `@Upserter` assembles each section's syncer on demand from the foundation recipe namespace

## Test plan

- [ ] Song/album/book/movie/podcast/playlist detail views render correctly with artwork, credit, and info line
- [ ] Album and playlist detail shows `TrackListSection`
- [ ] Notes section shows only the current item's notes
- [ ] Pull-to-refresh shows "Updating…" during refresh, "Updated \<relative\>" on success, "Couldn't update" on network failure — no alert
- [ ] Orphan detail refresh preserves notes (`?notes=true` path)
- [ ] Navigation stable after a catalogue sync (no stale-reference crash)
- [ ] Catalogue tab pull-to-refresh still runs the full `SyncGroup` (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)