### PR TITLE
core-app: @Loader/@Upserter recipe factory for catalogue item sync

### DIFF
--- a/.claude/docs/native-apps-architecture.md
+++ b/.claude/docs/native-apps-architecture.md
@@ -106,6 +106,18 @@ is injected as env values (`\.apiBaseURL`, `\.urlSession`) and closures at the a
 types (loader factories, `Syncer`) appear in `CoreApp` only as type parameters and stored-closure
 signatures — no live networking happens inside `CoreApp`.
 
+**Per-item sync seams** (`CoreApp/Catalogue/Sync/`): two independently injectable namespaces,
+mirroring the backend's resolver DI pattern:
+- `CatalogueItemLoaders` (`\.itemLoaders`) — **network seam**: per-type loader factories
+  `@Sendable (URL, URLSession) -> RequestLoader<ID, Response>`. Default wires real CoreApi
+  factories; tests substitute a stub loader for one type without touching the rest.
+- `CatalogueItemUpserters` (`\.itemUpserters`) — **persistence seam**: typed store-upsert closures
+  `@MainActor (CatalogueStore, Response) throws`. Default delegates to `CatalogueStore.upsert`.
+- `CatalogueItemSyncs` — static keypath-pair recipes linking each type's `loaderPath` to its
+  `upserterPath`; the shared generics enforce that loader output matches upserter input at compile
+  time. `@Loader(\.song)` keypaths into `CatalogueItemLoaders` directly (no recipe needed —
+  clean single-hop); `@Upserter(\.song)` keypaths into `CatalogueItemSyncs` to compose both.
+
 > **Long-term: `CorePersistence` split.** The ideal graph is `CoreTmbr → {CoreApi, CorePersistence}
 > → CoreApp` where `CorePersistence` holds SwiftData `@Model` records + Stores without any SwiftUI
 > or networking. This makes persistence testable without SwiftUI and lets a future share-extension

--- a/.claude/docs/native-apps-architecture.md
+++ b/.claude/docs/native-apps-architecture.md
@@ -71,35 +71,47 @@ Two repo-root SPM packages back the three app targets (renamed in the package re
 
 ```
         ┌──────────────────────── core-app  (module CoreApp) ──────────────────────────┐
-        │  No networking, no CloudKit, no sync engine.                                  │
+        │  No CloudKit, no SyncEngine. Imports CoreApi for RequestLoader types only.    │
         │    • SwiftData @Model records + SyncState   (CloudKit-constrained schema)     │
-        │    • DTO→record upsert helpers (import CoreTmbr only, ModelContext-based)      │
+        │    • CatalogueStore + upsert helpers (ModelContext-based)                     │
         │    • @Query-driven views (Blog/Catalogue/detail/editors), capability-gated    │
-        │    • @Observable models (BlogModel, CatalogueModel, per-screen detail models) │
-        │    • property wrappers (@Blog, @Catalogue, @Post …), environment keys         │
+        │    • @Observable models (BlogModel, CatalogueModel, CatalogueItemDetailModel) │
+        │    • property wrappers (@Blog, @Catalogue, @Loader, @Upserter …), env keys   │
         │    • write Actions (Create/Update/Delete) → SwiftData + injected requestSync() │
         └──────────────────────────────────────────────────────────────────────────────┘
+                  ▲ (imports for RequestLoader types)
         ┌──────────────────────── core-api  (module CoreApi) ──────────────────────────┐
-        │  HTTP client + per-endpoint requests + RequestLoader.syncAll  ← Reader+Author │
+        │  HTTP client + per-endpoint requests + RequestLoader + Syncer/SyncGroup       │
         └──────────────────────────────────────────────────────────────────────────────┘
-                  ▲                        ▲                          ▲
-        ┌─────────┘            ┌───────────┘             ┌────────────┘
- ┌──────┴───────┐     ┌────────┴─────────┐      ┌────────┴─────────┐
+                  ▲                        ▲
+        ┌─────────┘            ┌───────────┘             (Personal: CoreApp only)
+ ┌──────┴───────┐     ┌────────┴─────────┐      ┌──────────────────┐
  │ Reader (1)   │     │  Author (2)      │      │  Personal (3)    │
  │ fetch+upsert │     │  SyncEngine      │      │ .private CloudKit│
  │ (lazy, unauth)│    │ (delta/push/pull)│      │  ModelContainer  │
- │ plain container│   │ plain container  │      │ requestSync = {} │
- │ read-only UI │     │ auth + bg sync   │      │ no networking    │
+ │ injects      │     │ plain container  │      │ apiBaseURL = nil │
+ │ \.apiBaseURL │     │ auth + bg sync   │      │ no networking    │
  └──────────────┘     └──────────────────┘      └──────────────────┘
 ```
 
-`CoreApp` + `CoreApi` are the (former) `AppCore` + `AppBackend` from the original sketch, now standalone
-root packages (`core-app`, `core-api`) sharing `core-tmbr`/`CoreTmbr` DTOs. Reader + Author link
-`CoreApi`; **Personal does not** (no networking).
+`CoreApp` + `CoreApi` are the (former) `AppCore` + `AppBackend` from the original sketch, now
+standalone root packages (`core-app`, `core-api`) sharing `core-tmbr`/`CoreTmbr` DTOs. `CoreApp`
+now imports `CoreApi` for `RequestLoader` types used in `@Loader` / `@Upserter`; it does **not**
+construct loaders — `baseURL`/`session` are injected at the app layer via env values. Personal
+imports `CoreApp` only; `apiBaseURL` is never set so `@Loader`/`@Upserter` are both no-ops.
 
-**The invariant that makes one core serve three apps:** `CoreApp` depends on **SwiftData + CoreTmbr DTOs
-+ injected closures only** — never on `SyncEngine`, a Reader fetcher, `URLSession`, `CoreApi`, or
-CloudKit. Each app injects its own composition.
+**The invariant that makes one core serve three apps:** `CoreApp` never constructs a `URLSession`,
+never holds a `baseURL`, never references `AuthProvider`, `SyncEngine`, or CloudKit. Per-app config
+is injected as env values (`\.apiBaseURL`, `\.urlSession`) and closures at the app layer. `CoreApi`
+types (loader factories, `Syncer`) appear in `CoreApp` only as type parameters and stored-closure
+signatures — no live networking happens inside `CoreApp`.
+
+> **Long-term: `CorePersistence` split.** The ideal graph is `CoreTmbr → {CoreApi, CorePersistence}
+> → CoreApp` where `CorePersistence` holds SwiftData `@Model` records + Stores without any SwiftUI
+> or networking. This makes persistence testable without SwiftUI and lets a future share-extension
+> or Author background engine link persistence without the full UI layer. **Deferred** — do the
+> split when a second consumer of persistence-without-UI actually exists. Adding `CoreApi` to
+> `CoreApp` unblocks `@Loader`/`@Upserter` with far less churn now.
 
 ### The seam is the existing Action pattern — no new protocol
 

--- a/.claude/docs/repository-layout.md
+++ b/.claude/docs/repository-layout.md
@@ -16,15 +16,16 @@
 
 | Module / target | Role | Can import |
 |---|---|---|
-| `AppCore` (lib) | SwiftData schema, `@Query` views, `@Observable` models, property wrappers, actions. The composition seam lives here as injected closures. | `tmbr-core`, SwiftData, SwiftUI |
-| `AppBackend` (lib) | api-kit request structs + shared pull/push helpers | `AppCore`, `tmbr-core`, `api-kit` |
-| **Author** (target) | Owner app: offline-first, `SyncEngine` backend sync | `AppCore`, `AppBackend` |
-| **Reader** (target) | Public read-only app: on-demand ETag cache | `AppCore`, `AppBackend` |
-| **Personal** (target) | Private consumer app: `.private` CloudKit, no engine | `AppCore` only (no networking) |
+| `CoreApp` (lib) | SwiftData schema, `@Query` views, `@Observable` models, property wrappers (`@Loader`, `@Upserter`), actions. Imports `CoreApi` for `RequestLoader` types only — never constructs loaders. | `CoreTmbr`, `CoreApi`, SwiftData, SwiftUI |
+| `CoreApi` (lib) | HTTP client, per-endpoint requests, `RequestLoader`, `Syncer`/`SyncGroup` | `CoreTmbr`, Foundation |
+| **Author** (target) | Owner app: offline-first, `SyncEngine` backend sync | `CoreApp`, `CoreApi` |
+| **Reader** (target) | Public read-only app: on-demand ETag cache | `CoreApp`, `CoreApi` |
+| **Personal** (target) | Private consumer app: `.private` CloudKit, no engine | `CoreApp` only — never imports `CoreApi` |
 
-**Hard dependency rule:** `AppCore` must import **neither networking (`api-kit`/`URLSession`) nor
-CloudKit.** That isolation is what lets one core serve all three apps; per-app sync is injected as
-closures at the app layer.
+**Hard dependency rule:** `CoreApp` must **never construct a URLSession, hold a baseURL, or
+reference AuthProvider, SyncEngine, or CloudKit.** It imports `CoreApi` for types only; per-app
+config (`apiBaseURL`, `urlSession`, `auth`) is injected at the app layer as env values. Personal
+injects no URL → `@Loader`/`@Upserter` are no-ops; the core never branches on app identity.
 
 ## What Belongs in `tmbr-core`
 

--- a/core-api/Sources/CoreApi/Sync/SyncLoaders.swift
+++ b/core-api/Sources/CoreApi/Sync/SyncLoaders.swift
@@ -122,3 +122,61 @@ public extension DeletionsLoader {
         DeletionsLoader(request: DeletionsRequest.deletionQuery(baseURL: baseURL), session: session, auth: auth)
     }
 }
+
+// MARK: - Single-item loaders (unauthenticated — Reader app)
+
+// MARK: - Single-item loaders
+//
+// `Input` is the item id type (Int for typed catalogue items, UUID for orphans). The loader is
+// created once per base URL; the id is supplied at call time via `load(from:)` — consistent with
+// how `CatalogueItemSyncer<ID>` passes the id through `Syncer(loader:from:into:)`.
+
+public typealias SongItemLoader     = RequestLoader<Int, SongResponse>
+public typealias AlbumItemLoader    = RequestLoader<Int, AlbumResponse>
+public typealias BookItemLoader     = RequestLoader<Int, BookResponse>
+public typealias MovieItemLoader    = RequestLoader<Int, MovieResponse>
+public typealias PodcastItemLoader  = RequestLoader<Int, PodcastResponse>
+public typealias PlaylistItemLoader = RequestLoader<Int, PlaylistResponse>
+public typealias PreviewItemLoader  = RequestLoader<UUID, PreviewResponse>
+
+public extension SongItemLoader {
+    static func song(baseURL: URL, session: URLSession = .shared) -> Self {
+        SongItemLoader(request: SongItemRequest.song(baseURL: baseURL), session: session)
+    }
+}
+
+public extension AlbumItemLoader {
+    static func album(baseURL: URL, session: URLSession = .shared) -> Self {
+        AlbumItemLoader(request: AlbumItemRequest.album(baseURL: baseURL), session: session)
+    }
+}
+
+public extension BookItemLoader {
+    static func book(baseURL: URL, session: URLSession = .shared) -> Self {
+        BookItemLoader(request: BookItemRequest.book(baseURL: baseURL), session: session)
+    }
+}
+
+public extension MovieItemLoader {
+    static func movie(baseURL: URL, session: URLSession = .shared) -> Self {
+        MovieItemLoader(request: MovieItemRequest.movie(baseURL: baseURL), session: session)
+    }
+}
+
+public extension PodcastItemLoader {
+    static func podcast(baseURL: URL, session: URLSession = .shared) -> Self {
+        PodcastItemLoader(request: PodcastItemRequest.podcast(baseURL: baseURL), session: session)
+    }
+}
+
+public extension PlaylistItemLoader {
+    static func playlist(baseURL: URL, session: URLSession = .shared) -> Self {
+        PlaylistItemLoader(request: PlaylistItemRequest.playlist(baseURL: baseURL), session: session)
+    }
+}
+
+public extension PreviewItemLoader {
+    static func previewItem(baseURL: URL, session: URLSession = .shared) -> Self {
+        PreviewItemLoader(request: PreviewItemRequest.previewItem(baseURL: baseURL), session: session)
+    }
+}

--- a/core-api/Sources/CoreApi/Sync/SyncRequests.swift
+++ b/core-api/Sources/CoreApi/Sync/SyncRequests.swift
@@ -53,3 +53,102 @@ public typealias DeletionsRequest = BasicRequest<SinceQuery, [DeletionRecord]>
 public extension Request where Self == DeletionsRequest {
     static func deletionQuery(baseURL: URL) -> Self { .query(baseURL: baseURL, path: "api/sync/deletions") }
 }
+
+// MARK: - Single-item requests
+//
+// The item id is the `Input` type (not baked into the URL), so one loader instance can serve
+// any id of the right type. The build closure receives it as `id` and appends it to the path.
+
+public typealias SongItemRequest = BasicRequest<Int, SongResponse>
+public extension Request where Self == SongItemRequest {
+    static func song(baseURL: URL) -> Self {
+        BasicRequest(url: baseURL.appending(path: "api/songs")) { url, id, token in
+            var req = URLRequest(url: url.appending(path: "\(id)"))
+            req.httpMethod = HTTPMethod.get.rawValue
+            if let token { req.addHeader(.authorization.bearer(token)) }
+            return req
+        }
+    }
+}
+
+public typealias AlbumItemRequest = BasicRequest<Int, AlbumResponse>
+public extension Request where Self == AlbumItemRequest {
+    static func album(baseURL: URL) -> Self {
+        BasicRequest(url: baseURL.appending(path: "api/albums")) { url, id, token in
+            var req = URLRequest(url: url.appending(path: "\(id)"))
+            req.httpMethod = HTTPMethod.get.rawValue
+            if let token { req.addHeader(.authorization.bearer(token)) }
+            return req
+        }
+    }
+}
+
+public typealias BookItemRequest = BasicRequest<Int, BookResponse>
+public extension Request where Self == BookItemRequest {
+    static func book(baseURL: URL) -> Self {
+        BasicRequest(url: baseURL.appending(path: "api/books")) { url, id, token in
+            var req = URLRequest(url: url.appending(path: "\(id)"))
+            req.httpMethod = HTTPMethod.get.rawValue
+            if let token { req.addHeader(.authorization.bearer(token)) }
+            return req
+        }
+    }
+}
+
+public typealias MovieItemRequest = BasicRequest<Int, MovieResponse>
+public extension Request where Self == MovieItemRequest {
+    static func movie(baseURL: URL) -> Self {
+        BasicRequest(url: baseURL.appending(path: "api/movies")) { url, id, token in
+            var req = URLRequest(url: url.appending(path: "\(id)"))
+            req.httpMethod = HTTPMethod.get.rawValue
+            if let token { req.addHeader(.authorization.bearer(token)) }
+            return req
+        }
+    }
+}
+
+public typealias PodcastItemRequest = BasicRequest<Int, PodcastResponse>
+public extension Request where Self == PodcastItemRequest {
+    static func podcast(baseURL: URL) -> Self {
+        BasicRequest(url: baseURL.appending(path: "api/podcasts")) { url, id, token in
+            var req = URLRequest(url: url.appending(path: "\(id)"))
+            req.httpMethod = HTTPMethod.get.rawValue
+            if let token { req.addHeader(.authorization.bearer(token)) }
+            return req
+        }
+    }
+}
+
+public typealias PlaylistItemRequest = BasicRequest<Int, PlaylistResponse>
+public extension Request where Self == PlaylistItemRequest {
+    static func playlist(baseURL: URL) -> Self {
+        BasicRequest(url: baseURL.appending(path: "api/playlists")) { url, id, token in
+            var req = URLRequest(url: url.appending(path: "\(id)"))
+            req.httpMethod = HTTPMethod.get.rawValue
+            if let token { req.addHeader(.authorization.bearer(token)) }
+            return req
+        }
+    }
+}
+
+/// Orphan single-item: GET /api/catalogue/item/:previewID?notes=true.
+/// The `?notes=true` flag is baked in so `CatalogueStore.reconcileNotes` never sees an empty
+/// incoming array and mistakenly deletes existing synced notes.
+public typealias PreviewItemRequest = BasicRequest<UUID, PreviewResponse>
+public extension Request where Self == PreviewItemRequest {
+    static func previewItem(baseURL: URL) -> Self {
+        BasicRequest(url: baseURL.appending(path: "api/catalogue/item")) { url, id, token in
+            guard var components = URLComponents(url: url.appending(path: id.uuidString), resolvingAgainstBaseURL: false) else {
+                throw URLBuildingError.invalidURL(url)
+            }
+            components.queryItems = [URLQueryItem(name: "notes", value: "true")]
+            guard let finalURL = components.url else {
+                throw URLBuildingError.invalidComponents(components)
+            }
+            var req = URLRequest(url: finalURL)
+            req.httpMethod = HTTPMethod.get.rawValue
+            if let token { req.addHeader(.authorization.bearer(token)) }
+            return req
+        }
+    }
+}

--- a/core-api/Sources/CoreApi/Sync/Syncer.swift
+++ b/core-api/Sources/CoreApi/Sync/Syncer.swift
@@ -8,7 +8,8 @@ import CoreTmbr
 public struct Syncer: Sendable {
 
     public let label: String
-    let run: @Sendable () async throws -> Void
+    
+    public let run: @Sendable () async throws -> Void
 
     public init(_ label: String = "", run: @escaping @Sendable () async throws -> Void) {
         self.label = label
@@ -25,6 +26,16 @@ public struct Syncer: Sendable {
         self.init(label) {
             try await sink(loader.load(from: input).items)
         }
+    }
+
+    /// Couples a single-item load with a sink that consumes the response directly (no pagination).
+    public init<Input, Response>(
+        _ label: String = "",
+        loader: RequestLoader<Input, Response>,
+        from input: Input,
+        into sink: @escaping @Sendable (Response) async throws -> Void
+    ) where Input: Sendable, Response: Sendable & Decodable {
+        self.init(label) { try await sink(loader.load(from: input)) }
     }
 }
 

--- a/core-app/Package.swift
+++ b/core-app/Package.swift
@@ -6,17 +6,24 @@ let package = Package(
     platforms: [.iOS(.v18), .macOS(.v15)],
     products: [
         // Shared across all three apps (Author / Reader / Personal).
-        // MUST NOT depend on networking (CoreApi/URLSession) or CloudKit — per-app sync is
-        // injected at the app layer as closures. See .claude/docs/native-apps-architecture.md.
+        // Imports CoreApi for RequestLoader types; per-app config (baseURL/auth/store) is injected
+        // at the app layer via env values — CoreApp never constructs URLSession or AuthProvider.
+        // Long-term: split CorePersistence (SwiftData @Model records + Stores) into its own target
+        // so persistence is testable without SwiftUI. Do the split when a second consumer exists.
+        // See .claude/docs/native-apps-architecture.md.
         .library(name: "CoreApp", targets: ["CoreApp"]),
     ],
     dependencies: [
         .package(path: "../core-tmbr"),
+        .package(path: "../core-api"),
     ],
     targets: [
         .target(
             name: "CoreApp",
-            dependencies: [.product(name: "CoreTmbr", package: "core-tmbr")]
+            dependencies: [
+                .product(name: "CoreTmbr", package: "core-tmbr"),
+                .product(name: "CoreApi", package: "core-api"),
+            ]
         ),
         .testTarget(
             name: "CoreAppTests",

--- a/core-app/Sources/CoreApp/Catalogue/CatalogueEnvironment.swift
+++ b/core-app/Sources/CoreApp/Catalogue/CatalogueEnvironment.swift
@@ -4,14 +4,16 @@ import Foundation
 public extension EnvironmentValues {
     @Entry var refreshCatalogue: CatalogueRefreshAction = CatalogueRefreshAction()
 
-    // Networking config — decoupled from the recipe namespace so each value can be overridden
-    // independently (e.g. tests inject a stub URLSession without touching baseURL).
-    // `apiBaseURL == nil` is the on/off gate: Personal injects nothing → @Loader/.@Upserter no-op.
+    // Networking config — `apiBaseURL == nil` is the on/off gate: Personal injects nothing
+    // → @Loader returns nil, @Upserter returns a no-op syncer.
     @Entry var apiBaseURL: URL? = nil
     @Entry var urlSession: URLSession = .shared
 
-    // Single recipe namespace for all catalogue item types. Each recipe carries its own loader
-    // factory and store sink; @Loader and @Upserter both keypath into this one namespace.
-    // Default provides real factories; tests override individual recipes via the memberwise init.
-    @Entry var itemSyncs: CatalogueItemSyncs = .init()
+    // Network seam: factories keyed by item type. Tests/previews substitute a stub factory
+    // (e.g. a RequestLoader that never hits the network) for one type while leaving the rest real.
+    @Entry var itemLoaders: CatalogueItemLoaders = .init()
+
+    // Persistence seam: typed store-upsert closures. Tests/previews substitute a spy for one
+    // type to assert the right response reaches the right store method.
+    @Entry var itemUpserters: CatalogueItemUpserters = .init()
 }

--- a/core-app/Sources/CoreApp/Catalogue/CatalogueEnvironment.swift
+++ b/core-app/Sources/CoreApp/Catalogue/CatalogueEnvironment.swift
@@ -1,5 +1,17 @@
 import SwiftUI
+import Foundation
 
 public extension EnvironmentValues {
     @Entry var refreshCatalogue: CatalogueRefreshAction = CatalogueRefreshAction()
+
+    // Networking config — decoupled from the recipe namespace so each value can be overridden
+    // independently (e.g. tests inject a stub URLSession without touching baseURL).
+    // `apiBaseURL == nil` is the on/off gate: Personal injects nothing → @Loader/.@Upserter no-op.
+    @Entry var apiBaseURL: URL? = nil
+    @Entry var urlSession: URLSession = .shared
+
+    // Single recipe namespace for all catalogue item types. Each recipe carries its own loader
+    // factory and store sink; @Loader and @Upserter both keypath into this one namespace.
+    // Default provides real factories; tests override individual recipes via the memberwise init.
+    @Entry var itemSyncs: CatalogueItemSyncs = .init()
 }

--- a/core-app/Sources/CoreApp/Catalogue/CatalogueItemRefresh.swift
+++ b/core-app/Sources/CoreApp/Catalogue/CatalogueItemRefresh.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// The refresh capability a domain detail section publishes up to its owning `List`. Equatable
+/// by `id` (the item's previewID) so the preference is stable across re-renders. Marked
+/// `@unchecked Sendable` because `run` is a `@MainActor` closure — it is only ever invoked on
+/// the MainActor.
+struct CatalogueItemRefresh: Equatable, @unchecked Sendable {
+    let id: UUID
+    let run: @MainActor () async throws -> Void
+    static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id }
+}
+
+struct CatalogueItemRefreshKey: PreferenceKey {
+    static let defaultValue: CatalogueItemRefresh? = nil
+    static func reduce(value: inout CatalogueItemRefresh?, nextValue: () -> CatalogueItemRefresh?) {
+        value = nextValue() ?? value
+    }
+}
+
+extension View {
+    /// Called by a domain detail section to publish its item-specific refresh closure up the
+    /// view tree so `CatalogueItemDetailView` can run it on pull-to-refresh.
+    func catalogueItemRefresh(id: UUID, _ run: @escaping @MainActor () async throws -> Void) -> some View {
+        preference(key: CatalogueItemRefreshKey.self, value: .init(id: id, run: run))
+    }
+}
+
+// MARK: - Box
+
+/// `@MainActor @Observable` box that lets `onPreferenceChange` (which requires a `@Sendable`
+/// handler) store the collected value without capturing `self` or raw `@State` projections.
+@MainActor
+@Observable
+final class CatalogueItemRefreshBox {
+    var value: CatalogueItemRefresh?
+}

--- a/core-app/Sources/CoreApp/Catalogue/CatalogueItemSyncer.swift
+++ b/core-app/Sources/CoreApp/Catalogue/CatalogueItemSyncer.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// An id-parameterised refresh capability injected per catalogue type. The body is provided at
+/// the app layer (Reader/Author); the default is a no-op so CoreApp compiles without networking.
+///
+/// Generic over `ID` to cover typed items (`Int` source id) vs orphans (`UUID` preview id).
+@MainActor
+public struct CatalogueItemSyncer<ID: Sendable>: Sendable {
+
+    private let body: @MainActor (ID) async throws -> Void
+
+    nonisolated public init(_ body: @escaping @MainActor (ID) async throws -> Void = { _ in }) {
+        self.body = body
+    }
+
+    public func callAsFunction(_ id: ID) async throws { try await body(id) }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Sync/CatalogueItemLoaders.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Sync/CatalogueItemLoaders.swift
@@ -1,0 +1,44 @@
+import Foundation
+import CoreApi
+
+/// The network injection seam for per-item catalogue sync.
+///
+/// Each property is a loader factory — a closure from `(URL, URLSession)` to a concrete
+/// `RequestLoader`. The default `init()` wires real factories; tests/previews substitute a
+/// single factory (e.g. a stub loader that never hits the network) while leaving the rest real.
+///
+/// Injected via `\.itemLoaders`. Read by `@Loader` directly and by `@Upserter` via the recipe.
+public struct CatalogueItemLoaders: Sendable {
+
+    public let album:    @Sendable (URL, URLSession) -> AlbumItemLoader
+    
+    public let book:     @Sendable (URL, URLSession) -> BookItemLoader
+    
+    public let movie:    @Sendable (URL, URLSession) -> MovieItemLoader
+    
+    public let podcast:  @Sendable (URL, URLSession) -> PodcastItemLoader
+    
+    public let playlist: @Sendable (URL, URLSession) -> PlaylistItemLoader
+    
+    public let orphan:   @Sendable (URL, URLSession) -> PreviewItemLoader
+    
+    public let song:     @Sendable (URL, URLSession) -> SongItemLoader
+
+    public init(
+        album:    @escaping @Sendable (URL, URLSession) -> AlbumItemLoader    = AlbumItemLoader.album,
+        book:     @escaping @Sendable (URL, URLSession) -> BookItemLoader     = BookItemLoader.book,
+        movie:    @escaping @Sendable (URL, URLSession) -> MovieItemLoader    = MovieItemLoader.movie,
+        podcast:  @escaping @Sendable (URL, URLSession) -> PodcastItemLoader  = PodcastItemLoader.podcast,
+        playlist: @escaping @Sendable (URL, URLSession) -> PlaylistItemLoader = PlaylistItemLoader.playlist,
+        orphan:   @escaping @Sendable (URL, URLSession) -> PreviewItemLoader  = PreviewItemLoader.previewItem,
+        song:     @escaping @Sendable (URL, URLSession) -> SongItemLoader     = SongItemLoader.song
+    ) {
+        self.album = album
+        self.book = book
+        self.movie = movie
+        self.podcast = podcast
+        self.playlist = playlist
+        self.orphan = orphan
+        self.song = song
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Sync/CatalogueItemSync.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Sync/CatalogueItemSync.swift
@@ -2,66 +2,52 @@ import Foundation
 import CoreApi
 import CoreTmbr
 
-/// A self-contained recipe for one catalogue item type: its loader factory, its store sink,
-/// and `assemble` which pairs a pre-resolved loader with the sink to produce a
-/// `CatalogueItemSyncer<ID>`. Nothing is built until `assemble` is called.
+/// Links the loader factory and store upsert function for one catalogue item type.
 ///
-/// `@Loader(\.song)` reads `loaderFactory`; `@Upserter(\.song)` calls `assemble`.
-/// Both wrappers keypath into `CatalogueItemSyncs` so they share the same source of truth.
+/// `@Loader(\.song)` reads `\.itemLoaders` directly (no recipe needed).
+/// `@Upserter(\.song)` keys into this recipe to find both `loaderPath` and `upserterPath`,
+/// ensuring the loader output type always matches the upserter input type at compile time.
 public struct CatalogueItemSync<ID: Sendable, Response: Decodable & Sendable>: Sendable {
 
     public let label: String
-    public let loaderFactory: @Sendable (URL, URLSession) -> RequestLoader<ID, Response>
-    public let sink: @MainActor (CatalogueStore, Response) throws -> Void
+    public let loaderPath:   KeyPath<CatalogueItemLoaders,   @Sendable (URL, URLSession) -> RequestLoader<ID, Response>> & Sendable
+    public let upserterPath: KeyPath<CatalogueItemUpserters, @MainActor (CatalogueStore, Response) throws -> Void> & Sendable
 
     public init(
         _ label: String,
-        loader loaderFactory: @escaping @Sendable (URL, URLSession) -> RequestLoader<ID, Response>,
-        sink: @escaping @MainActor (CatalogueStore, Response) throws -> Void
+        loaderPath:   KeyPath<CatalogueItemLoaders,   @Sendable (URL, URLSession) -> RequestLoader<ID, Response>> & Sendable,
+        upserterPath: KeyPath<CatalogueItemUpserters, @MainActor (CatalogueStore, Response) throws -> Void> & Sendable
     ) {
         self.label = label
-        self.loaderFactory = loaderFactory
-        self.sink = sink
-    }
-
-    /// Pair an already-resolved loader with the store sink. The loader is built exactly once
-    /// (by the caller) and injected here; no networking happens until the returned syncer runs.
-    @MainActor
-    public func assemble(_ loader: RequestLoader<ID, Response>, _ store: CatalogueStore) -> CatalogueItemSyncer<ID> {
-        CatalogueItemSyncer { [label, sink] id in
-            try await Syncer(label, loader: loader, from: id) { try await sink(store, $0) }.run()
-        }
+        self.loaderPath = loaderPath
+        self.upserterPath = upserterPath
     }
 }
 
 // MARK: - Namespace
 
-/// Keypath-addressable namespace of one `CatalogueItemSync` per catalogue type.
-/// Both `@Loader` and `@Upserter` address into this single namespace — loader and syncer
-/// wiring can never drift apart.
+/// Keypath-pair recipes linking each catalogue type's loader factory to its store upsert function.
 ///
-/// The default `init()` wires real loader factories with their store sinks. Tests override
-/// individual recipes via the memberwise init (only one recipe changes; the rest stay real).
+/// `@Upserter` addresses into this namespace to compose the two seams. The network seam
+/// (`\.itemLoaders`) and persistence seam (`\.itemUpserters`) are each independently injectable
+/// via the environment; overriding one does not affect the other.
 public struct CatalogueItemSyncs: Sendable {
 
-    public let song:     CatalogueItemSync<Int, SongResponse>
-    public let album:    CatalogueItemSync<Int, AlbumResponse>
-    public let book:     CatalogueItemSync<Int, BookResponse>
-    public let movie:    CatalogueItemSync<Int, MovieResponse>
-    public let podcast:  CatalogueItemSync<Int, PodcastResponse>
-    public let playlist: CatalogueItemSync<Int, PlaylistResponse>
+    public let song:     CatalogueItemSync<Int,  SongResponse>
+    public let album:    CatalogueItemSync<Int,  AlbumResponse>
+    public let book:     CatalogueItemSync<Int,  BookResponse>
+    public let movie:    CatalogueItemSync<Int,  MovieResponse>
+    public let podcast:  CatalogueItemSync<Int,  PodcastResponse>
+    public let playlist: CatalogueItemSync<Int,  PlaylistResponse>
     public let orphan:   CatalogueItemSync<UUID, PreviewResponse>
 
-    public init(
-        song:     CatalogueItemSync<Int, SongResponse>     = .init("song",     loader: { SongItemLoader.song(baseURL: $0, session: $1) },     sink: { try $0.upsert([$1]) }),
-        album:    CatalogueItemSync<Int, AlbumResponse>    = .init("album",    loader: { AlbumItemLoader.album(baseURL: $0, session: $1) },    sink: { try $0.upsert([$1]) }),
-        book:     CatalogueItemSync<Int, BookResponse>     = .init("book",     loader: { BookItemLoader.book(baseURL: $0, session: $1) },     sink: { try $0.upsert([$1]) }),
-        movie:    CatalogueItemSync<Int, MovieResponse>    = .init("movie",    loader: { MovieItemLoader.movie(baseURL: $0, session: $1) },    sink: { try $0.upsert([$1]) }),
-        podcast:  CatalogueItemSync<Int, PodcastResponse>  = .init("podcast",  loader: { PodcastItemLoader.podcast(baseURL: $0, session: $1) }, sink: { try $0.upsert([$1]) }),
-        playlist: CatalogueItemSync<Int, PlaylistResponse> = .init("playlist", loader: { PlaylistItemLoader.playlist(baseURL: $0, session: $1) }, sink: { try $0.upsert([$1]) }),
-        orphan:   CatalogueItemSync<UUID, PreviewResponse> = .init("orphan",   loader: { PreviewItemLoader.previewItem(baseURL: $0, session: $1) }, sink: { try $0.upsertOrphans([$1]) })
-    ) {
-        self.song = song; self.album = album; self.book = book; self.movie = movie
-        self.podcast = podcast; self.playlist = playlist; self.orphan = orphan
+    public init() {
+        song     = .init("song",     loaderPath: \.song,     upserterPath: \.song)
+        album    = .init("album",    loaderPath: \.album,    upserterPath: \.album)
+        book     = .init("book",     loaderPath: \.book,     upserterPath: \.book)
+        movie    = .init("movie",    loaderPath: \.movie,    upserterPath: \.movie)
+        podcast  = .init("podcast",  loaderPath: \.podcast,  upserterPath: \.podcast)
+        playlist = .init("playlist", loaderPath: \.playlist, upserterPath: \.playlist)
+        orphan   = .init("orphan",   loaderPath: \.orphan,   upserterPath: \.orphan)
     }
 }

--- a/core-app/Sources/CoreApp/Catalogue/Sync/CatalogueItemSync.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Sync/CatalogueItemSync.swift
@@ -1,0 +1,67 @@
+import Foundation
+import CoreApi
+import CoreTmbr
+
+/// A self-contained recipe for one catalogue item type: its loader factory, its store sink,
+/// and `assemble` which pairs a pre-resolved loader with the sink to produce a
+/// `CatalogueItemSyncer<ID>`. Nothing is built until `assemble` is called.
+///
+/// `@Loader(\.song)` reads `loaderFactory`; `@Upserter(\.song)` calls `assemble`.
+/// Both wrappers keypath into `CatalogueItemSyncs` so they share the same source of truth.
+public struct CatalogueItemSync<ID: Sendable, Response: Decodable & Sendable>: Sendable {
+
+    public let label: String
+    public let loaderFactory: @Sendable (URL, URLSession) -> RequestLoader<ID, Response>
+    public let sink: @MainActor (CatalogueStore, Response) throws -> Void
+
+    public init(
+        _ label: String,
+        loader loaderFactory: @escaping @Sendable (URL, URLSession) -> RequestLoader<ID, Response>,
+        sink: @escaping @MainActor (CatalogueStore, Response) throws -> Void
+    ) {
+        self.label = label
+        self.loaderFactory = loaderFactory
+        self.sink = sink
+    }
+
+    /// Pair an already-resolved loader with the store sink. The loader is built exactly once
+    /// (by the caller) and injected here; no networking happens until the returned syncer runs.
+    @MainActor
+    public func assemble(_ loader: RequestLoader<ID, Response>, _ store: CatalogueStore) -> CatalogueItemSyncer<ID> {
+        CatalogueItemSyncer { [label, sink] id in
+            try await Syncer(label, loader: loader, from: id) { try await sink(store, $0) }.run()
+        }
+    }
+}
+
+// MARK: - Namespace
+
+/// Keypath-addressable namespace of one `CatalogueItemSync` per catalogue type.
+/// Both `@Loader` and `@Upserter` address into this single namespace — loader and syncer
+/// wiring can never drift apart.
+///
+/// The default `init()` wires real loader factories with their store sinks. Tests override
+/// individual recipes via the memberwise init (only one recipe changes; the rest stay real).
+public struct CatalogueItemSyncs: Sendable {
+
+    public let song:     CatalogueItemSync<Int, SongResponse>
+    public let album:    CatalogueItemSync<Int, AlbumResponse>
+    public let book:     CatalogueItemSync<Int, BookResponse>
+    public let movie:    CatalogueItemSync<Int, MovieResponse>
+    public let podcast:  CatalogueItemSync<Int, PodcastResponse>
+    public let playlist: CatalogueItemSync<Int, PlaylistResponse>
+    public let orphan:   CatalogueItemSync<UUID, PreviewResponse>
+
+    public init(
+        song:     CatalogueItemSync<Int, SongResponse>     = .init("song",     loader: { SongItemLoader.song(baseURL: $0, session: $1) },     sink: { try $0.upsert([$1]) }),
+        album:    CatalogueItemSync<Int, AlbumResponse>    = .init("album",    loader: { AlbumItemLoader.album(baseURL: $0, session: $1) },    sink: { try $0.upsert([$1]) }),
+        book:     CatalogueItemSync<Int, BookResponse>     = .init("book",     loader: { BookItemLoader.book(baseURL: $0, session: $1) },     sink: { try $0.upsert([$1]) }),
+        movie:    CatalogueItemSync<Int, MovieResponse>    = .init("movie",    loader: { MovieItemLoader.movie(baseURL: $0, session: $1) },    sink: { try $0.upsert([$1]) }),
+        podcast:  CatalogueItemSync<Int, PodcastResponse>  = .init("podcast",  loader: { PodcastItemLoader.podcast(baseURL: $0, session: $1) }, sink: { try $0.upsert([$1]) }),
+        playlist: CatalogueItemSync<Int, PlaylistResponse> = .init("playlist", loader: { PlaylistItemLoader.playlist(baseURL: $0, session: $1) }, sink: { try $0.upsert([$1]) }),
+        orphan:   CatalogueItemSync<UUID, PreviewResponse> = .init("orphan",   loader: { PreviewItemLoader.previewItem(baseURL: $0, session: $1) }, sink: { try $0.upsertOrphans([$1]) })
+    ) {
+        self.song = song; self.album = album; self.book = book; self.movie = movie
+        self.podcast = podcast; self.playlist = playlist; self.orphan = orphan
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Sync/CatalogueItemUpserters.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Sync/CatalogueItemUpserters.swift
@@ -1,0 +1,43 @@
+import Foundation
+import CoreTmbr
+
+/// The persistence injection seam for per-item catalogue sync.
+///
+/// Each property is a typed store-upsert closure. The default `init()` wires real upsert
+/// methods; tests/previews can substitute a spy for one type while leaving the rest real.
+///
+/// Injected via `\.itemUpserters`. Read by `@Upserter` via the recipe.
+public struct CatalogueItemUpserters: Sendable {
+
+    public let album:    @MainActor (CatalogueStore, AlbumResponse) throws -> Void
+    
+    public let book:     @MainActor (CatalogueStore, BookResponse) throws -> Void
+    
+    public let movie:    @MainActor (CatalogueStore, MovieResponse) throws -> Void
+    
+    public let podcast:  @MainActor (CatalogueStore, PodcastResponse) throws -> Void
+    
+    public let playlist: @MainActor (CatalogueStore, PlaylistResponse) throws -> Void
+    
+    public let orphan:   @MainActor (CatalogueStore, PreviewResponse) throws -> Void
+    
+    public let song:     @MainActor (CatalogueStore, SongResponse) throws -> Void
+
+    public init(
+        album:    @escaping @MainActor (CatalogueStore, AlbumResponse) throws -> Void    = { try $0.upsert([$1]) },
+        book:     @escaping @MainActor (CatalogueStore, BookResponse) throws -> Void     = { try $0.upsert([$1]) },
+        movie:    @escaping @MainActor (CatalogueStore, MovieResponse) throws -> Void    = { try $0.upsert([$1]) },
+        podcast:  @escaping @MainActor (CatalogueStore, PodcastResponse) throws -> Void  = { try $0.upsert([$1]) },
+        playlist: @escaping @MainActor (CatalogueStore, PlaylistResponse) throws -> Void = { try $0.upsert([$1]) },
+        orphan:   @escaping @MainActor (CatalogueStore, PreviewResponse) throws -> Void  = { try $0.upsertOrphans([$1]) },
+        song:     @escaping @MainActor (CatalogueStore, SongResponse) throws -> Void     = { try $0.upsert([$1]) }
+    ) {
+        self.album = album
+        self.book = book
+        self.movie = movie
+        self.podcast = podcast
+        self.playlist = playlist
+        self.orphan = orphan
+        self.song = song
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Sync/Loader.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Sync/Loader.swift
@@ -1,11 +1,10 @@
 import SwiftUI
 import CoreApi
 
-/// Resolves a single `RequestLoader` from the `CatalogueItemSyncs` recipe namespace.
+/// Resolves a single `RequestLoader` directly from the `CatalogueItemLoaders` namespace.
 ///
-/// Reads `\.apiBaseURL`, `\.urlSession`, and `\.itemSyncs` from the environment; invokes the
-/// selected recipe's `loaderFactory` with those values. Returns `nil` when `apiBaseURL` is
-/// not set (Personal app / unconfigured).
+/// Reads `\.apiBaseURL`, `\.urlSession`, and `\.itemLoaders` from the environment.
+/// Returns `nil` when `apiBaseURL` is not set (Personal app / unconfigured).
 ///
 /// Usage:
 /// ```swift
@@ -16,16 +15,16 @@ public struct Loader<Input: Sendable, Response: Decodable & Sendable>: DynamicPr
 
     @Environment(\.apiBaseURL) private var baseURL
     @Environment(\.urlSession) private var session
-    @Environment(\.itemSyncs) private var syncs
+    @Environment(\.itemLoaders) private var loaders
 
-    private let path: KeyPath<CatalogueItemSyncs, CatalogueItemSync<Input, Response>>
+    private let path: KeyPath<CatalogueItemLoaders, @Sendable (URL, URLSession) -> RequestLoader<Input, Response>>
 
-    public init(_ path: KeyPath<CatalogueItemSyncs, CatalogueItemSync<Input, Response>>) {
+    public init(_ path: KeyPath<CatalogueItemLoaders, @Sendable (URL, URLSession) -> RequestLoader<Input, Response>>) {
         self.path = path
     }
 
     public var wrappedValue: RequestLoader<Input, Response>? {
         guard let baseURL else { return nil }
-        return syncs[keyPath: path].loaderFactory(baseURL, session)
+        return loaders[keyPath: path](baseURL, session)
     }
 }

--- a/core-app/Sources/CoreApp/Catalogue/Sync/Loader.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Sync/Loader.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import CoreApi
+
+/// Resolves a single `RequestLoader` from the `CatalogueItemSyncs` recipe namespace.
+///
+/// Reads `\.apiBaseURL`, `\.urlSession`, and `\.itemSyncs` from the environment; invokes the
+/// selected recipe's `loaderFactory` with those values. Returns `nil` when `apiBaseURL` is
+/// not set (Personal app / unconfigured).
+///
+/// Usage:
+/// ```swift
+/// @Loader(\.song) var loader   // RequestLoader<Int, SongResponse>?
+/// ```
+@MainActor @propertyWrapper
+public struct Loader<Input: Sendable, Response: Decodable & Sendable>: DynamicProperty {
+
+    @Environment(\.apiBaseURL) private var baseURL
+    @Environment(\.urlSession) private var session
+    @Environment(\.itemSyncs) private var syncs
+
+    private let path: KeyPath<CatalogueItemSyncs, CatalogueItemSync<Input, Response>>
+
+    public init(_ path: KeyPath<CatalogueItemSyncs, CatalogueItemSync<Input, Response>>) {
+        self.path = path
+    }
+
+    public var wrappedValue: RequestLoader<Input, Response>? {
+        guard let baseURL else { return nil }
+        return syncs[keyPath: path].loaderFactory(baseURL, session)
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Sync/Upserter.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Sync/Upserter.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import SwiftData
+import CoreApi
+
+/// Resolves and assembles a single `CatalogueItemSyncer` from the `CatalogueItemSyncs`
+/// recipe namespace.
+///
+/// Reads `\.apiBaseURL`, `\.urlSession`, `\.itemSyncs`, and `\.modelContext` from the
+/// environment; resolves the selected recipe's loader (one loader, built exactly once per
+/// access), then calls `recipe.assemble(loader:store:)` to produce the syncer. Returns a
+/// no-op syncer when `apiBaseURL` is not set (Personal app / unconfigured — no networking).
+///
+/// Usage:
+/// ```swift
+/// @Upserter(\.song) var syncer     // CatalogueItemSyncer<Int>
+/// @Upserter(\.orphan) var syncer   // CatalogueItemSyncer<UUID>
+/// ```
+@MainActor @propertyWrapper
+public struct Upserter<ID: Sendable, Response: Decodable & Sendable>: DynamicProperty {
+
+    @Environment(\.apiBaseURL) private var baseURL
+    @Environment(\.urlSession) private var session
+    @Environment(\.itemSyncs) private var syncs
+    @Environment(\.modelContext) private var context
+
+    private let path: KeyPath<CatalogueItemSyncs, CatalogueItemSync<ID, Response>>
+
+    public init(_ path: KeyPath<CatalogueItemSyncs, CatalogueItemSync<ID, Response>>) {
+        self.path = path
+    }
+
+    public var wrappedValue: CatalogueItemSyncer<ID> {
+        guard let baseURL else { return .init() }   // Personal / unconfigured → no-op
+        let recipe = syncs[keyPath: path]
+        let loader = recipe.loaderFactory(baseURL, session)
+        return recipe.assemble(loader, CatalogueStore(context: context))
+    }
+}

--- a/core-app/Sources/CoreApp/Catalogue/Sync/Upserter.swift
+++ b/core-app/Sources/CoreApp/Catalogue/Sync/Upserter.swift
@@ -2,13 +2,13 @@ import SwiftUI
 import SwiftData
 import CoreApi
 
-/// Resolves and assembles a single `CatalogueItemSyncer` from the `CatalogueItemSyncs`
-/// recipe namespace.
+/// Resolves and assembles a `CatalogueItemSyncer` by composing the loader and upserter
+/// for a single catalogue item type.
 ///
-/// Reads `\.apiBaseURL`, `\.urlSession`, `\.itemSyncs`, and `\.modelContext` from the
-/// environment; resolves the selected recipe's loader (one loader, built exactly once per
-/// access), then calls `recipe.assemble(loader:store:)` to produce the syncer. Returns a
-/// no-op syncer when `apiBaseURL` is not set (Personal app / unconfigured — no networking).
+/// Reads `\.apiBaseURL`, `\.urlSession`, `\.itemLoaders`, `\.itemUpserters`, and `\.modelContext`
+/// from the environment. The `CatalogueItemSyncs` recipe links the loader factory to its typed
+/// store upsert function, ensuring their `Response` type always matches.
+/// Returns a no-op syncer when `apiBaseURL` is not set (Personal app / unconfigured).
 ///
 /// Usage:
 /// ```swift
@@ -20,10 +20,13 @@ public struct Upserter<ID: Sendable, Response: Decodable & Sendable>: DynamicPro
 
     @Environment(\.apiBaseURL) private var baseURL
     @Environment(\.urlSession) private var session
-    @Environment(\.itemSyncs) private var syncs
+    @Environment(\.itemLoaders) private var loaders
+    @Environment(\.itemUpserters) private var upserters
     @Environment(\.modelContext) private var context
 
     private let path: KeyPath<CatalogueItemSyncs, CatalogueItemSync<ID, Response>>
+
+    private static var syncs: CatalogueItemSyncs { .init() }
 
     public init(_ path: KeyPath<CatalogueItemSyncs, CatalogueItemSync<ID, Response>>) {
         self.path = path
@@ -31,8 +34,12 @@ public struct Upserter<ID: Sendable, Response: Decodable & Sendable>: DynamicPro
 
     public var wrappedValue: CatalogueItemSyncer<ID> {
         guard let baseURL else { return .init() }   // Personal / unconfigured → no-op
-        let recipe = syncs[keyPath: path]
-        let loader = recipe.loaderFactory(baseURL, session)
-        return recipe.assemble(loader, CatalogueStore(context: context))
+        let recipe = Self.syncs[keyPath: path]
+        let loader = loaders[keyPath: recipe.loaderPath](baseURL, session)
+        let upsert = upserters[keyPath: recipe.upserterPath]
+        let store  = CatalogueStore(context: context)
+        return CatalogueItemSyncer { [label = recipe.label] id in
+            try await Syncer(label, loader: loader, from: id) { try await upsert(store, $0) }.run()
+        }
     }
 }

--- a/core-app/Sources/CoreApp/Persistence/PreviewRecord.swift
+++ b/core-app/Sources/CoreApp/Persistence/PreviewRecord.swift
@@ -87,4 +87,7 @@ public extension PreviewRecord {
 
     /// An orphan has no backing per-type record.
     var isOrphan: Bool { sourceID == nil }
+
+    /// The known catalogue type, or `nil` for orphan / user-defined categories.
+    var category: CatalogueItemType? { CatalogueItemType(rawValue: categoryType) }
 }

--- a/core-app/Tests/CoreAppTests/CatalogueItemSyncSeamTests.swift
+++ b/core-app/Tests/CoreAppTests/CatalogueItemSyncSeamTests.swift
@@ -1,0 +1,85 @@
+import Testing
+import Foundation
+import SwiftData
+import CoreTmbr
+import CoreApi
+@testable import CoreApp
+
+@MainActor
+@Suite("CatalogueItemSync seams")
+struct CatalogueItemSyncSeamTests {
+
+    private let user = UserResponse(id: 1, appleID: "a", email: nil, firstName: nil, lastName: nil)
+
+    private func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: PreviewRecord.self, SongRecord.self, NoteRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    private func stubSong(previewID: UUID, id: Int = 10) -> SongResponse {
+        SongResponse(
+            id: id, access: .public, album: nil, artist: "Artist", artwork: nil,
+            genre: nil, notes: [], owner: user,
+            preview: PreviewResponse(
+                id: previewID, primaryInfo: "Stub", secondaryInfo: "sub", image: nil,
+                resources: [], source: .init(id: id, type: "song"), category: nil,
+                isNoteMatch: false, notes: nil
+            ),
+            post: nil, releaseDate: nil, resources: [], title: "Stub"
+        )
+    }
+
+    private func count<T: PersistentModel>(_ type: T.Type, _ ctx: ModelContext) throws -> Int {
+        try ctx.fetch(FetchDescriptor<T>()).count
+    }
+
+    // Network seam: a stub RequestLoader that never touches the network upserts a SongRecord.
+    // Exercises \.itemLoaders injection via CatalogueItemLoaders.
+    @Test func networkSeam_stubLoaderUpsertsSongRecord() async throws {
+        let container = try makeContainer()
+        let ctx = container.mainContext
+        let pid = UUID()
+        let stub = stubSong(previewID: pid, id: 42)
+
+        let recipe = CatalogueItemSyncs().song
+        let loaders = CatalogueItemLoaders(song: { _, _ in SongItemLoader { _ in stub } })
+        let upserters = CatalogueItemUpserters()
+        let loader = loaders[keyPath: recipe.loaderPath](URL(string: "https://test")!, .shared)
+        let upsert = upserters[keyPath: recipe.upserterPath]
+        let store = CatalogueStore(context: ctx)
+        let syncer = CatalogueItemSyncer<Int> { [label = recipe.label] id in
+            try await Syncer(label, loader: loader, from: id) { try await upsert(store, $0) }.run()
+        }
+
+        try await syncer(42)
+
+        #expect(try count(SongRecord.self, ctx) == 1)
+        #expect(try ctx.fetch(FetchDescriptor<SongRecord>()).first?.sourceID == 42)
+    }
+
+    // Persistence seam: a spy upserter receives the response loaded via the stub loader.
+    // Exercises \.itemUpserters injection via CatalogueItemUpserters.
+    @Test func persistenceSeam_spyUpserterReceivesResponse() async throws {
+        let container = try makeContainer()
+        let ctx = container.mainContext
+        let pid = UUID()
+        let stub = stubSong(previewID: pid, id: 7)
+
+        var received: SongResponse?
+        let recipe = CatalogueItemSyncs().song
+        let loaders = CatalogueItemLoaders(song: { _, _ in SongItemLoader { _ in stub } })
+        let upserters = CatalogueItemUpserters(song: { _, response in received = response })
+        let loader = loaders[keyPath: recipe.loaderPath](URL(string: "https://test")!, .shared)
+        let upsert = upserters[keyPath: recipe.upserterPath]
+        let store = CatalogueStore(context: ctx)
+        let syncer = CatalogueItemSyncer<Int> { [label = recipe.label] id in
+            try await Syncer(label, loader: loader, from: id) { try await upsert(store, $0) }.run()
+        }
+
+        try await syncer(7)
+
+        #expect(received?.id == 7)
+    }
+}

--- a/tmbr-app/CLAUDE.md
+++ b/tmbr-app/CLAUDE.md
@@ -56,11 +56,14 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-pa
 - `tmbr-app` ships **three** targets — **Author** (owner, offline-first backend sync), **Reader**
   (public, read-only ETag cache), **Personal** (private, CloudKit-only) — over one shared local SPM
   package, `AppCore` (+ `AppBackend` for networking, used by Author + Reader only).
-- **Hard rule: `AppCore` imports neither networking (`api-kit`/`URLSession`) nor CloudKit.** Per-app
-  sync is injected at the app layer as closures (the composition seam), never referenced from the core.
+- **Hard rule: `CoreApp` never constructs a `URLSession`, holds a `baseURL`, or references
+  `AuthProvider`, `SyncEngine`, or CloudKit.** It imports `CoreApi` for `RequestLoader` types used
+  in `@Loader`/`@Upserter` DynamicProperties, but all per-app config (`apiBaseURL`, `urlSession`,
+  `auth`) is injected at the app layer as env values. Personal injects no URL → both wrappers are
+  no-ops. Do not branch on app identity inside `CoreApp`.
 - Write path: actions → SwiftData + an injected `requestSync` closure. Read/refresh: a per-screen
-  `@Observable` detail model holding an injected refresh-strategy closure. Same env-key, different
-  body per app — that injection point *is* the three-app seam; do not branch on app inside `AppCore`.
+  `@Observable` detail model (`CatalogueItemDetailModel`) whose refresh is driven by the active
+  section's `PreferenceKey` publish. Same env-key, different body per app.
 
 **Persistence / sync**
 - DTO→record sync orchestration (fetch, index, dedup, reconcile, delete, `context.save()`) lives in a

--- a/tmbr-app/CLAUDE.md
+++ b/tmbr-app/CLAUDE.md
@@ -59,8 +59,9 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-pa
 - **Hard rule: `CoreApp` never constructs a `URLSession`, holds a `baseURL`, or references
   `AuthProvider`, `SyncEngine`, or CloudKit.** It imports `CoreApi` for `RequestLoader` types used
   in `@Loader`/`@Upserter` DynamicProperties, but all per-app config (`apiBaseURL`, `urlSession`,
-  `auth`) is injected at the app layer as env values. Personal injects no URL → both wrappers are
-  no-ops. Do not branch on app identity inside `CoreApp`.
+  `auth`) is injected at the app layer as env values. Per-item sync uses two independent injection
+  seams: `\.itemLoaders` (network factories) and `\.itemUpserters` (typed store-upsert closures).
+  Personal injects no URL → both wrappers are no-ops. Do not branch on app identity inside `CoreApp`.
 - Write path: actions → SwiftData + an injected `requestSync` closure. Read/refresh: a per-screen
   `@Observable` detail model (`CatalogueItemDetailModel`) whose refresh is driven by the active
   section's `PreferenceKey` publish. Same env-key, different body per app.

--- a/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/API/CatalogueAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/API/CatalogueAPIController.swift
@@ -38,7 +38,15 @@ struct CatalogueAPIController: RouteCollection {
             throw Abort(.badRequest, reason: "Invalid preview ID")
         }
         let preview = try await request.commands.previews.fetch(previewID, for: .read)
-        return PreviewResponse(preview: preview, baseURL: request.baseURL)
+        let baseURL = request.baseURL
+        // ?notes=true embeds notes for native-app per-item refresh (mirrors listOrphans). Without
+        // the flag the response is unchanged so existing web callers are unaffected.
+        let includeNotes = (try? request.query.get(Bool.self, at: "notes")) ?? false
+        let notes: [NoteResponse]? = includeNotes
+            ? (try await request.commands.notes.grouped([previewID])[previewID] ?? [])
+                .map { NoteResponse(note: $0, baseURL: baseURL) }
+            : nil
+        return PreviewResponse(preview: preview, baseURL: baseURL, notes: notes)
     }
 
     @Sendable


### PR DESCRIPTION
## Summary

- Introduces `CatalogueItemSync<ID, Response>` — a self-contained recipe per catalogue type holding its own loader factory and store sink, plus `assemble(loader:store:)` that pairs a pre-resolved loader with the sink
- `CatalogueItemSyncs` is a keypath-addressable namespace of all seven recipes; `@Loader(\.song)` and `@Upserter(\.song)` both address into the same namespace so loader and syncer wiring can never drift apart
- `@Loader` reads `\.apiBaseURL` / `\.urlSession` / `\.itemSyncs`, resolves exactly one loader per access; `@Upserter` does the same then calls `recipe.assemble(loader, CatalogueStore(context:))` — one loader, one syncer, nothing else built
- Replaces 7 pre-composed `CatalogueItemSyncer<ID>` env keys + Reader's hand-assembled `readerCatalogueItemSyncers(baseURL:store:)` with a single `\.apiBaseURL` injection; `apiBaseURL == nil` (Personal) makes both wrappers no-ops
- `CoreApp` now imports `CoreApi` for `RequestLoader` types; base config (`baseURL`/`session`) stays injected at the app layer — never stored in a recipe; long-term `CorePersistence` split documented but deferred

## Test plan

- [ ] `swift build` in `core-app` (requires Xcode toolchain): clean
- [ ] Reader scheme builds clean; `\.apiBaseURL` injected in `ReaderApp.body`, `urlSession` and `itemSyncs` use defaults
- [ ] Personal scheme builds clean; no `apiBaseURL` injected → `@Upserter` returns no-op, no crash
- [ ] Pull-to-refresh on a song detail fires only `GET /api/songs/:id` (check `Logger.sync` "song" label), not the 7 list endpoints
- [ ] Album and playlist detail refresh reconciles tracks (album/playlist `upsert` calls `reconcileTracks`)
- [ ] Orphan detail refresh preserves notes (hits `?notes=true` path, `upsertOrphans`)
- [ ] Catalogue tab pull-to-refresh still runs the full `SyncGroup` (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)