### PR TITLE
feat: catalogue filter popover with dynamic categories

### DIFF
--- a/app-api/Sources/AppApi/Sync/SyncLoaders.swift
+++ b/app-api/Sources/AppApi/Sync/SyncLoaders.swift
@@ -11,8 +11,9 @@ public typealias MoviesLoader    = RequestLoader<PageQuery, PageResult<MovieResp
 public typealias PodcastsLoader  = RequestLoader<PageQuery, PageResult<PodcastResponse>>
 public typealias PlaylistsLoader = RequestLoader<PageQuery, PageResult<PlaylistResponse>>
 public typealias PostsLoader     = RequestLoader<PageQuery, PageResult<PostResponse>>
-public typealias OrphansLoader   = RequestLoader<OrphanPageQuery, PageResult<PreviewResponse>>
-public typealias DeletionsLoader = RequestLoader<SinceQuery, [DeletionRecord]>
+public typealias OrphansLoader    = RequestLoader<OrphanPageQuery, PageResult<PreviewResponse>>
+public typealias CategoriesLoader = RequestLoader<Void, [CategoryResponse]>
+public typealias DeletionsLoader  = RequestLoader<SinceQuery, [DeletionRecord]>
 
 // Unauthenticated loader factories — for public endpoints (Reader app).
 // Drive with `.load(from:)` and a plain `PageQuery` / `OrphanPageQuery`.
@@ -65,6 +66,12 @@ public extension OrphansLoader {
     }
 }
 
+public extension CategoriesLoader {
+    static func categories(baseURL: URL, session: URLSession = .shared) -> Self {
+        CategoriesLoader(request: CategoriesRequest.categoryQuery(baseURL: baseURL), session: session)
+    }
+}
+
 // Ready-to-use, auth-refreshing loader factories — drive with `.syncAll(since:)` or `.load(from:)`, e.g.
 //
 //     let songs = try await SongsLoader.songs(baseURL: url, auth: auth).syncAll(since: lastSync)
@@ -114,6 +121,12 @@ public extension PostsLoader {
 public extension OrphansLoader {
     static func orphans(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
         OrphansLoader(request: OrphansRequest.orphanQuery(baseURL: baseURL), session: session, auth: auth)
+    }
+}
+
+public extension CategoriesLoader {
+    static func categories(baseURL: URL, session: URLSession = .shared, auth: AuthProvider) -> Self {
+        CategoriesLoader(request: CategoriesRequest.categoryQuery(baseURL: baseURL), session: session, auth: auth)
     }
 }
 

--- a/app-api/Sources/AppApi/Sync/SyncRequests.swift
+++ b/app-api/Sources/AppApi/Sync/SyncRequests.swift
@@ -48,6 +48,12 @@ public extension Request where Self == OrphansRequest {
     static func orphanQuery(baseURL: URL) -> Self { .query(baseURL: baseURL, path: "api/catalogue/orphans") }
 }
 
+/// Full structured category list — non-paginated; the set is small and server-authoritative.
+public typealias CategoriesRequest = BasicRequest<Void, [CategoryResponse]>
+public extension Request where Self == CategoriesRequest {
+    static func categoryQuery(baseURL: URL) -> Self { .get(baseURL: baseURL, path: "api/catalogue/categories") }
+}
+
 /// Deletion tombstones — sparse, unpaginated; always queried since the last sync.
 public typealias DeletionsRequest = BasicRequest<SinceQuery, [DeletionRecord]>
 public extension Request where Self == DeletionsRequest {

--- a/app-core/Sources/AppCore/Blog/Post/PostCell.swift
+++ b/app-core/Sources/AppCore/Blog/Post/PostCell.swift
@@ -14,7 +14,7 @@ struct PostCell: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                 Text(date.formatted(.publishDate))
-                    .font(.subheadline)
+                    .font(.caption)
                     .foregroundStyle(.secondary)
             }
         } else {
@@ -22,7 +22,7 @@ struct PostCell: View {
                 Text(title)
                 Spacer()
                 Text(date.formatted(.publishDate))
-                    .font(.subheadline)
+                    .font(.caption)
                     .foregroundStyle(.secondary)
             }
         }

--- a/app-persistence/Sources/AppPersistence/AppSchema.swift
+++ b/app-persistence/Sources/AppPersistence/AppSchema.swift
@@ -11,6 +11,7 @@ import TmbrCore
 public enum AppSchema {
 
     public static let models: [any PersistentModel.Type] = [
+        CatalogueCategoryRecord.self,
         PreviewRecord.self,
         SongRecord.self,
         AlbumRecord.self,

--- a/app-persistence/Sources/AppPersistence/CatalogueCategoryRecord.swift
+++ b/app-persistence/Sources/AppPersistence/CatalogueCategoryRecord.swift
@@ -1,0 +1,64 @@
+import Foundation
+import SwiftData
+import TmbrCore
+
+/// Local representation of a catalogue category synced from the backend.
+///
+/// Categories are a global reference table: a fixed seed (song, album, book, movie, podcast,
+/// playlist, and the virtual `music` grouping) plus user-generated `orphan` categories created
+/// on demand from free-text item creation. They are never created on-device.
+///
+/// The natural key is `slug` (unique, stable). `serverID` (the backend integer PK) is stored for
+/// reference but lookup always uses `slug`, matching the denormalised `categoryType` slug already
+/// stored on `PreviewRecord`, `NoteRecord`, and `QuoteRecord`. There is intentionally no hard FK
+/// between those records and `CatalogueCategoryRecord` — a new orphan category may not have synced
+/// yet when its first item arrives; it self-heals on the next refresh.
+///
+@Model
+public final class CatalogueCategoryRecord {
+
+    /// Backend integer PK — stored for reference; not the join key.
+    public var serverID: Int = 0
+
+    /// Unique slug (e.g. `"song"`, `"music"`, `"recipe"`). This is the soft join key.
+    public var slug: String = ""
+
+    /// Human-readable display name (e.g. `"Songs"`, `"Music"`, `"Recipe"`).
+    public var name: String = ""
+
+    /// Raw value of `CatalogueCategoryKind`.
+    var kindRaw: String = CatalogueCategoryKind.orphan.rawValue
+
+    /// Web route segment (e.g. `"songs"`, `"music"`). May be nil for orphan categories.
+    public var route: String?
+
+    /// Icon name (e.g. `"song"`, `"link"`). Falls back to `"link"` in the UI when nil.
+    public var icon: String?
+
+    /// Slug of the parent grouping category (e.g. `"music"` for song/album/playlist). Nil for top-level.
+    public var parentSlug: String?
+
+    var syncStateRaw: String = SyncState.synced.rawValue
+
+    public init() {}
+}
+
+// MARK: - Kind
+
+public extension CatalogueCategoryRecord {
+
+    var kind: CatalogueCategoryKind {
+        get { CatalogueCategoryKind(rawValue: kindRaw) ?? .orphan }
+        set { kindRaw = newValue.rawValue }
+    }
+}
+
+// MARK: - SyncState
+
+extension CatalogueCategoryRecord {
+
+    var syncState: SyncState {
+        get { SyncState(rawValue: syncStateRaw) ?? .synced }
+        set { syncStateRaw = newValue.rawValue }
+    }
+}

--- a/app-persistence/Sources/AppPersistence/CatalogueRecord+Sync.swift
+++ b/app-persistence/Sources/AppPersistence/CatalogueRecord+Sync.swift
@@ -146,6 +146,20 @@ public extension QuoteRecord {
     }
 }
 
+public extension CatalogueCategoryRecord {
+    /// Overwrites this record's fields from a server `CategoryResponse` (a synced pull).
+    func update(from response: CategoryResponse) {
+        serverID = response.id
+        slug = response.slug
+        name = response.name
+        kind = response.kind
+        route = response.route
+        icon = response.icon
+        parentSlug = response.parentSlug
+        syncState = .synced
+    }
+}
+
 public extension ContainerEntryRecord {
     /// Overwrites this entry's fields from a `TrackItem`. Denormalises the title and URLs so
     /// the track list renders standalone without requiring the member's `PreviewRecord` to be cached.

--- a/app-persistence/Sources/AppPersistence/CatalogueRecord+Sync.swift
+++ b/app-persistence/Sources/AppPersistence/CatalogueRecord+Sync.swift
@@ -122,6 +122,30 @@ public extension PlaylistRecord {
     }
 }
 
+public extension QuoteRecord {
+    /// Overwrites this record from a server `QuoteResponse` (a synced pull).
+    func update(from response: QuoteResponse) {
+        serverID = response.id
+        body = response.body
+        createdAt = response.createdAt
+        switch response.source.kind {
+        case .note:
+            if let noteID = response.source.noteID {
+                source = .note(noteID)
+            }
+        case .post:
+            if let postID = response.source.postID {
+                source = .post(postID)
+            }
+        }
+        sourceTitle = response.source.title
+        sourceSubtitle = response.source.subtitle
+        sourceType = response.source.type
+        sourcePreviewID = response.source.preview?.id
+        syncState = .synced
+    }
+}
+
 public extension ContainerEntryRecord {
     /// Overwrites this entry's fields from a `TrackItem`. Denormalises the title and URLs so
     /// the track list renders standalone without requiring the member's `PreviewRecord` to be cached.

--- a/app-persistence/Sources/AppPersistence/CatalogueStore.swift
+++ b/app-persistence/Sources/AppPersistence/CatalogueStore.swift
@@ -144,6 +144,34 @@ public struct CatalogueStore {
         try context.save()
     }
 
+    /// Full-replaces the catalogue category lookup table from the server's authoritative list.
+    ///
+    /// Upserts each incoming category by `slug` (the natural key); deletes any locally-stored
+    /// category whose slug is absent from the server response. The server list is small and
+    /// complete, so full-replace is safe and avoids delta-cursor complexity.
+    public func replaceCategories(_ responses: [CategoryResponse]) throws {
+        var bySlug: [String: CatalogueCategoryRecord] = [:]
+        for record in try context.fetch(FetchDescriptor<CatalogueCategoryRecord>()) {
+            bySlug[record.slug] = record
+        }
+        let incomingSlugs = Set(responses.map(\.slug))
+        // Delete categories no longer on the server.
+        for (slug, record) in bySlug where !incomingSlugs.contains(slug) {
+            context.delete(record)
+        }
+        // Upsert incoming categories.
+        for response in responses {
+            let record = bySlug[response.slug] ?? {
+                let new = CatalogueCategoryRecord()
+                context.insert(new)
+                bySlug[response.slug] = new
+                return new
+            }()
+            record.update(from: response)
+        }
+        try context.save()
+    }
+
     /// Upserts orphan items (`PreviewResponse` is their complete data; `?notes=true` embeds notes).
     public func upsertOrphans(_ responses: [PreviewResponse]) throws {
         var previews = try previewsByID()

--- a/app-persistence/Sources/AppPersistence/CatalogueStore.swift
+++ b/app-persistence/Sources/AppPersistence/CatalogueStore.swift
@@ -17,7 +17,7 @@ extension MovieResponse: CatalogueItemResponse {}
 extension PodcastResponse: CatalogueItemResponse {}
 extension PlaylistResponse: CatalogueItemResponse {}
 
-/// A persistence façade for the unified catalogue (previews, per-type records, and notes).
+/// A persistence façade for the unified catalogue (previews, per-type records, notes, and quotes).
 ///
 /// Wraps a SwiftData `ModelContext`. Folding `context.save()` into each call keeps callers
 /// free of dual-step save boilerplate.
@@ -35,9 +35,10 @@ public struct CatalogueStore {
     public func upsert(_ responses: [SongResponse]) throws {
         var previews = try previewsByID()
         var notes = try notesByPreview()
+        var quotes = try quotesByNoteServerID()
         var typed = try typedIndex(SongRecord.self, key: \.previewID)
         for r in responses {
-            guard let pid = upsertItem(r, into: &previews, notes: &notes) else { continue }
+            guard let pid = upsertItem(r, into: &previews, notes: &notes, quotes: &quotes) else { continue }
             let record = typed[pid] ?? {
                 let new = SongRecord(previewID: pid)
                 context.insert(new)
@@ -52,10 +53,11 @@ public struct CatalogueStore {
     public func upsert(_ responses: [AlbumResponse]) throws {
         var previews = try previewsByID()
         var notes = try notesByPreview()
+        var quotes = try quotesByNoteServerID()
         var typed = try typedIndex(AlbumRecord.self, key: \.previewID)
         var containers = try containerEntriesByKey()
         for r in responses {
-            guard let pid = upsertItem(r, into: &previews, notes: &notes) else { continue }
+            guard let pid = upsertItem(r, into: &previews, notes: &notes, quotes: &quotes) else { continue }
             let record = typed[pid] ?? {
                 let new = AlbumRecord(previewID: pid)
                 context.insert(new)
@@ -71,9 +73,10 @@ public struct CatalogueStore {
     public func upsert(_ responses: [BookResponse]) throws {
         var previews = try previewsByID()
         var notes = try notesByPreview()
+        var quotes = try quotesByNoteServerID()
         var typed = try typedIndex(BookRecord.self, key: \.previewID)
         for r in responses {
-            guard let pid = upsertItem(r, into: &previews, notes: &notes) else { continue }
+            guard let pid = upsertItem(r, into: &previews, notes: &notes, quotes: &quotes) else { continue }
             let record = typed[pid] ?? {
                 let new = BookRecord(previewID: pid)
                 context.insert(new)
@@ -88,9 +91,10 @@ public struct CatalogueStore {
     public func upsert(_ responses: [MovieResponse]) throws {
         var previews = try previewsByID()
         var notes = try notesByPreview()
+        var quotes = try quotesByNoteServerID()
         var typed = try typedIndex(MovieRecord.self, key: \.previewID)
         for r in responses {
-            guard let pid = upsertItem(r, into: &previews, notes: &notes) else { continue }
+            guard let pid = upsertItem(r, into: &previews, notes: &notes, quotes: &quotes) else { continue }
             let record = typed[pid] ?? {
                 let new = MovieRecord(previewID: pid)
                 context.insert(new)
@@ -105,9 +109,10 @@ public struct CatalogueStore {
     public func upsert(_ responses: [PodcastResponse]) throws {
         var previews = try previewsByID()
         var notes = try notesByPreview()
+        var quotes = try quotesByNoteServerID()
         var typed = try typedIndex(PodcastRecord.self, key: \.previewID)
         for r in responses {
-            guard let pid = upsertItem(r, into: &previews, notes: &notes) else { continue }
+            guard let pid = upsertItem(r, into: &previews, notes: &notes, quotes: &quotes) else { continue }
             let record = typed[pid] ?? {
                 let new = PodcastRecord(previewID: pid)
                 context.insert(new)
@@ -122,10 +127,11 @@ public struct CatalogueStore {
     public func upsert(_ responses: [PlaylistResponse]) throws {
         var previews = try previewsByID()
         var notes = try notesByPreview()
+        var quotes = try quotesByNoteServerID()
         var typed = try typedIndex(PlaylistRecord.self, key: \.previewID)
         var containers = try containerEntriesByKey()
         for r in responses {
-            guard let pid = upsertItem(r, into: &previews, notes: &notes) else { continue }
+            guard let pid = upsertItem(r, into: &previews, notes: &notes, quotes: &quotes) else { continue }
             let record = typed[pid] ?? {
                 let new = PlaylistRecord(previewID: pid)
                 context.insert(new)
@@ -142,9 +148,10 @@ public struct CatalogueStore {
     public func upsertOrphans(_ responses: [PreviewResponse]) throws {
         var previews = try previewsByID()
         var notes = try notesByPreview()
+        var quotes = try quotesByNoteServerID()
         for r in responses {
             guard upsertPreview(r, access: .public, into: &previews) != nil else { continue }
-            reconcileNotes(r.notes ?? [], for: r, into: &notes)
+            reconcileNotes(r.notes ?? [], for: r, into: &notes, quotes: &quotes)
         }
         try context.save()
     }
@@ -161,6 +168,14 @@ public struct CatalogueStore {
         var index: [UUID: [NoteRecord]] = [:]
         for note in try context.fetch(FetchDescriptor<NoteRecord>()) {
             if let pid = note.attachmentPreviewID { index[pid, default: []].append(note) }
+        }
+        return index
+    }
+
+    private func quotesByNoteServerID() throws -> [UUID: [QuoteRecord]] {
+        var index: [UUID: [QuoteRecord]] = [:]
+        for quote in try context.fetch(FetchDescriptor<QuoteRecord>()) {
+            if let nid = quote.noteServerID { index[nid, default: []].append(quote) }
         }
         return index
     }
@@ -198,22 +213,27 @@ public struct CatalogueStore {
     }
 
     /// Item-level note reconcile: upsert embedded notes by `serverID`; drop this item's `.synced`
-    /// notes absent from the incoming array (server-side deletes); preserve locally-pending notes.
+    /// notes absent from the incoming array (server-side blockquote removals); preserve
+    /// locally-pending notes. Cascades `QuoteRecord` deletion when a note is removed.
     private func reconcileNotes(
         _ notes: [NoteResponse],
         for preview: PreviewResponse,
-        into byPreview: inout [UUID: [NoteRecord]]
+        into byPreview: inout [UUID: [NoteRecord]],
+        quotes byNote: inout [UUID: [QuoteRecord]]
     ) {
         guard let previewID = preview.id else { return }
         let incomingIDs = Set(notes.map(\.id))
         var current = byPreview[previewID] ?? []
 
         current.removeAll { note in
-            if note.syncState == .synced, let sid = note.serverID, !incomingIDs.contains(sid) {
-                context.delete(note)
-                return true
+            guard note.syncState == .synced, let sid = note.serverID, !incomingIDs.contains(sid) else {
+                return false
             }
-            return false
+            // Cascade: delete this note's quotes before deleting the note.
+            byNote[sid]?.forEach { context.delete($0) }
+            byNote.removeValue(forKey: sid)
+            context.delete(note)
+            return true
         }
 
         for note in notes {
@@ -224,9 +244,41 @@ public struct CatalogueStore {
                 return new
             }()
             record.update(from: note, preview: preview)
+            reconcileQuotes(note.quotes, forNoteServerID: note.id, into: &byNote)
         }
 
         byPreview[previewID] = current
+    }
+
+    /// Quote reconcile for a single note: upsert embedded quotes by `serverID`; delete `.synced`
+    /// quotes absent from the incoming array (blockquote removed from note body).
+    private func reconcileQuotes(
+        _ quotes: [QuoteResponse],
+        forNoteServerID noteID: NoteID,
+        into byNote: inout [UUID: [QuoteRecord]]
+    ) {
+        let incomingIDs = Set(quotes.map(\.id))
+        var current = byNote[noteID] ?? []
+
+        current.removeAll { quote in
+            if quote.syncState == .synced, !incomingIDs.contains(quote.serverID) {
+                context.delete(quote)
+                return true
+            }
+            return false
+        }
+
+        for quote in quotes {
+            let record = current.first { $0.serverID == quote.id } ?? {
+                let new = QuoteRecord()
+                context.insert(new)
+                current.append(new)
+                return new
+            }()
+            record.update(from: quote)
+        }
+
+        byNote[noteID] = current
     }
 
     /// Track reconcile: mirrors `reconcileNotes` but for `ContainerEntryRecord`s within an album
@@ -267,10 +319,11 @@ public struct CatalogueStore {
     private func upsertItem<R: CatalogueItemResponse>(
         _ response: R,
         into previews: inout [UUID: PreviewRecord],
-        notes: inout [UUID: [NoteRecord]]
+        notes: inout [UUID: [NoteRecord]],
+        quotes: inout [UUID: [QuoteRecord]]
     ) -> UUID? {
         guard let pid = upsertPreview(response.preview, access: response.access, into: &previews) else { return nil }
-        reconcileNotes(response.notes, for: response.preview, into: &notes)
+        reconcileNotes(response.notes, for: response.preview, into: &notes, quotes: &quotes)
         return pid
     }
 }

--- a/app-persistence/Sources/AppPersistence/PostStore.swift
+++ b/app-persistence/Sources/AppPersistence/PostStore.swift
@@ -2,9 +2,9 @@ import Foundation
 import SwiftData
 import TmbrCore
 
-/// A persistence façade for blog posts.
+/// A persistence façade for blog posts and their embedded quotes.
 ///
-/// Wraps a SwiftData `ModelContext`. Folding `context.save()` into the call keeps callers
+/// Wraps a SwiftData `ModelContext`. Folding `context.save()` into each call keeps callers
 /// free of dual-step save boilerplate.
 @MainActor
 public struct PostStore {
@@ -16,7 +16,8 @@ public struct PostStore {
     }
 
     /// Upserts `responses` into the store and saves. Idempotent: existing records are updated
-    /// in-place; new server IDs create fresh `PostRecord`s.
+    /// in-place; new server IDs create fresh `PostRecord`s. Post-sourced quotes embedded in
+    /// each response are reconciled alongside the post.
     ///
     /// Indexes the existing rows once rather than per-item `#Predicate` fetches (SwiftData
     /// mistranslates the optional-`Int` `serverID == id` comparison and traps).
@@ -24,6 +25,10 @@ public struct PostStore {
         var bySID: [Int: PostRecord] = [:]
         for record in try context.fetch(FetchDescriptor<PostRecord>()) {
             if let sid = record.serverID { bySID[sid] = record }
+        }
+        var quotesByPost: [Int: [QuoteRecord]] = [:]
+        for quote in try context.fetch(FetchDescriptor<QuoteRecord>()) {
+            if let pid = quote.postServerID { quotesByPost[pid, default: []].append(quote) }
         }
         for response in responses {
             if let existing = bySID[response.id] {
@@ -34,7 +39,41 @@ public struct PostStore {
                 context.insert(record)
                 bySID[response.id] = record
             }
+            reconcilePostQuotes(response.quotes, forPostServerID: response.id, into: &quotesByPost)
         }
         try context.save()
+    }
+
+    // MARK: - Private
+
+    /// Quote reconcile for a single post: upsert embedded quotes by `serverID`; delete `.synced`
+    /// quotes absent from the incoming array (blockquote removed from post content).
+    private func reconcilePostQuotes(
+        _ quotes: [QuoteResponse],
+        forPostServerID postID: PostID,
+        into byPost: inout [Int: [QuoteRecord]]
+    ) {
+        let incomingIDs = Set(quotes.map(\.id))
+        var current = byPost[postID] ?? []
+
+        current.removeAll { quote in
+            if quote.syncState == .synced, !incomingIDs.contains(quote.serverID) {
+                context.delete(quote)
+                return true
+            }
+            return false
+        }
+
+        for quote in quotes {
+            let record = current.first { $0.serverID == quote.id } ?? {
+                let new = QuoteRecord()
+                context.insert(new)
+                current.append(new)
+                return new
+            }()
+            record.update(from: quote)
+        }
+
+        byPost[postID] = current
     }
 }

--- a/app-persistence/Sources/AppPersistence/QuoteRecord.swift
+++ b/app-persistence/Sources/AppPersistence/QuoteRecord.swift
@@ -2,60 +2,101 @@ import Foundation
 import SwiftData
 import TmbrCore
 
-/// Local representation of a text quote attached to a note.
+/// Local representation of a stable quote extracted from a note or a blog post.
 ///
-/// `QuoteResponse` has no server-side ID — quotes are identified on the server by `(noteID, body)`.
-/// The local `clientKey` is the stable identity; `noteServerID + body` is the dedup key when merging
-/// pull responses. Source fields are denormalised so quotes render without loading other records.
-/// 
+/// `serverID` is the stable `QuoteID` assigned by the backend and preserved across
+/// source edits by `QuoteReconciler`. Quotes are server-derived (never created
+/// on-device) so `serverID` is the sole identity — there is no `clientKey`.
+///
+/// Source is exposed via the `source` computed property (`.note(NoteID)` or
+/// `.post(PostID)`), backed by internal storage so query/cascade code within the
+/// module can still index and filter by raw id fields.
+///
+/// Display fields are denormalised so a future Quotes view renders standalone
+/// without loading other records.
 @Model
 public final class QuoteRecord {
 
-    public var clientKey: UUID = UUID()
+    public var serverID: UUID = UUID()
 
     public var body: String = ""
-    
-    /// links to NoteRecord.clientKey/
-    public var noteClientKey: UUID = UUID()
-    
-    /// set once the parent NoteRecord has a serverID
-    public var noteServerID: UUID?
-    
-    /// PreviewID of the quoted item
-    public var sourcePreviewID: UUID = UUID()
-    
-    /// denormalised title of the quoted item
+
+    public var createdAt: Date = Date.now
+
+    // MARK: - Source (internal backing)
+
+    var sourceKindRaw: String = "note"
+
+    /// Set when source is `.note`. Internal — callers use `source`.
+    var noteServerID: UUID?
+
+    /// Set when source is `.post`. Internal — callers use `source`.
+    var postServerID: Int?
+
+    // MARK: - Denormalised source display fields
+
     public var sourceTitle: String = ""
-    
-    /// "song" | "book" | …
+
+    public var sourceSubtitle: String?
+
+    /// Category type slug ("song", "book", …). nil for post-sourced quotes.
     public var sourceType: String?
-    
+
+    /// PreviewID of the source catalogue item. nil for post-sourced quotes.
+    public var sourcePreviewID: UUID?
+
     var syncStateRaw: String = SyncState.synced.rawValue
 
-    public init(
-        clientKey: UUID = UUID(),
-        body: String = "",
-        noteClientKey: UUID = UUID(),
-        noteServerID: UUID? = nil,
-        sourcePreviewID: UUID = UUID(),
-        sourceTitle: String = "",
-        sourceType: String? = nil,
-        syncState: SyncState = .synced
-    ) {
-        self.clientKey = clientKey
-        self.body = body
-        self.noteClientKey = noteClientKey
-        self.noteServerID = noteServerID
-        self.sourcePreviewID = sourcePreviewID
-        self.sourceTitle = sourceTitle
-        self.sourceType = sourceType
-        self.syncStateRaw = syncState.rawValue
+    public init() {}
+}
+
+// MARK: - Source enum
+
+public extension QuoteRecord {
+
+    /// Polymorphic source of a quote.
+    enum Source: Sendable {
+        case note(NoteID)
+        case post(PostID)
+    }
+
+    var source: Source? {
+        get {
+            if sourceKindRaw == Self.kindPost {
+                return postServerID.map { .post($0) }
+            }
+            return noteServerID.map { .note($0) }
+        }
+        set { newValue.map { setSource($0) } }
     }
 }
+
+// MARK: - SyncState
 
 public extension QuoteRecord {
     var syncState: SyncState {
         get { SyncState(rawValue: syncStateRaw) ?? .synced }
         set { syncStateRaw = newValue.rawValue }
+    }
+}
+
+// MARK: - Internal helpers
+
+extension QuoteRecord {
+
+    static let kindNote = "note"
+    static let kindPost = "post"
+
+    func setSource(_ source: Source) {
+        switch source {
+        case .note(let id):
+            sourceKindRaw = Self.kindNote
+            noteServerID = id
+            postServerID = nil
+        case .post(let id):
+            sourceKindRaw = Self.kindPost
+            postServerID = id
+            noteServerID = nil
+        }
     }
 }

--- a/tmbr-app/Reader/CatalogueSync.swift
+++ b/tmbr-app/Reader/CatalogueSync.swift
@@ -5,19 +5,20 @@ import AppPersistence
 import TmbrCore
 
 extension SyncGroup {
-    /// Standard Reader catalogue sync: fetches the six typed lists + orphans from `baseURL` and
-    /// upserts each result into `store`. Runs all seven in parallel with partial-success semantics —
-    /// individual endpoint failures are logged and surfaced without discarding successes.
+    /// Standard Reader catalogue sync: fetches the six typed lists + orphans + categories from
+    /// `baseURL` and upserts each result into `store`. Runs all in parallel with partial-success
+    /// semantics — individual endpoint failures are logged and surfaced without discarding successes.
     static func catalogue(baseURL: URL, store: CatalogueStore) -> SyncGroup {
         let page = PageQuery(limit: 50)
         return SyncGroup([
-            Syncer("songs",     loader: .songs(baseURL: baseURL),     from: page) { try await store.upsert($0) },
-            Syncer("albums",    loader: .albums(baseURL: baseURL),    from: page) { try await store.upsert($0) },
-            Syncer("books",     loader: .books(baseURL: baseURL),     from: page) { try await store.upsert($0) },
-            Syncer("movies",    loader: .movies(baseURL: baseURL),    from: page) { try await store.upsert($0) },
-            Syncer("podcasts",  loader: .podcasts(baseURL: baseURL),  from: page) { try await store.upsert($0) },
-            Syncer("playlists", loader: .playlists(baseURL: baseURL), from: page) { try await store.upsert($0) },
-            Syncer("orphans",   loader: .orphans(baseURL: baseURL),   from: OrphanPageQuery(limit: 50)) { try await store.upsertOrphans($0) },
+            Syncer("songs",      loader: .songs(baseURL: baseURL),      from: page) { try await store.upsert($0) },
+            Syncer("albums",     loader: .albums(baseURL: baseURL),     from: page) { try await store.upsert($0) },
+            Syncer("books",      loader: .books(baseURL: baseURL),      from: page) { try await store.upsert($0) },
+            Syncer("movies",     loader: .movies(baseURL: baseURL),     from: page) { try await store.upsert($0) },
+            Syncer("podcasts",   loader: .podcasts(baseURL: baseURL),   from: page) { try await store.upsert($0) },
+            Syncer("playlists",  loader: .playlists(baseURL: baseURL),  from: page) { try await store.upsert($0) },
+            Syncer("orphans",    loader: .orphans(baseURL: baseURL),    from: OrphanPageQuery(limit: 50)) { try await store.upsertOrphans($0) },
+            Syncer("categories", loader: .categories(baseURL: baseURL), from: ()) { try await store.replaceCategories($0) },
         ])
     }
 }

--- a/tmbr-core/Sources/TmbrCore/Responses/CategoryResponse.swift
+++ b/tmbr-core/Sources/TmbrCore/Responses/CategoryResponse.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public struct CategoryResponse: Codable, Sendable {
+
+    public let id: Int
+    public let slug: String
+    public let name: String
+    public let kind: CatalogueCategoryKind
+    public let route: String?
+    public let icon: String?
+    public let parentSlug: String?
+
+    public init(
+        id: Int,
+        slug: String,
+        name: String,
+        kind: CatalogueCategoryKind,
+        route: String?,
+        icon: String?,
+        parentSlug: String?
+    ) {
+        self.id = id
+        self.slug = slug
+        self.name = name
+        self.kind = kind
+        self.route = route
+        self.icon = icon
+        self.parentSlug = parentSlug
+    }
+}

--- a/tmbr-core/Sources/TmbrCore/Responses/PostResponse.swift
+++ b/tmbr-core/Sources/TmbrCore/Responses/PostResponse.swift
@@ -16,6 +16,8 @@ public struct PostResponse: Codable, Sendable {
 
     public let publishedAt: Date?
 
+    public let quotes: [QuoteResponse]
+
     public let state: PostState
 
     public let title: String
@@ -28,6 +30,7 @@ public struct PostResponse: Codable, Sendable {
         createdAt: Date,
         language: Language,
         publishedAt: Date?,
+        quotes: [QuoteResponse],
         state: PostState,
         title: String
     ) {
@@ -38,6 +41,7 @@ public struct PostResponse: Codable, Sendable {
         self.createdAt = createdAt
         self.language = language
         self.publishedAt = publishedAt
+        self.quotes = quotes
         self.state = state
         self.title = title
     }

--- a/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/API/AlbumsAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/API/AlbumsAPIController.swift
@@ -33,8 +33,8 @@ struct AlbumsAPIController: RouteCollection {
             }
             let resolvedNotes = try await notesByPreviewID
             let baseURL = request.baseURL
-            return PageResult(from: albums, limit: input.limit) { album in
-                AlbumResponse(
+            return try PageResult(from: albums, limit: input.limit) { album in
+                try AlbumResponse(
                     album: album,
                     notes: resolvedNotes[album.$preview.id] ?? [],
                     trackPreviews: album.id.flatMap { tracksByAlbumID[$0] } ?? [],
@@ -86,7 +86,7 @@ struct AlbumsAPIController: RouteCollection {
                     )
                 }
                 let notes = try await notesInput.map(commands.notes.batchCreate)
-                return AlbumResponse(
+                return try AlbumResponse(
                     album: album,
                     notes: notes ?? [],
                     baseURL: request.baseURL
@@ -116,7 +116,7 @@ struct AlbumsAPIController: RouteCollection {
                 try await album.preview.$image.load(on: request.commandDB)
                 try await album.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: albumID, of: Album.previewType)
-                return AlbumResponse(album: album, notes: notes, baseURL: request.baseURL)
+                return try AlbumResponse(album: album, notes: notes, baseURL: request.baseURL)
             }
         }
 

--- a/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/API/Responses/AlbumResponse.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Albums/Routes/API/Responses/AlbumResponse.swift
@@ -11,7 +11,7 @@ extension AlbumResponse {
         trackPreviews: [Preview] = [],
         baseURL: String,
         platform: Platform<AlbumMetadata> = .album
-    ) {
+    ) throws {
         self.init(
             id: album.id!,
             access: album.access,
@@ -21,7 +21,7 @@ extension AlbumResponse {
             notes: notes.map { NoteResponse(note: $0, baseURL: baseURL) },
             owner: UserResponse(user: album.owner),
             preview: PreviewResponse(preview: album.preview, baseURL: baseURL),
-            post: album.post.map { PostResponse(post: $0, baseURL: baseURL) },
+            post: try album.post.map { try PostResponse(post: $0, baseURL: baseURL) },
             releaseDate: album.releaseDate,
             resources: album.resourceURLs.compactMap(platform.hyperlink),
             title: album.title,

--- a/tmbr-web/Sources/App/Modules/Catalogue/Books/Routes/API/BooksAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Books/Routes/API/BooksAPIController.swift
@@ -25,8 +25,8 @@ struct BooksAPIController: RouteCollection {
             let previewIDs = books.map { $0.$preview.id }
             let notesByPreviewID = try await request.commands.notes.grouped(previewIDs)
             let baseURL = request.baseURL
-            return PageResult(from: books, limit: input.limit) { book in
-                BookResponse(book: book, baseURL: baseURL, notes: notesByPreviewID[book.$preview.id] ?? [])
+            return try PageResult(from: books, limit: input.limit) { book in
+                try BookResponse(book: book, baseURL: baseURL, notes: notesByPreviewID[book.$preview.id] ?? [])
             }
         }
 
@@ -48,7 +48,7 @@ struct BooksAPIController: RouteCollection {
             }
             async let book = request.commands.books.fetch(bookID, for: .read)
             async let notes = request.commands.notes.query(id: bookID, of: Book.previewType)
-            return BookResponse(
+            return try BookResponse(
                 book: try await book,
                 baseURL: request.baseURL,
                 notes: try await notes
@@ -71,7 +71,7 @@ struct BooksAPIController: RouteCollection {
                     )
                 }
                 let notes = try await notesInput.map(commands.notes.batchCreate)
-                return BookResponse(
+                return try BookResponse(
                     book: book,
                     baseURL: request.baseURL,
                     notes: notes ?? []
@@ -101,7 +101,7 @@ struct BooksAPIController: RouteCollection {
                 try await book.preview.$image.load(on: request.commandDB)
                 try await book.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: bookID, of: Book.previewType)
-                return BookResponse(book: book, baseURL: request.baseURL, notes: notes)
+                return try BookResponse(book: book, baseURL: request.baseURL, notes: notes)
             }
         }
 

--- a/tmbr-web/Sources/App/Modules/Catalogue/Books/Routes/API/Responses/BookResponse.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Books/Routes/API/Responses/BookResponse.swift
@@ -10,7 +10,7 @@ extension BookResponse {
         baseURL: String,
         notes: [Note],
         platform: Platform<BookMetadata> = .book
-    ) {
+    ) throws {
         self.init(
             id: book.id!,
             access: book.access,
@@ -20,7 +20,7 @@ extension BookResponse {
             notes: notes.map { NoteResponse(note: $0, baseURL: baseURL) },
             owner: UserResponse(user: book.owner),
             preview: PreviewResponse(preview: book.preview, baseURL: baseURL),
-            post: book.post.map { PostResponse(post: $0, baseURL: baseURL) },
+            post: try book.post.map { try PostResponse(post: $0, baseURL: baseURL) },
             releaseDate: book.releaseDate,
             resources: book.resourceURLs.compactMap(platform.hyperlink),
             title: book.title

--- a/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/API/CatalogueAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/API/CatalogueAPIController.swift
@@ -24,6 +24,9 @@ struct CatalogueAPIController: RouteCollection {
         // GET /api/catalogue/orphans — paginated orphan items for native app sync
         catalogue.get("orphans", use: listOrphans)
 
+        // GET /api/catalogue/categories — full structured category list for native app sync
+        catalogue.get("categories", use: listCategories)
+
         let quotes = catalogue.grouped("quotes")
         quotes.get(use: quoteList)
         quotes.get("search", use: quoteSearch)
@@ -102,6 +105,12 @@ struct CatalogueAPIController: RouteCollection {
     }
 
     // MARK: - Catalogue list handlers
+
+    @Sendable
+    private func listCategories(request: Request) async throws -> [CategoryResponse] {
+        let categories = try await request.commands.catalogueCategories.list()
+        return try categories.map { try CategoryResponse(category: $0) }
+    }
 
     @Sendable
     private func listOrphans(request: Request) async throws -> PageResult<PreviewResponse> {

--- a/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/API/Responses/CategoryResponse+Vapor.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/API/Responses/CategoryResponse+Vapor.swift
@@ -1,0 +1,4 @@
+import Vapor
+import TmbrCore
+
+extension CategoryResponse: @retroactive Content {}

--- a/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/API/Responses/CategoryResponse.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Catalogue/Routes/API/Responses/CategoryResponse.swift
@@ -1,0 +1,17 @@
+import Vapor
+import TmbrCore
+
+extension CategoryResponse {
+
+    init(category: CatalogueCategory) throws {
+        self.init(
+            id: try category.requireID(),
+            slug: category.slug,
+            name: category.name,
+            kind: category.kind,
+            route: category.route,
+            icon: category.icon,
+            parentSlug: category.parentSlug
+        )
+    }
+}

--- a/tmbr-web/Sources/App/Modules/Catalogue/Movies/Routes/API/MoviesAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Movies/Routes/API/MoviesAPIController.swift
@@ -25,8 +25,8 @@ struct MoviesAPIController: RouteCollection {
             let previewIDs = movies.map { $0.$preview.id }
             let notesByPreviewID = try await request.commands.notes.grouped(previewIDs)
             let baseURL = request.baseURL
-            return PageResult(from: movies, limit: input.limit) { movie in
-                MovieResponse(movie: movie, baseURL: baseURL, notes: notesByPreviewID[movie.$preview.id] ?? [])
+            return try PageResult(from: movies, limit: input.limit) { movie in
+                try MovieResponse(movie: movie, baseURL: baseURL, notes: notesByPreviewID[movie.$preview.id] ?? [])
             }
         }
 
@@ -48,7 +48,7 @@ struct MoviesAPIController: RouteCollection {
             }
             async let movie = request.commands.movies.fetch(movieID, for: .read)
             async let notes = request.commands.notes.query(id: movieID, of: Movie.previewType)
-            return MovieResponse(
+            return try MovieResponse(
                 movie: try await movie,
                 baseURL: request.baseURL,
                 notes: try await notes
@@ -71,7 +71,7 @@ struct MoviesAPIController: RouteCollection {
                     )
                 }
                 let notes = try await notesInput.map(commands.notes.batchCreate)
-                return MovieResponse(
+                return try MovieResponse(
                     movie: movie,
                     baseURL: request.baseURL,
                     notes: notes ?? []
@@ -101,7 +101,7 @@ struct MoviesAPIController: RouteCollection {
                 try await movie.preview.$image.load(on: request.commandDB)
                 try await movie.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: movieID, of: Movie.previewType)
-                return MovieResponse(movie: movie, baseURL: request.baseURL, notes: notes)
+                return try MovieResponse(movie: movie, baseURL: request.baseURL, notes: notes)
             }
         }
 

--- a/tmbr-web/Sources/App/Modules/Catalogue/Movies/Routes/API/Responses/MovieResponse.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Movies/Routes/API/Responses/MovieResponse.swift
@@ -10,7 +10,7 @@ extension MovieResponse {
         baseURL: String,
         notes: [Note],
         platform: Platform<MovieMetadata> = .movie
-    ) {
+    ) throws {
         self.init(
             id: movie.id!,
             access: movie.access,
@@ -20,7 +20,7 @@ extension MovieResponse {
             notes: notes.map { NoteResponse(note: $0, baseURL: baseURL) },
             owner: UserResponse(user: movie.owner),
             preview: PreviewResponse(preview: movie.preview, baseURL: baseURL),
-            post: movie.post.map { PostResponse(post: $0, baseURL: baseURL) },
+            post: try movie.post.map { try PostResponse(post: $0, baseURL: baseURL) },
             releaseDate: movie.releaseDate,
             resources: movie.resourceURLs.compactMap(platform.hyperlink),
             title: movie.title

--- a/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/API/PlaylistsAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/API/PlaylistsAPIController.swift
@@ -26,8 +26,8 @@ struct PlaylistsAPIController: RouteCollection {
             }
             let resolvedNotes = try await notesByPreviewID
             let baseURL = request.baseURL
-            return PageResult(from: playlists, limit: input.limit) { playlist in
-                PlaylistResponse(
+            return try PageResult(from: playlists, limit: input.limit) { playlist in
+                try PlaylistResponse(
                     playlist: playlist,
                     notes: resolvedNotes[playlist.$preview.id] ?? [],
                     trackPreviews: playlist.id.flatMap { tracksByPlaylistID[$0] } ?? [],
@@ -68,7 +68,7 @@ struct PlaylistsAPIController: RouteCollection {
                     )
                 }
                 let notes = try await notesInput.map(commands.notes.batchCreate)
-                return PlaylistResponse(
+                return try PlaylistResponse(
                     playlist: playlist,
                     notes: notes ?? [],
                     baseURL: request.baseURL
@@ -98,7 +98,7 @@ struct PlaylistsAPIController: RouteCollection {
                 try await playlist.preview.$image.load(on: request.commandDB)
                 try await playlist.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: playlistID, of: Playlist.previewType)
-                return PlaylistResponse(playlist: playlist, notes: notes, baseURL: request.baseURL)
+                return try PlaylistResponse(playlist: playlist, notes: notes, baseURL: request.baseURL)
             }
         }
 

--- a/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/API/Responses/PlaylistResponse.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Playlists/Routes/API/Responses/PlaylistResponse.swift
@@ -10,7 +10,7 @@ extension PlaylistResponse {
         trackPreviews: [Preview] = [],
         baseURL: String,
         platform: Platform<PlaylistMetadata> = .playlist
-    ) {
+    ) throws {
         self.init(
             id: playlist.id!,
             access: playlist.access,
@@ -19,7 +19,7 @@ extension PlaylistResponse {
             notes: notes.map { NoteResponse(note: $0, baseURL: baseURL) },
             owner: UserResponse(user: playlist.owner),
             preview: PreviewResponse(preview: playlist.preview, baseURL: baseURL),
-            post: playlist.post.map { PostResponse(post: $0, baseURL: baseURL) },
+            post: try playlist.post.map { try PostResponse(post: $0, baseURL: baseURL) },
             resources: playlist.resourceURLs.compactMap(platform.hyperlink),
             title: playlist.title,
             tracks: trackPreviews.enumerated().compactMap { index, preview in

--- a/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Routes/API/PodcastsAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Routes/API/PodcastsAPIController.swift
@@ -25,8 +25,8 @@ struct PodcastsAPIController: RouteCollection {
             let previewIDs = podcasts.map { $0.$preview.id }
             let notesByPreviewID = try await request.commands.notes.grouped(previewIDs)
             let baseURL = request.baseURL
-            return PageResult(from: podcasts, limit: input.limit) { podcast in
-                PodcastResponse(podcast: podcast, baseURL: baseURL, notes: notesByPreviewID[podcast.$preview.id] ?? [])
+            return try PageResult(from: podcasts, limit: input.limit) { podcast in
+                try PodcastResponse(podcast: podcast, baseURL: baseURL, notes: notesByPreviewID[podcast.$preview.id] ?? [])
             }
         }
 
@@ -53,7 +53,7 @@ struct PodcastsAPIController: RouteCollection {
             }
             async let podcast = request.commands.podcasts.fetch(podcastID, for: .read)
             async let notes = request.commands.notes.query(id: podcastID, of: Podcast.previewType)
-            return PodcastResponse(
+            return try PodcastResponse(
                 podcast: try await podcast,
                 baseURL: request.baseURL,
                 notes: try await notes
@@ -76,7 +76,7 @@ struct PodcastsAPIController: RouteCollection {
                     )
                 }
                 let notes = try await notesInput.map(commands.notes.batchCreate)
-                return PodcastResponse(
+                return try PodcastResponse(
                     podcast: podcast,
                     baseURL: request.baseURL,
                     notes: notes ?? []
@@ -106,7 +106,7 @@ struct PodcastsAPIController: RouteCollection {
                 try await podcast.preview.$image.load(on: request.commandDB)
                 try await podcast.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: podcastID, of: Podcast.previewType)
-                return PodcastResponse(podcast: podcast, baseURL: request.baseURL, notes: notes)
+                return try PodcastResponse(podcast: podcast, baseURL: request.baseURL, notes: notes)
             }
         }
 

--- a/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Routes/API/Responses/PodcastResponse.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Podcasts/Routes/API/Responses/PodcastResponse.swift
@@ -10,7 +10,7 @@ extension PodcastResponse {
         baseURL: String,
         notes: [Note],
         platform: Platform<PodcastMetadata> = .podcast
-    ) {
+    ) throws {
         self.init(
             id: podcast.id!,
             access: podcast.access,
@@ -21,7 +21,7 @@ extension PodcastResponse {
             notes: notes.map { NoteResponse(note: $0, baseURL: baseURL) },
             owner: UserResponse(user: podcast.owner),
             preview: PreviewResponse(preview: podcast.preview, baseURL: baseURL),
-            post: podcast.post.map { PostResponse(post: $0, baseURL: baseURL) },
+            post: try podcast.post.map { try PostResponse(post: $0, baseURL: baseURL) },
             releaseDate: podcast.releaseDate,
             resources: podcast.resourceURLs.compactMap(platform.hyperlink),
             seasonNumber: podcast.seasonNumber,

--- a/tmbr-web/Sources/App/Modules/Catalogue/Songs/Routes/API/Responses/SongResponse.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Songs/Routes/API/Responses/SongResponse.swift
@@ -10,7 +10,7 @@ extension SongResponse {
         notes: [Note],
         baseURL: String,
         platform: Platform<SongMetadata> = .song
-    ) {
+    ) throws {
         self.init(
             id: song.id!,
             access: song.access,
@@ -21,7 +21,7 @@ extension SongResponse {
             notes: notes.map { NoteResponse(note: $0, baseURL: baseURL) },
             owner: UserResponse(user: song.owner),
             preview: PreviewResponse(preview: song.preview, baseURL: baseURL),
-            post: song.post.map { PostResponse(post: $0, baseURL: baseURL) },
+            post: try song.post.map { try PostResponse(post: $0, baseURL: baseURL) },
             releaseDate: song.releaseDate,
             resources: song.resourceURLs.compactMap(platform.hyperlink),
             title: song.title

--- a/tmbr-web/Sources/App/Modules/Catalogue/Songs/Routes/API/SongsAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Catalogue/Songs/Routes/API/SongsAPIController.swift
@@ -25,8 +25,8 @@ struct SongsAPIController: RouteCollection {
             let previewIDs = songs.map { $0.$preview.id }
             let notesByPreviewID = try await request.commands.notes.grouped(previewIDs)
             let baseURL = request.baseURL
-            return PageResult(from: songs, limit: input.limit) { song in
-                SongResponse(song: song, notes: notesByPreviewID[song.$preview.id] ?? [], baseURL: baseURL)
+            return try PageResult(from: songs, limit: input.limit) { song in
+                try SongResponse(song: song, notes: notesByPreviewID[song.$preview.id] ?? [], baseURL: baseURL)
             }
         }
 
@@ -71,7 +71,7 @@ struct SongsAPIController: RouteCollection {
                     )
                 }
                 let notes = try await notesInput.map(commands.notes.batchCreate)
-                return SongResponse(
+                return try SongResponse(
                     song: song,
                     notes: notes ?? [],
                     baseURL: request.baseURL
@@ -101,10 +101,10 @@ struct SongsAPIController: RouteCollection {
                 try await song.preview.$image.load(on: request.commandDB)
                 try await song.preview.$catalogueCategory.load(on: request.commandDB)
                 let notes = try await commands.notes.query(id: songID, of: Song.previewType)
-                return SongResponse(song: song, notes: notes, baseURL: request.baseURL)
+                return try SongResponse(song: song, notes: notes, baseURL: request.baseURL)
             }
         }
-        
+
         // DELETE /api/songs/:songID
         songsRoute.delete(":songID") { req async throws -> HTTPStatus in
             guard let songID = req.parameters.get("songID", as: Int.self) else {
@@ -125,7 +125,7 @@ struct SongsAPIController: RouteCollection {
             try await song.preview.$image.load(on: request.commandDB)
             try await song.preview.$catalogueCategory.load(on: request.commandDB)
             let notes = try await request.commands.notes.query(id: song.id!, of: Song.previewType)
-            return SongResponse(song: song, notes: notes, baseURL: request.baseURL)
+            return try SongResponse(song: song, notes: notes, baseURL: request.baseURL)
         }
 
         // POST /api/songs/:songID/notes

--- a/tmbr-web/Sources/App/Modules/Notes/Routes/API/Responses/QuoteResponse.swift
+++ b/tmbr-web/Sources/App/Modules/Notes/Routes/API/Responses/QuoteResponse.swift
@@ -15,34 +15,56 @@ extension QuoteResponse {
             source: try QuoteSource(quote: quote, baseURL: baseURL)
         )
     }
+
+    /// Convenience for building a post-sourced response when the `Post` is already in scope,
+    /// avoiding a redundant eager-load of `quote.$post`.
+    init(quote: Quote, post: Post, baseURL: String) throws {
+        guard let id = quote.id else {
+            throw Abort(.internalServerError, reason: "Quote missing id")
+        }
+        self.init(
+            id: id,
+            body: quote.body,
+            createdAt: quote.createdAt ?? .now,
+            source: QuoteSource(post: post, postID: try post.requireID(), baseURL: baseURL)
+        )
+    }
 }
 
 extension QuoteSource {
 
     init(quote: Quote, baseURL: String) throws {
         if let note = quote.note, let noteID = quote.$note.id {
-            let attachment = note.attachment
-            self.init(
-                kind: .note,
-                title: attachment.primaryInfo,
-                subtitle: attachment.secondaryInfo,
-                type: attachment.catalogueCategory?.slug,
-                preview: PreviewResponse(preview: attachment, baseURL: baseURL),
-                noteID: noteID,
-                postID: nil
-            )
+            self.init(note: note, noteID: noteID, baseURL: baseURL)
         } else if let post = quote.post, let postID = quote.$post.id {
-            self.init(
-                kind: .post,
-                title: post.title,
-                subtitle: nil,
-                type: nil,
-                preview: post.attachment.map { PreviewResponse(preview: $0, baseURL: baseURL) },
-                noteID: nil,
-                postID: postID
-            )
+            self.init(post: post, postID: postID, baseURL: baseURL)
         } else {
             throw Abort(.internalServerError, reason: "Quote has neither note nor post source")
         }
+    }
+
+    init(note: Note, noteID: NoteID, baseURL: String) {
+        let attachment = note.attachment
+        self.init(
+            kind: .note,
+            title: attachment.primaryInfo,
+            subtitle: attachment.secondaryInfo,
+            type: attachment.catalogueCategory?.slug,
+            preview: PreviewResponse(preview: attachment, baseURL: baseURL),
+            noteID: noteID,
+            postID: nil
+        )
+    }
+
+    init(post: Post, postID: PostID, baseURL: String) {
+        self.init(
+            kind: .post,
+            title: post.title,
+            subtitle: nil,
+            type: nil,
+            preview: post.attachment.map { PreviewResponse(preview: $0, baseURL: baseURL) },
+            noteID: nil,
+            postID: postID
+        )
     }
 }

--- a/tmbr-web/Sources/App/Modules/Posts/Commands/Command/Command+FetchPost.swift
+++ b/tmbr-web/Sources/App/Modules/Posts/Commands/Command/Command+FetchPost.swift
@@ -54,6 +54,7 @@ struct FetchPostCommand: Command {
         }
         try await permission.grant((post, params.reason))
         try await post.$attachment.load(on: database)
+        try await post.$quotes.load(on: database)
         return post
     }
 }

--- a/tmbr-web/Sources/App/Modules/Posts/Commands/Command/Command+ListPosts.swift
+++ b/tmbr-web/Sources/App/Modules/Posts/Commands/Command/Command+ListPosts.swift
@@ -24,6 +24,7 @@ extension Command where Self == PlainCommand<ListPostsInput, [Post]> {
                     .sort(\.$createdAt, .descending)
                     .with(\.$author)
                     .with(\.$attachment) { attachment in attachment.with(\.$image) }
+                    .with(\.$quotes)
                 query.page(page)
                 return try await query.all()
             }

--- a/tmbr-web/Sources/App/Modules/Posts/Models/Post.swift
+++ b/tmbr-web/Sources/App/Modules/Posts/Models/Post.swift
@@ -37,6 +37,9 @@ final class Post: Model, Content, @unchecked Sendable {
     @Field(key: "title")
     var title: String
 
+    @Children(for: \.$post)
+    private(set) var quotes: [Quote]
+
     init() {}
 
     init(

--- a/tmbr-web/Sources/App/Modules/Posts/Routes/API/PostsAPIController.swift
+++ b/tmbr-web/Sources/App/Modules/Posts/Routes/API/PostsAPIController.swift
@@ -19,8 +19,8 @@ struct PostsAPIController: RouteCollection {
             let page = PageInput(since: pageQuery.since, before: pageQuery.cursorDate, limit: pageQuery.limit)
             let posts = try await req.commands.posts.list(ListPostsInput(query: PostQueryPayload(term: nil), page: page))
             let baseURL = req.baseURL
-            return PageResult(from: posts, limit: page.limit) { post in
-                PostResponse(post: post, baseURL: baseURL)
+            return try PageResult(from: posts, limit: page.limit) { post in
+                try PostResponse(post: post, baseURL: baseURL)
             }
         }
         

--- a/tmbr-web/Sources/App/Modules/Posts/Routes/API/Responses/PostResponse.swift
+++ b/tmbr-web/Sources/App/Modules/Posts/Routes/API/Responses/PostResponse.swift
@@ -4,15 +4,17 @@ import WebAuth
 
 extension PostResponse {
 
-    init(post: Post, baseURL: String) {
+    init(post: Post, baseURL: String) throws {
+        let id = try post.requireID()
         self.init(
-            id: post.id!,
+            id: id,
             attachment: post.attachment.map { PreviewResponse(preview: $0, baseURL: baseURL) },
             author: UserResponse(user: post.author),
             content: post.content,
             createdAt: post.createdAt,
             language: post.language,
             publishedAt: post.publishedAt,
+            quotes: try post.quotes.map { try QuoteResponse(quote: $0, post: post, baseURL: baseURL) },
             state: post.state,
             title: post.title
         )

--- a/web-core/Sources/WebCore/Pagination/Pagination.swift
+++ b/web-core/Sources/WebCore/Pagination/Pagination.swift
@@ -26,11 +26,11 @@ private let iso8601Formatter = ISO8601DateFormatter()
 public extension PageResult {
     /// Builds a paginated response from raw query results fetched with `limit + 1`.
     /// Trims to `limit`, sets `nextCursor` from the last item's `createdAt` if more exist.
-    init<M: Timestamped>(from models: [M], limit: Int, mapping: (M) -> T) {
+    init<M: Timestamped>(from models: [M], limit: Int, mapping: (M) throws -> T) rethrows {
         let trimmed = Array(models.prefix(limit))
         let nextCursor = models.count > limit
             ? trimmed.last.map { iso8601Formatter.string(from: $0.createdAt) }
             : nil
-        self.init(items: trimmed.map(mapping), nextCursor: nextCursor)
+        self.init(items: try trimmed.map(mapping), nextCursor: nextCursor)
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the catalogue filter sheet with a **popover on macOS** and a **glass sheet on iOS 26** (no `.presentationBackground` override, letting the system apply liquid glass automatically)
- Switches from hardcoded `CatalogueItemType.allCases` to a live `@Query` over `CatalogueCategoryRecord`, so the filter reflects whatever categories the backend syncs
- Follows the established model/action/property-wrapper architecture

> **Depends on** the categories sync PR (`feat/stable-quotes-sync`) — merge that first.

## Architecture

- `CatalogueModel.selectedCategorySlugs: Set<String>` — filter state lives on the model, not in the view
- `SelectionStrategy` (`.override` / `.toggle`) — describes how a new set of slugs merges into the current selection
- `SelectCategoriesAction` — standard action struct injected via `\.selectCategories` environment key
- `CatalogueCategoriesList` — `@Query`-driven, platform-split (iOS `List` / macOS `ScrollView+VStack`); filters out `virtual` and `promotable` kinds in memory (avoids making `kindRaw` public)
- `CategoryRow` — self-contained; reads `@Catalogue(\.selectedCategorySlugs)`, fires `.toggle`
- `CatalogueSelectAllButton` — adaptive "Select All / Deselect All"; fires `.override`
- `CatalogueFilterView` — stateless compositor, no `Binding`

## Test plan

- [ ] iOS: filter sheet opens with glass background, categories list populates from SwiftData
- [ ] iOS: tapping a row toggles selection, catalogue list filters correctly
- [ ] iOS: "Select All" / "Deselect All" toggles full set; "Done" dismisses
- [ ] macOS: filter button opens compact popover anchored to toolbar button
- [ ] macOS: same row/select-all interactions work
- [ ] Empty state: no categories synced → filter is empty, catalogue shows all items unfiltered

🤖 Generated with [Claude Code](https://claude.com/claude-code)