### PR TITLE
fix: mobile toolbar overlaps site navigation on detail pages

### DIFF
--- a/tmbr-web/Public/Styles/Shared/main.css
+++ b/tmbr-web/Public/Styles/Shared/main.css
@@ -972,7 +972,9 @@ p.published-date {
 
 @media screen and (max-width: 600px) {
     main {
-        padding: calc(env(safe-area-inset-top) + 20px) 1.2em 20px 1.2em;
+        /* top padding matches toolbar height (~52px = 17px icon + 2×16px margin)
+           to prevent the absolute-positioned toolbar from overlapping the site navigation */
+        padding: calc(env(safe-area-inset-top) + 52px) 1.2em 20px 1.2em;
     }
     
     main > section > ul.counted > a > li {


### PR DESCRIPTION
## Summary

- On screens ≤600px, `#toolbar` (`position: absolute; top: 0`) occupies ~52px at the top of the viewport but `main`'s mobile top padding was only `env(safe-area-inset-top) + 20px` — leaving the Blog/Catalogue/Quotes nav links under the toolbar and untappable
- Raised mobile `padding-top` to `env(safe-area-inset-top) + 52px` to match the actual toolbar footprint (17px icon + 2×16px margin), mirroring how the desktop value of 60px already clears it
- Affects all detail pages (`post.leaf`, `quote.leaf`, `catalogue/details.leaf`) and list pages

## Test plan

- [ ] `swift run Backend serve` from `tmbr-web/`
- [ ] Open a post detail page in browser responsive mode at ≤600px — confirm Blog/Catalogue/Quotes links are fully clear of the globe icon and tappable
- [ ] Repeat for a catalogue detail and a quote detail page
- [ ] Confirm list pages (`/posts`, `/catalogue`, `/quotes`) and desktop widths (>600px) look unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)