### PR TITLE
feat: catalogue filter popover with dynamic categories

### DIFF
--- a/app-core/Sources/AppCore/Catalogue/Actions/SelectCategoriesAction.swift
+++ b/app-core/Sources/AppCore/Catalogue/Actions/SelectCategoriesAction.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@MainActor
+public struct SelectCategoriesAction: Sendable {
+
+    private let body: @MainActor (Set<String>, SelectionStrategy) -> Void
+
+    nonisolated public init(_ body: @escaping @MainActor (Set<String>, SelectionStrategy) -> Void = { _, _ in }) {
+        self.body = body
+    }
+
+    @MainActor
+    public init(model: CatalogueModel) {
+        self.init { slugs, strategy in
+            model.selectedCategorySlugs = strategy.apply(model.selectedCategorySlugs, slugs)
+        }
+    }
+
+    public func callAsFunction(_ slugs: Set<String>, strategy: SelectionStrategy) {
+        body(slugs, strategy)
+    }
+}

--- a/app-core/Sources/AppCore/Catalogue/Actions/SelectionStrategy.swift
+++ b/app-core/Sources/AppCore/Catalogue/Actions/SelectionStrategy.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Determines how a new set of category slugs is merged into the current selection.
+public struct SelectionStrategy: Sendable {
+
+    let apply: @Sendable (_ current: Set<String>, _ incoming: Set<String>) -> Set<String>
+
+    /// Replaces the current selection with the incoming set.
+    public static let override = SelectionStrategy { _, incoming in incoming }
+
+    /// Toggles each incoming slug: already-selected → remove, not-selected → add.
+    public static let toggle = SelectionStrategy { current, incoming in
+        incoming.reduce(into: current) { set, slug in
+            if set.contains(slug) { set.remove(slug) } else { set.insert(slug) }
+        }
+    }
+}

--- a/app-core/Sources/AppCore/Catalogue/CatalogueEnvironment.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueEnvironment.swift
@@ -3,6 +3,7 @@ import Foundation
 
 public extension EnvironmentValues {
     @Entry var refreshCatalogue: CatalogueRefreshAction = CatalogueRefreshAction()
+    @Entry var selectCategories: SelectCategoriesAction = SelectCategoriesAction()
 
     // Networking config — `apiBaseURL == nil` is the on/off gate: Personal injects nothing
     // → @Loader returns nil, @Upserter returns a no-op syncer.

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -53,6 +53,7 @@ public struct CatalogueFilterView: View {
                 .listRowBackground(Color.clear)
             }
             .listStyle(.plain)
+            .scrollContentBackground(.hidden)
         }
         .presentationDetents([.medium])
         .presentationBackground(.ultraThinMaterial)

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -40,6 +40,7 @@ public struct CatalogueFilterView: View {
                 .listRowBackground(Color.clear)
             }
             .scrollContentBackground(.hidden)
+            .contentMargins(.top, 0, for: .scrollContent)
             .navigationTitle("Filter")
             .toolbarTitleDisplayMode(.inline)
             .toolbar {

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -75,6 +75,7 @@ public struct CatalogueFilterView: View {
                         .foregroundStyle(.tint)
                 }
             }
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -8,8 +8,29 @@ public struct CatalogueFilterView: View {
         self._selectedTypes = selectedTypes
     }
 
+    private var allSelected: Bool {
+        selectedTypes.count == CatalogueItemType.allCases.count
+    }
+
     public var body: some View {
-        NavigationStack {
+        VStack(spacing: 0) {
+            HStack {
+                Button(allSelected ? "Deselect All" : "Select All") {
+                    if allSelected {
+                        selectedTypes.removeAll()
+                    } else {
+                        selectedTypes = Set(CatalogueItemType.allCases)
+                    }
+                }
+                Spacer()
+                Text("Filter")
+                    .font(.headline)
+                Spacer()
+                Button("Done") { dismiss() }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 12)
+
             List(CatalogueItemType.allCases) { type in
                 Button {
                     if selectedTypes.contains(type) {
@@ -32,25 +53,8 @@ public struct CatalogueFilterView: View {
                 .listRowBackground(Color.clear)
             }
             .listStyle(.plain)
-            .navigationTitle("Filter")
-            .toolbarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    let allSelected = selectedTypes.count == CatalogueItemType.allCases.count
-                    Button(allSelected ? "Deselect All" : "Select All") {
-                        if allSelected {
-                            selectedTypes.removeAll()
-                        } else {
-                            selectedTypes = Set(CatalogueItemType.allCases)
-                        }
-                    }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { dismiss() }
-                }
-            }
         }
         .presentationDetents([.medium])
-        .frame(minWidth: 320, minHeight: 380)
+        .presentationBackground(.ultraThinMaterial)
     }
 }

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -43,7 +43,6 @@ public struct CatalogueFilterView: View {
         }
         #if os(iOS)
         .presentationDetents([.medium, .large])
-        .presentationBackground(.clear)
         #else
         .frame(minWidth: 200, maxHeight: 400)
         #endif

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -55,7 +55,11 @@ public struct CatalogueFilterView: View {
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
         }
+        #if os(iOS)
         .presentationDetents([.medium])
         .presentationBackground(.ultraThinMaterial)
+        #else
+        .frame(minWidth: 280, minHeight: 300)
+        #endif
     }
 }

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -43,7 +43,7 @@ public struct CatalogueFilterView: View {
         }
         #if os(iOS)
         .presentationDetents([.medium, .large])
-        .presentationBackground(.ultraThinMaterial)
+        .presentationBackground(.clear)
         #else
         .frame(minWidth: 200, maxHeight: 400)
         #endif

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -31,7 +31,6 @@ public struct CatalogueFilterView: View {
             .padding(.horizontal)
             .padding(.vertical, 12)
 
-            #if os(macOS)
             VStack(spacing: 0) {
                 ForEach(CatalogueItemType.allCases) { type in
                     row(for: type)
@@ -39,15 +38,6 @@ public struct CatalogueFilterView: View {
                         .padding(.vertical, 7)
                 }
             }
-            #else
-            List(CatalogueItemType.allCases) { type in
-                row(for: type)
-                    .listRowSeparator(.hidden)
-                    .listRowBackground(Color.clear)
-            }
-            .listStyle(.plain)
-            .scrollContentBackground(.hidden)
-            #endif
         }
         #if os(iOS)
         .presentationDetents([.medium])

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -31,36 +31,51 @@ public struct CatalogueFilterView: View {
             .padding(.horizontal)
             .padding(.vertical, 12)
 
-            List(CatalogueItemType.allCases) { type in
-                Button {
-                    if selectedTypes.contains(type) {
-                        selectedTypes.remove(type)
-                    } else {
-                        selectedTypes.insert(type)
-                    }
-                } label: {
-                    HStack {
-                        Label(type.label, systemImage: type.systemImage)
-                            .foregroundStyle(.primary)
-                        Spacer()
-                        if selectedTypes.contains(type) {
-                            Image(systemName: "checkmark")
-                                .foregroundStyle(.tint)
-                        }
-                    }
+            #if os(macOS)
+            VStack(spacing: 0) {
+                ForEach(CatalogueItemType.allCases) { type in
+                    row(for: type)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
                 }
-                .buttonStyle(.plain)
-                .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
+            }
+            #else
+            List(CatalogueItemType.allCases) { type in
+                row(for: type)
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
+            #endif
         }
         #if os(iOS)
         .presentationDetents([.medium])
         .presentationBackground(.ultraThinMaterial)
         #else
-        .frame(minWidth: 280, minHeight: 300)
+        .frame(minWidth: 200)
         #endif
+    }
+
+    @ViewBuilder
+    private func row(for type: CatalogueItemType) -> some View {
+        Button {
+            if selectedTypes.contains(type) {
+                selectedTypes.remove(type)
+            } else {
+                selectedTypes.insert(type)
+            }
+        } label: {
+            HStack {
+                Label(type.label, systemImage: type.systemImage)
+                    .foregroundStyle(.primary)
+                Spacer()
+                if selectedTypes.contains(type) {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.tint)
+                }
+            }
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -1,74 +1,32 @@
 import SwiftUI
 
 public struct CatalogueFilterView: View {
-    @Binding var selectedTypes: Set<CatalogueItemType>
-    @Environment(\.dismiss) private var dismiss
 
-    public init(selectedTypes: Binding<Set<CatalogueItemType>>) {
-        self._selectedTypes = selectedTypes
-    }
+    @Environment(\.dismiss)
+    private var dismiss
 
-    private var allSelected: Bool {
-        selectedTypes.count == CatalogueItemType.allCases.count
-    }
-
-    private func toggle(_ type: CatalogueItemType) {
-        if selectedTypes.contains(type) {
-            selectedTypes.remove(type)
-        } else {
-            selectedTypes.insert(type)
-        }
-    }
+    public init() {}
 
     public var body: some View {
         #if os(iOS)
         NavigationStack {
-            List(CatalogueItemType.allCases) { type in
-                Button { toggle(type) } label: {
-                    HStack {
-                        Label(type.label, systemImage: type.systemImage)
-                            .foregroundStyle(.primary)
-                        Spacer()
-                        if selectedTypes.contains(type) {
-                            Image(systemName: "checkmark")
-                                .foregroundStyle(.tint)
-                        }
+            CatalogueCategoriesList()
+                .navigationTitle("Filter")
+                .toolbarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        CatalogueSelectAllButton()
                     }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .listRowBackground(Color.clear)
-            }
-            .scrollContentBackground(.hidden)
-            .contentMargins(.top, 0, for: .scrollContent)
-            .navigationTitle("Filter")
-            .toolbarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(allSelected ? "Deselect All" : "Select All") {
-                        if allSelected {
-                            selectedTypes.removeAll()
-                        } else {
-                            selectedTypes = Set(CatalogueItemType.allCases)
-                        }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") { dismiss() }
                     }
                 }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { dismiss() }
-                }
-            }
         }
         .presentationDetents([.medium, .large])
         #else
         VStack(spacing: 0) {
             HStack {
-                Button(allSelected ? "Deselect All" : "Select All") {
-                    if allSelected {
-                        selectedTypes.removeAll()
-                    } else {
-                        selectedTypes = Set(CatalogueItemType.allCases)
-                    }
-                }
+                CatalogueSelectAllButton()
                 Spacer()
                 Text("Filter")
                     .font(.headline)
@@ -78,27 +36,7 @@ public struct CatalogueFilterView: View {
             .padding(.horizontal)
             .padding(.vertical, 12)
 
-            ScrollView {
-                VStack(spacing: 0) {
-                    ForEach(CatalogueItemType.allCases) { type in
-                        Button { toggle(type) } label: {
-                            HStack {
-                                Label(type.label, systemImage: type.systemImage)
-                                    .foregroundStyle(.primary)
-                                Spacer()
-                                if selectedTypes.contains(type) {
-                                    Image(systemName: "checkmark")
-                                        .foregroundStyle(.tint)
-                                }
-                            }
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 7)
-                    }
-                }
-            }
+            CatalogueCategoriesList()
         }
         .frame(minWidth: 200, maxHeight: 400)
         #endif

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -31,19 +31,21 @@ public struct CatalogueFilterView: View {
             .padding(.horizontal)
             .padding(.vertical, 12)
 
-            VStack(spacing: 0) {
-                ForEach(CatalogueItemType.allCases) { type in
-                    row(for: type)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 7)
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(CatalogueItemType.allCases) { type in
+                        row(for: type)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 7)
+                    }
                 }
             }
         }
         #if os(iOS)
-        .presentationDetents([.medium])
+        .presentationDetents([.medium, .large])
         .presentationBackground(.ultraThinMaterial)
         #else
-        .frame(minWidth: 200)
+        .frame(minWidth: 200, maxHeight: 400)
         #endif
     }
 

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -49,6 +49,7 @@ public struct CatalogueFilterView: View {
                         }
                     }
                 }
+                .buttonStyle(.plain)
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
             }

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -12,7 +12,53 @@ public struct CatalogueFilterView: View {
         selectedTypes.count == CatalogueItemType.allCases.count
     }
 
+    private func toggle(_ type: CatalogueItemType) {
+        if selectedTypes.contains(type) {
+            selectedTypes.remove(type)
+        } else {
+            selectedTypes.insert(type)
+        }
+    }
+
     public var body: some View {
+        #if os(iOS)
+        NavigationStack {
+            List(CatalogueItemType.allCases) { type in
+                Button { toggle(type) } label: {
+                    HStack {
+                        Label(type.label, systemImage: type.systemImage)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        if selectedTypes.contains(type) {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.tint)
+                        }
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .listRowBackground(Color.clear)
+            }
+            .scrollContentBackground(.hidden)
+            .navigationTitle("Filter")
+            .toolbarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(allSelected ? "Deselect All" : "Select All") {
+                        if allSelected {
+                            selectedTypes.removeAll()
+                        } else {
+                            selectedTypes = Set(CatalogueItemType.allCases)
+                        }
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        #else
         VStack(spacing: 0) {
             HStack {
                 Button(allSelected ? "Deselect All" : "Select All") {
@@ -34,40 +80,26 @@ public struct CatalogueFilterView: View {
             ScrollView {
                 VStack(spacing: 0) {
                     ForEach(CatalogueItemType.allCases) { type in
-                        row(for: type)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 7)
+                        Button { toggle(type) } label: {
+                            HStack {
+                                Label(type.label, systemImage: type.systemImage)
+                                    .foregroundStyle(.primary)
+                                Spacer()
+                                if selectedTypes.contains(type) {
+                                    Image(systemName: "checkmark")
+                                        .foregroundStyle(.tint)
+                                }
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
                     }
                 }
             }
         }
-        #if os(iOS)
-        .presentationDetents([.medium, .large])
-        #else
         .frame(minWidth: 200, maxHeight: 400)
         #endif
-    }
-
-    @ViewBuilder
-    private func row(for type: CatalogueItemType) -> some View {
-        Button {
-            if selectedTypes.contains(type) {
-                selectedTypes.remove(type)
-            } else {
-                selectedTypes.insert(type)
-            }
-        } label: {
-            HStack {
-                Label(type.label, systemImage: type.systemImage)
-                    .foregroundStyle(.primary)
-                Spacer()
-                if selectedTypes.contains(type) {
-                    Image(systemName: "checkmark")
-                        .foregroundStyle(.tint)
-                }
-            }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 }

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public struct CatalogueFilterSheet: View {
+public struct CatalogueFilterView: View {
     @Binding var selectedTypes: Set<CatalogueItemType>
     @Environment(\.dismiss) private var dismiss
 
@@ -48,6 +48,7 @@ public struct CatalogueFilterSheet: View {
                 }
             }
         }
+        .presentationDetents([.medium])
         .frame(minWidth: 320, minHeight: 380)
     }
 }

--- a/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueFilterView.swift
@@ -28,6 +28,8 @@ public struct CatalogueFilterView: View {
                         }
                     }
                 }
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
             }
             .listStyle(.plain)
             .navigationTitle("Filter")

--- a/app-core/Sources/AppCore/Catalogue/CatalogueModel.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueModel.swift
@@ -18,6 +18,9 @@ public final class CatalogueModel {
     /// When the last successful refresh completed.
     public private(set) var lastFetched: Date?
 
+    /// Slugs of the categories currently active in the filter. Empty = no filter (show all).
+    public var selectedCategorySlugs: Set<String> = []
+
     // MARK: - Dependencies
 
     private let _refresh: @Sendable () async throws -> Void

--- a/app-core/Sources/AppCore/Catalogue/CatalogueTab.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueTab.swift
@@ -57,9 +57,6 @@ struct CatalogueTab: View {
                     Button { showFilter = true } label: {
                         Image(systemName: "line.3.horizontal.decrease")
                     }
-                    .popover(isPresented: $showFilter) {
-                        CatalogueFilterView(selectedTypes: $filterTypes)
-                    }
                 }
                 ToolbarItem(placement: .topBarLeading) {
                     AuthoringButton(systemImage: "square.and.pencil") { showTypePicker = true }
@@ -68,9 +65,6 @@ struct CatalogueTab: View {
                 ToolbarItem(placement: .automatic) {
                     Button { showFilter = true } label: {
                         Image(systemName: "line.3.horizontal.decrease")
-                    }
-                    .popover(isPresented: $showFilter) {
-                        CatalogueFilterView(selectedTypes: $filterTypes)
                     }
                 }
                 ToolbarItem(placement: .primaryAction) {
@@ -85,6 +79,9 @@ struct CatalogueTab: View {
             .refreshable { await refreshCatalogue() }
         }
         .task { await refreshCatalogue() }
+        .sheet(isPresented: $showFilter) {
+            CatalogueFilterView(selectedTypes: $filterTypes)
+        }
         .sheet(isPresented: $showTypePicker) {
             MediaTypePickerSheet { type in
                 selectedType = type

--- a/app-core/Sources/AppCore/Catalogue/CatalogueTab.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueTab.swift
@@ -66,6 +66,9 @@ struct CatalogueTab: View {
                     Button { showFilter = true } label: {
                         Image(systemName: "line.3.horizontal.decrease")
                     }
+                    .popover(isPresented: $showFilter) {
+                        CatalogueFilterView(selectedTypes: $filterTypes)
+                    }
                 }
                 ToolbarItem(placement: .primaryAction) {
                     AuthoringButton(systemImage: "square.and.pencil") { showTypePicker = true }
@@ -79,9 +82,11 @@ struct CatalogueTab: View {
             .refreshable { await refreshCatalogue() }
         }
         .task { await refreshCatalogue() }
+        #if os(iOS)
         .sheet(isPresented: $showFilter) {
             CatalogueFilterView(selectedTypes: $filterTypes)
         }
+        #endif
         .sheet(isPresented: $showTypePicker) {
             MediaTypePickerSheet { type in
                 selectedType = type

--- a/app-core/Sources/AppCore/Catalogue/CatalogueTab.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueTab.swift
@@ -57,6 +57,9 @@ struct CatalogueTab: View {
                     Button { showFilter = true } label: {
                         Image(systemName: "line.3.horizontal.decrease")
                     }
+                    .popover(isPresented: $showFilter) {
+                        CatalogueFilterView(selectedTypes: $filterTypes)
+                    }
                 }
                 ToolbarItem(placement: .topBarLeading) {
                     AuthoringButton(systemImage: "square.and.pencil") { showTypePicker = true }
@@ -65,6 +68,9 @@ struct CatalogueTab: View {
                 ToolbarItem(placement: .automatic) {
                     Button { showFilter = true } label: {
                         Image(systemName: "line.3.horizontal.decrease")
+                    }
+                    .popover(isPresented: $showFilter) {
+                        CatalogueFilterView(selectedTypes: $filterTypes)
                     }
                 }
                 ToolbarItem(placement: .primaryAction) {
@@ -79,9 +85,6 @@ struct CatalogueTab: View {
             .refreshable { await refreshCatalogue() }
         }
         .task { await refreshCatalogue() }
-        .popover(isPresented: $showFilter) {
-            CatalogueFilterView(selectedTypes: $filterTypes)
-        }
         .sheet(isPresented: $showTypePicker) {
             MediaTypePickerSheet { type in
                 selectedType = type

--- a/app-core/Sources/AppCore/Catalogue/CatalogueTab.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueTab.swift
@@ -8,20 +8,21 @@ struct CatalogueTab: View {
 
     @Environment(\.refreshCatalogue)
     private var refreshCatalogue
-    
+
     @Environment(\.canAuthor)
     private var canAuthor
+
+    @Catalogue(\.selectedCategorySlugs)
+    private var selectedCategorySlugs
 
     @State private var showFilter = false
     @State private var showTypePicker = false
     @State private var selectedType: CatalogueItemType?
     @State private var showEditor = false
-    @State private var filterTypes: Set<CatalogueItemType> = []
 
     private var items: [PreviewRecord] {
-        guard !filterTypes.isEmpty else { return allItems }
-        let raw = Set(filterTypes.map(\.rawValue))
-        return allItems.filter { raw.contains($0.categoryType) }
+        guard !selectedCategorySlugs.isEmpty else { return allItems }
+        return allItems.filter { selectedCategorySlugs.contains($0.categoryType) }
     }
 
     var body: some View {
@@ -67,7 +68,7 @@ struct CatalogueTab: View {
                         Image(systemName: "line.3.horizontal.decrease")
                     }
                     .popover(isPresented: $showFilter) {
-                        CatalogueFilterView(selectedTypes: $filterTypes)
+                        CatalogueFilterView()
                     }
                 }
                 ToolbarItem(placement: .primaryAction) {
@@ -84,7 +85,7 @@ struct CatalogueTab: View {
         .task { await refreshCatalogue() }
         #if os(iOS)
         .sheet(isPresented: $showFilter) {
-            CatalogueFilterView(selectedTypes: $filterTypes)
+            CatalogueFilterView()
         }
         #endif
         .sheet(isPresented: $showTypePicker) {

--- a/app-core/Sources/AppCore/Catalogue/CatalogueTab.swift
+++ b/app-core/Sources/AppCore/Catalogue/CatalogueTab.swift
@@ -79,8 +79,8 @@ struct CatalogueTab: View {
             .refreshable { await refreshCatalogue() }
         }
         .task { await refreshCatalogue() }
-        .sheet(isPresented: $showFilter) {
-            CatalogueFilterSheet(selectedTypes: $filterTypes)
+        .popover(isPresented: $showFilter) {
+            CatalogueFilterView(selectedTypes: $filterTypes)
         }
         .sheet(isPresented: $showTypePicker) {
             MediaTypePickerSheet { type in

--- a/app-core/Sources/AppCore/Catalogue/Controls/CatalogueSelectAllButton.swift
+++ b/app-core/Sources/AppCore/Catalogue/Controls/CatalogueSelectAllButton.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import SwiftData
+import AppPersistence
+
+/// Adaptively shows "Select All" or "Deselect All" based on whether every filterable category
+/// is currently selected. Uses .override strategy so it replaces the selection in one tap.
+struct CatalogueSelectAllButton: View {
+
+    private static let virtual = CatalogueCategoryKind.virtual.rawValue
+    private static let promotable = CatalogueCategoryKind.promotable.rawValue
+
+    @Query(
+        filter: #Predicate<CatalogueCategoryRecord> {
+            $0.kindRaw != CatalogueSelectAllButton.virtual &&
+            $0.kindRaw != CatalogueSelectAllButton.promotable
+        }
+    )
+    private var categories: [CatalogueCategoryRecord]
+
+    @Catalogue(\.selectedCategorySlugs)
+    private var selectedSlugs
+
+    @Environment(\.selectCategories)
+    private var selectCategories
+
+    private var allSelected: Bool {
+        !categories.isEmpty && categories.allSatisfy { selectedSlugs.contains($0.slug) }
+    }
+
+    var body: some View {
+        Button(allSelected ? "Deselect All" : "Select All") {
+            let slugs = allSelected ? [] : Set(categories.map(\.slug))
+            selectCategories(slugs, strategy: .override)
+        }
+    }
+}

--- a/app-core/Sources/AppCore/Catalogue/Controls/CatalogueSelectAllButton.swift
+++ b/app-core/Sources/AppCore/Catalogue/Controls/CatalogueSelectAllButton.swift
@@ -1,21 +1,18 @@
 import SwiftUI
 import SwiftData
 import AppPersistence
+import TmbrCore
 
 /// Adaptively shows "Select All" or "Deselect All" based on whether every filterable category
 /// is currently selected. Uses .override strategy so it replaces the selection in one tap.
 struct CatalogueSelectAllButton: View {
 
-    private static let virtual = CatalogueCategoryKind.virtual.rawValue
-    private static let promotable = CatalogueCategoryKind.promotable.rawValue
+    @Query
+    private var allCategories: [CatalogueCategoryRecord]
 
-    @Query(
-        filter: #Predicate<CatalogueCategoryRecord> {
-            $0.kindRaw != CatalogueSelectAllButton.virtual &&
-            $0.kindRaw != CatalogueSelectAllButton.promotable
-        }
-    )
-    private var categories: [CatalogueCategoryRecord]
+    private var categories: [CatalogueCategoryRecord] {
+        allCategories.filter { $0.kind != .virtual && $0.kind != .promotable }
+    }
 
     @Catalogue(\.selectedCategorySlugs)
     private var selectedSlugs

--- a/app-core/Sources/AppCore/Catalogue/View+Catalogue.swift
+++ b/app-core/Sources/AppCore/Catalogue/View+Catalogue.swift
@@ -5,5 +5,6 @@ public extension View {
     func catalogue(_ model: CatalogueModel) -> some View {
         environment(model)
             .environment(\.refreshCatalogue, CatalogueRefreshAction(model: model))
+            .environment(\.selectCategories, SelectCategoriesAction(model: model))
     }
 }

--- a/app-core/Sources/AppCore/Catalogue/Views/CatalogueCategoriesList.swift
+++ b/app-core/Sources/AppCore/Catalogue/Views/CatalogueCategoriesList.swift
@@ -5,7 +5,7 @@ import AppPersistence
 /// Displays all filterable catalogue categories (excludes virtual groupings and promotable placeholders).
 struct CatalogueCategoriesList: View {
 
-    @Query(sort: \.name)
+    @Query(sort: \CatalogueCategoryRecord.name)
     private var allCategories: [CatalogueCategoryRecord]
 
     private var categories: [CatalogueCategoryRecord] {

--- a/app-core/Sources/AppCore/Catalogue/Views/CatalogueCategoriesList.swift
+++ b/app-core/Sources/AppCore/Catalogue/Views/CatalogueCategoriesList.swift
@@ -5,17 +5,12 @@ import AppPersistence
 /// Displays all filterable catalogue categories (excludes virtual groupings and promotable placeholders).
 struct CatalogueCategoriesList: View {
 
-    private static let virtual = CatalogueCategoryKind.virtual.rawValue
-    private static let promotable = CatalogueCategoryKind.promotable.rawValue
+    @Query(sort: \.name)
+    private var allCategories: [CatalogueCategoryRecord]
 
-    @Query(
-        filter: #Predicate<CatalogueCategoryRecord> {
-            $0.kindRaw != CatalogueCategoriesList.virtual &&
-            $0.kindRaw != CatalogueCategoriesList.promotable
-        },
-        sort: \.name
-    )
-    private var categories: [CatalogueCategoryRecord]
+    private var categories: [CatalogueCategoryRecord] {
+        allCategories.filter { $0.kind != .virtual && $0.kind != .promotable }
+    }
 
     var body: some View {
         #if os(iOS)

--- a/app-core/Sources/AppCore/Catalogue/Views/CatalogueCategoriesList.swift
+++ b/app-core/Sources/AppCore/Catalogue/Views/CatalogueCategoriesList.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import SwiftData
+import AppPersistence
+
+/// Displays all filterable catalogue categories (excludes virtual groupings and promotable placeholders).
+struct CatalogueCategoriesList: View {
+
+    private static let virtual = CatalogueCategoryKind.virtual.rawValue
+    private static let promotable = CatalogueCategoryKind.promotable.rawValue
+
+    @Query(
+        filter: #Predicate<CatalogueCategoryRecord> {
+            $0.kindRaw != CatalogueCategoriesList.virtual &&
+            $0.kindRaw != CatalogueCategoriesList.promotable
+        },
+        sort: \.name
+    )
+    private var categories: [CatalogueCategoryRecord]
+
+    var body: some View {
+        #if os(iOS)
+        List(categories) { category in
+            CategoryRow(category: category)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.automatic)
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .contentMargins(.top, 0, for: .scrollContent)
+        #else
+        ScrollView {
+            VStack(spacing: 0) {
+                ForEach(categories) { category in
+                    CategoryRow(category: category)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
+                }
+            }
+        }
+        #endif
+    }
+}

--- a/app-core/Sources/AppCore/Catalogue/Views/CategoryRow.swift
+++ b/app-core/Sources/AppCore/Catalogue/Views/CategoryRow.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import AppPersistence
+
+struct CategoryRow: View {
+
+    let category: CatalogueCategoryRecord
+
+    @Catalogue(\.selectedCategorySlugs)
+    private var selectedSlugs
+
+    @Environment(\.selectCategories)
+    private var selectCategories
+
+    var body: some View {
+        Button {
+            selectCategories([category.slug], strategy: .toggle)
+        } label: {
+            HStack {
+                Label(category.name, systemImage: category.icon ?? "link")
+                    .foregroundStyle(.primary)
+                Spacer()
+                if selectedSlugs.contains(category.slug) {
+                    Image(systemName: "checkmark")
+                        .foregroundStyle(.tint)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the catalogue filter sheet with a **popover on macOS** and a **glass sheet on iOS 26** (no `.presentationBackground` override, letting the system apply liquid glass automatically)
- Switches from hardcoded `CatalogueItemType.allCases` to a live `@Query` over `CatalogueCategoryRecord`, so the filter reflects whatever categories the backend syncs
- Follows the established model/action/property-wrapper architecture

## Architecture

- `CatalogueModel.selectedCategorySlugs: Set<String>` — filter state lives on the model, not in the view
- `SelectionStrategy` (`.override` / `.toggle`) — describes how a new set of slugs merges into the current selection
- `SelectCategoriesAction` — standard action struct injected via `\.selectCategories` environment key
- `CatalogueCategoriesList` — `@Query`-driven, platform-split (iOS `List` / macOS `ScrollView+VStack`); filters out `virtual` and `promotable` kinds in memory (avoids making `kindRaw` public)
- `CategoryRow` — self-contained; reads `@Catalogue(\.selectedCategorySlugs)`, fires `.toggle`
- `CatalogueSelectAllButton` — adaptive "Select All / Deselect All"; fires `.override`
- `CatalogueFilterView` — stateless compositor, no `Binding`

## Test plan

- [ ] iOS: filter sheet opens with glass background, categories list populates from SwiftData
- [ ] iOS: tapping a row toggles selection, catalogue list filters correctly
- [ ] iOS: "Select All" / "Deselect All" toggles full set; "Done" dismisses
- [ ] macOS: filter button opens compact popover anchored to toolbar button
- [ ] macOS: same row/select-all interactions work
- [ ] Empty state: no categories synced yet → filter is empty, catalogue shows all items unfiltered

🤖 Generated with [Claude Code](https://claude.com/claude-code)