### PR TITLE
fix: add RSS guid elements and force UTC dates

### DIFF
--- a/tmbr-core/Sources/TmbrCore/Formatting/Date+Formatting.swift
+++ b/tmbr-core/Sources/TmbrCore/Formatting/Date+Formatting.swift
@@ -57,6 +57,7 @@ public struct DateFormat: Sendable {
     public static let rfc822 = Self { date in
         let dateFormatter = DateFormatter()
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(identifier: "UTC")
         dateFormatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
         return dateFormatter.string(from: date)
     }

--- a/tmbr-web/Resources/Views/rss.leaf
+++ b/tmbr-web/Resources/Views/rss.leaf
@@ -10,6 +10,7 @@
       <item>
         <title>#(post.title)</title>
         <link>#(post.url)</link>
+        <guid>#(post.url)</guid>
         <pubDate>#(post.publishDate)</pubDate>
       </item>
       #endfor


### PR DESCRIPTION
## Summary

- Add `<guid>` per RSS item so readers can de-duplicate and track read state across polls (without it, many readers re-show every item as new on every fetch)
- Pin `rfc822` `DateFormatter` to UTC so `<pubDate>` values are consistent — without this, dates reflected the server's local timezone (`+0200` on dev, `+0000` on prod)

## Test plan

- [ ] Restart local server and confirm `pubDate` values in `/rss.xml` now show `+0000`
- [ ] Confirm each `<item>` contains a `<guid>` equal to the post URL
- [ ] Validate feed at https://validator.w3.org/feed/

🤖 Generated with [Claude Code](https://claude.com/claude-code)